### PR TITLE
fix(consensus): self-expiring fast-sync catch-up window for ratio-reward coinbase trust

### DIFF
--- a/consensus/src/consensus/storage.rs
+++ b/consensus/src/consensus/storage.rs
@@ -15,6 +15,7 @@ use crate::{
         past_pruning_points::DbPastPruningPointsStore,
         pom_proof::DbPomProofStore,
         pom_tier::DbPomTierStore,
+        production_seed::DbProductionIndexSeedStore,
         pruning::DbPruningStore,
         pruning_meta::PruningMetaStores,
         pruning_samples::DbPruningSamplesStore,
@@ -48,6 +49,9 @@ pub struct ConsensusStorage {
     pub reachability_relations_store: Arc<RwLock<DbRelationsStore>>,
     pub pruning_point_store: Arc<RwLock<DbPruningStore>>,
     pub headers_selected_tip_store: Arc<RwLock<DbHeadersSelectedTipStore>>,
+    /// Fast-sync catch-up: selected-chain index at which `windowed_production_store` was last
+    /// reset by a pruning-point UTXO import. See `production_seed` module doc.
+    pub production_index_seed_store: Arc<RwLock<DbProductionIndexSeedStore>>,
     pub body_tips_store: Arc<RwLock<DbTipsStore>>,
     pub pruning_meta_stores: Arc<RwLock<PruningMetaStores>>,
     pub virtual_stores: Arc<RwLock<VirtualStores>>,
@@ -241,6 +245,7 @@ impl ConsensusStorage {
 
         // Tips
         let headers_selected_tip_store = Arc::new(RwLock::new(DbHeadersSelectedTipStore::new(db.clone())));
+        let production_index_seed_store = Arc::new(RwLock::new(DbProductionIndexSeedStore::new(db.clone())));
         let body_tips_store = Arc::new(RwLock::new(DbTipsStore::new(db.clone())));
 
         // Block windows
@@ -271,6 +276,7 @@ impl ConsensusStorage {
             pruning_meta_stores,
             virtual_stores,
             selected_chain_store,
+            production_index_seed_store,
             acceptance_data_store,
             address_balance_store,
             windowed_production_store,

--- a/consensus/src/model/stores/mod.rs
+++ b/consensus/src/model/stores/mod.rs
@@ -13,6 +13,7 @@ pub mod headers_selected_tip;
 pub mod past_pruning_points;
 pub mod pom_proof;
 pub mod pom_tier;
+pub mod production_seed;
 pub mod pruning;
 pub mod pruning_meta;
 pub mod pruning_samples;

--- a/consensus/src/model/stores/production_seed.rs
+++ b/consensus/src/model/stores/production_seed.rs
@@ -1,0 +1,63 @@
+use keryx_database::prelude::DB;
+use keryx_database::prelude::StoreResult;
+use keryx_database::prelude::StoreResultExt;
+use keryx_database::prelude::{BatchDbWriter, CachedDbItem};
+use keryx_database::registry::DatabaseStorePrefixes;
+use rocksdb::WriteBatch;
+use std::sync::Arc;
+
+/// Fast-sync catch-up tracking for the ratio-reward windowed-production index.
+///
+/// `import_pruning_point_utxo_set` clears `windowed_production_store` on every pruning-point UTXO
+/// import (fast sync) instead of seeding it, on the assumption that the whole `ratio_reward_window`
+/// lies above the pruning point and gets rebuilt exactly by the body-IBD that follows. That holds
+/// only while the pruning point itself is still before the ratio-reward activation height; once the
+/// chain has advanced past `pruning_depth` beyond that height, every fresh fast sync starts its
+/// production index at zero exactly when the activation is already live, and needs a full
+/// `ratio_reward_window` of catch-up before its computed `ratio_bps` matches long-running nodes —
+/// during which it disqualifies every ratio-reward coinbase it sees.
+///
+/// This store records the virtual selected-chain index at the moment of the last import, so the
+/// node can tell whether it is still inside that catch-up window (see `trust_coinbase` in
+/// `VirtualStateProcessor`) and self-expire the relaxation once the window has organically refilled.
+pub trait ProductionIndexSeedStoreReader {
+    fn get(&self) -> StoreResult<u64>;
+}
+
+pub trait ProductionIndexSeedStore: ProductionIndexSeedStoreReader {
+    fn set_batch(&mut self, batch: &mut WriteBatch, seeded_at_index: u64) -> StoreResult<()>;
+}
+
+#[derive(Clone)]
+pub struct DbProductionIndexSeedStore {
+    access: CachedDbItem<u64>,
+}
+
+impl DbProductionIndexSeedStore {
+    pub fn new(db: Arc<DB>) -> Self {
+        Self { access: CachedDbItem::new(db, DatabaseStorePrefixes::ProductionIndexSeededAt.into()) }
+    }
+
+    pub fn clone_with_new_cache(&self, db: Arc<DB>) -> Self {
+        Self::new(db)
+    }
+
+    /// `None` if the node has never imported a pruning-point UTXO snapshot (built from genesis, so
+    /// `windowed_production_store` was never cleared/reset and has no catch-up gap), or pre-dates
+    /// this store.
+    pub fn get_optional(&self) -> Option<u64> {
+        self.access.read().optional().unwrap()
+    }
+}
+
+impl ProductionIndexSeedStoreReader for DbProductionIndexSeedStore {
+    fn get(&self) -> StoreResult<u64> {
+        self.access.read()
+    }
+}
+
+impl ProductionIndexSeedStore for DbProductionIndexSeedStore {
+    fn set_batch(&mut self, batch: &mut WriteBatch, seeded_at_index: u64) -> StoreResult<()> {
+        self.access.write(BatchDbWriter::new(batch), &seeded_at_index)
+    }
+}

--- a/consensus/src/pipeline/virtual_processor/processor.rs
+++ b/consensus/src/pipeline/virtual_processor/processor.rs
@@ -25,6 +25,7 @@ use crate::{
             address_amount::DbAddressAmountStore,
             past_pruning_points::DbPastPruningPointsStore,
             pom_tier::DbPomTierStore,
+            production_seed::{DbProductionIndexSeedStore, ProductionIndexSeedStore},
             pruning::{DbPruningStore, PruningStoreReader},
             pruning_meta::PruningMetaStores,
             pruning_samples::DbPruningSamplesStore,
@@ -132,6 +133,7 @@ pub struct VirtualStateProcessor {
     pub(super) body_tips_store: Arc<RwLock<DbTipsStore>>,
     pub(super) depth_store: Arc<DbDepthStore>,
     pub(super) selected_chain_store: Arc<RwLock<DbSelectedChainStore>>,
+    pub(super) production_index_seed_store: Arc<RwLock<DbProductionIndexSeedStore>>,
     pub(super) pruning_samples_store: Arc<DbPruningSamplesStore>,
 
     // Utxo-related stores
@@ -205,13 +207,24 @@ pub struct VirtualStateProcessor {
     // Trailing selected-chain window length (blocks) for the ratio-reward production index.
     pub(super) ratio_reward_window: u64,
 
-    // Skip ratio/tier coinbase verification while following the chain. Auto-enabled for ARCHIVAL
-    // nodes (`KERYX_TRUST_COINBASE=1` also forces it on): an archival node retains blocks below the
-    // pruning point, so its windowed-production fold subtracts leaving blocks that pruned nodes (the
-    // canonical majority) never see → it computes a different ratio and would disqualify the whole
-    // chain. The header `utxo_commitment` (checked first, always) already pins the resulting UTXO set
-    // to the canonical chain, so trusting the block's coinbase outputs is safe.
-    pub(super) trust_coinbase: bool,
+    // Skip ratio/tier coinbase verification while following the chain. Three independent reasons,
+    // ORed together and re-checked live (see `trust_coinbase()`) rather than fixed at construction:
+    //  - `is_archival`: an archival node retains blocks below the pruning point, so its
+    //    windowed-production fold subtracts leaving blocks that pruned nodes (the canonical
+    //    majority) never see → it computes a different ratio and would disqualify the whole chain.
+    //    Permanent for the node's lifetime.
+    //  - `KERYX_TRUST_COINBASE` env: manual operator override, also permanent.
+    //  - fast-sync catch-up window: `import_pruning_point_utxo_set` clears (does not seed) the
+    //    windowed-production index, on the assumption the whole `ratio_reward_window` lies above
+    //    the pruning point. That assumption breaks once the chain has advanced past `pruning_depth`
+    //    beyond the ratio-reward activation height — every fresh fast sync then starts its index at
+    //    zero while activation is already live, and needs a full window of catch-up before its
+    //    computed ratio matches long-running nodes. This case self-expires: once
+    //    `current_tip_index - seeded_at_index >= ratio_reward_window`, the index has organically
+    //    refilled and verification re-enables itself with no operator action.
+    // In every case the header `utxo_commitment` (checked first, always) already pins the resulting
+    // UTXO set to the canonical chain, so trusting the block's coinbase outputs is safe.
+    pub(super) is_archival: bool,
 }
 
 impl VirtualStateProcessor {
@@ -236,8 +249,7 @@ impl VirtualStateProcessor {
         // the ratio/tier coinbase. They therefore MUST trust it (the header utxo_commitment still
         // pins the resulting UTXO set). Auto-enabled by `--archival`; `KERYX_TRUST_COINBASE=1` also
         // forces it on. See field doc.
-        let trust_coinbase = is_archival || std::env::var("KERYX_TRUST_COINBASE").is_ok();
-        if trust_coinbase {
+        if is_archival || std::env::var("KERYX_TRUST_COINBASE").is_ok() {
             warn!(
                 "Ratio/tier coinbase verification DISABLED ({}) — following the chain on UTXO-commitment trust only.",
                 if is_archival { "archival node" } else { "KERYX_TRUST_COINBASE set" }
@@ -265,6 +277,7 @@ impl VirtualStateProcessor {
             body_tips_store: storage.body_tips_store.clone(),
             depth_store: storage.depth_store.clone(),
             selected_chain_store: storage.selected_chain_store.clone(),
+            production_index_seed_store: storage.production_index_seed_store.clone(),
             pruning_samples_store: storage.pruning_samples_store.clone(),
             utxo_diffs_store: storage.utxo_diffs_store.clone(),
             utxo_multisets_store: storage.utxo_multisets_store.clone(),
@@ -306,8 +319,32 @@ impl VirtualStateProcessor {
             pom_activation: params.pom_activation,
             ratio_reward_activation: params.ratio_reward_activation,
             ratio_reward_window: params.ratio_reward_window,
-            trust_coinbase,
+            is_archival,
         }
+    }
+
+    /// Whether ratio/tier coinbase verification should be skipped for the chain we're currently
+    /// following. See the field doc on `is_archival` for the three ORed conditions. Re-evaluated on
+    /// every call (cheap: one cached env lookup + at most one store read) rather than fixed at
+    /// construction, so the fast-sync catch-up relaxation auto-expires once the window refills.
+    pub(super) fn trust_coinbase(&self) -> bool {
+        self.is_archival || std::env::var("KERYX_TRUST_COINBASE").is_ok() || self.in_production_catchup_window()
+    }
+
+    /// True while we're still inside our own post-import catch-up window: fewer than
+    /// `ratio_reward_window` selected-chain blocks have been committed since the last
+    /// pruning-point UTXO import seeded (cleared) `windowed_production_store`. `false` if the node
+    /// has never imported a snapshot (built from genesis — no gap to begin with).
+    fn in_production_catchup_window(&self) -> bool {
+        let seeded_at = match self.production_index_seed_store.read().get_optional() {
+            Some(idx) => idx,
+            None => return false,
+        };
+        let tip_idx = match self.selected_chain_store.read().get_tip() {
+            Ok((idx, _)) => idx,
+            Err(_) => return false,
+        };
+        tip_idx.saturating_sub(seeded_at) < self.ratio_reward_window
     }
 
     pub fn worker(self: &Arc<Self>) {
@@ -1334,22 +1371,44 @@ impl VirtualStateProcessor {
             // diff since genesis; a fast-synced node skips that history, so seed the index directly
             // from the imported pruning-point UTXO snapshot (grouped per payout SPK). The incremental
             // lockstep maintenance in `commit_virtual_state` then carries it forward from here.
-            // The windowed-production index needs no seed (`W < pruning_depth` ⇒ its whole window lies
-            // above the pruning point and is rebuilt exactly by the IBD that follows); we only clear
-            // it so a re-import over a populated DB cannot leave stale aggregates.
+            //
+            // The windowed-production index is NOT seeded from the snapshot (there is nothing to seed
+            // it with — the snapshot is a UTXO set, not a production history) — we only clear it so a
+            // re-import over a populated DB cannot leave stale aggregates. This was historically assumed
+            // safe because `W < pruning_depth` ⇒ the whole window lies above the pruning point and gets
+            // rebuilt exactly by the IBD that follows, completing before the window matters. That holds
+            // only while the pruning point is still before the ratio-reward activation height; once the
+            // chain has advanced past `pruning_depth` beyond it, every fresh fast sync now lands its
+            // import after activation, and needs a full window of catch-up before its computed ratio
+            // matches long-running nodes. We record the pre-import chain position here so
+            // `trust_coinbase()` can detect and bound exactly that catch-up period (self-expiring once
+            // the window organically refills) instead of disqualifying every block it sees in the
+            // meantime. See `production_seed` module doc and `is_archival` field doc for the full
+            // rationale.
             let mut balances: HashMap<ScriptPublicKey, u64> = HashMap::new();
             for item in virtual_write.utxo_set.iterator() {
                 let (_, entry) = item.unwrap();
                 let acc = balances.entry(entry.script_public_key.clone()).or_default();
                 *acc = acc.saturating_add(entry.amount);
             }
+            let production_seed_index = match self.selected_chain_store.read().get_tip() {
+                Ok((idx, _)) => idx,
+                Err(_) => 0,
+            };
             let mut batch = WriteBatch::default();
             self.address_balance_store.clear(&mut batch).unwrap();
             self.windowed_production_store.clear(&mut batch).unwrap();
+            self.production_index_seed_store.write().set_batch(&mut batch, production_seed_index).unwrap();
             for (spk, amount) in balances {
                 self.address_balance_store.set_batch(&mut batch, &spk, amount).unwrap();
             }
             self.db.write(batch).unwrap();
+            info!(
+                "Ratio-reward windowed-production index reset at import (selected-chain index {}); \
+                 ratio/tier coinbase verification will be auto-trusted for the next ~{} blocks of \
+                 catch-up (see KERYX_TRUST_COINBASE / is_archival for the other ways this can happen).",
+                production_seed_index, self.ratio_reward_window
+            );
         }
 
         let virtual_read = self.virtual_stores.upgradable_read();

--- a/consensus/src/pipeline/virtual_processor/tests.rs
+++ b/consensus/src/pipeline/virtual_processor/tests.rs
@@ -471,6 +471,67 @@ async fn windowed_production_accumulates_per_producer_and_slides() {
     assert_eq!(one_cut, vp.coinbase_manager.base_miner_cut(sink_daa));
 }
 
+/// Fastsync production-window trust (Option A): `trust_coinbase()` must relax ratio-reward coinbase
+/// verification for exactly the `ratio_reward_window` selected-chain blocks following a pruning-point
+/// UTXO import (the only window during which a fast-synced node's freshly-cleared
+/// `windowed_production_store` cannot yet match a from-genesis node's), then self-expire. A node that
+/// has never imported a snapshot must never see this relaxation.
+///
+/// The import is simulated at genesis (mirrors the `set_initial_utxo_set` / integration-test pattern
+/// for `import_pruning_point_utxo_set`: an empty multiset trivially matches genesis's own UTXO
+/// commitment). `import_pruning_point_utxo_set` recomputes virtual with the imported pruning point as
+/// its sole parent, so this must happen *before* any blocks are built on top of genesis — doing it
+/// after would silently discard that chain progress from virtual's perspective. Real fast sync never
+/// hits that ordering hazard because the imported pruning point is always itself the current chain
+/// tip; constructing a *non-genesis* pruning point with a correctly matching multiset needs the full
+/// integration-test machinery (see `ratio_reward_balance_index_reconstruction_matches_incremental` /
+/// `testing/integration/src/consensus_integration_tests.rs`), which is out of scope for this
+/// unit-level test of `trust_coinbase()`'s windowing arithmetic.
+#[tokio::test]
+async fn fastsync_catchup_window_trusts_then_expires() {
+    use crate::model::stores::selected_chain::SelectedChainStoreReader;
+    use keryx_consensus_core::api::ConsensusApi;
+    use keryx_muhash::MuHash;
+
+    // Tiny window (mirrors `windowed_production_accumulates_per_producer_and_slides`) so the test
+    // exercises the full catch-up-then-expiry cycle in a handful of blocks instead of needing the
+    // real mainnet/testnet `ratio_reward_window` (864_000 / 1_000).
+    let mut params = MAINNET_PARAMS;
+    params.ratio_reward_window = 3;
+    let window = params.ratio_reward_window;
+    let config = ConfigBuilder::new(params).skip_proof_of_work().build();
+    let mut ctx = TestContext::new(TestConsensus::new(&config));
+    let vp = ctx.consensus.virtual_processor().clone();
+
+    // Never imported a snapshot ⇒ no catch-up gap to begin with, regardless of chain progress.
+    assert_eq!(vp.production_index_seed_store.read().get_optional(), None, "fresh node must have no seed recorded");
+    assert!(!vp.trust_coinbase(), "a from-genesis node must never get the fastsync relaxation");
+
+    // Simulate a pruning-point UTXO import (fast sync) at genesis, before any blocks are built (see
+    // doc comment above for why ordering matters here). The seeded index it records is the *current*
+    // selected-chain tip at the moment of the call — genesis, i.e. index 0.
+    let genesis_hash = ctx.consensus.params().genesis.hash;
+    ctx.consensus.import_pruning_point_utxo_set(genesis_hash, MuHash::new()).unwrap();
+
+    let seeded_at = vp.production_index_seed_store.read().get_optional().expect("import must record a seed");
+    assert_eq!(seeded_at, 0, "import happened at genesis ⇒ seeded index must be 0");
+    assert!(vp.trust_coinbase(), "must be trusted immediately after import (0 blocks into the catch-up window)");
+
+    // Still inside the window: ratio_reward_window - 1 more blocks keeps us under the threshold.
+    for i in 0..(window - 1) {
+        ctx.build_block_template_row(0..1).validate_and_insert_row().await;
+        let tip_idx = vp.selected_chain_store.read().get_tip().unwrap().0;
+        assert_eq!(tip_idx, i + 1, "single-chain row must advance the selected-chain tip by exactly one block");
+        assert!(vp.trust_coinbase(), "must stay trusted while still inside the post-import catch-up window");
+    }
+
+    // One more block crosses the window boundary ⇒ the relaxation must self-expire.
+    ctx.build_block_template_row(0..1).validate_and_insert_row().await;
+    let tip_idx = vp.selected_chain_store.read().get_tip().unwrap().0;
+    assert!(tip_idx - seeded_at >= window, "test setup sanity: must have crossed the window");
+    assert!(!vp.trust_coinbase(), "must self-expire once a full ratio_reward_window of blocks has passed since import");
+}
+
 /// Ratio-reward (Stage 2b) reconstruction-equality: the balance index maintained incrementally from
 /// genesis (lockstep with the virtual UTXO set in `commit_virtual_state`) must equal, key-for-key,
 /// the index a fast-synced node rebuilds at `import_pruning_point_utxo_set` by grouping the imported

--- a/consensus/src/pipeline/virtual_processor/utxo_validation.rs
+++ b/consensus/src/pipeline/virtual_processor/utxo_validation.rs
@@ -232,11 +232,12 @@ impl VirtualStateProcessor {
         // selected parent → this block via its mergeset) let the ratio-reward bracket be evaluated at
         // this block's own view from the virtual-anchored balance index.
         //
-        // Skipped under the `KERYX_TRUST_COINBASE` operator opt-in (see `trust_coinbase`): the
-        // `utxo_commitment` verified above already pins this block's resulting UTXO set to the
+        // Skipped while `trust_coinbase()` holds (archival node, `KERYX_TRUST_COINBASE` operator
+        // opt-in, or still inside our own fast-sync production-index catch-up window — see its doc):
+        // the `utxo_commitment` verified above already pins this block's resulting UTXO set to the
         // canonical chain, so the block's coinbase outputs are trusted without re-deriving the ratio
-        // bracket — which a clean node cannot reproduce for the post-fork canonical chain.
-        if !self.trust_coinbase {
+        // bracket — which such a node cannot yet reproduce for the post-fork canonical chain.
+        if !self.trust_coinbase() {
             self.verify_coinbase_transaction(
                 &txs[0],
                 header.daa_score,

--- a/database/src/registry.rs
+++ b/database/src/registry.rs
@@ -78,6 +78,10 @@ pub enum DatabaseStorePrefixes {
     /// Ratio-reward production index: payout SPK → Σ coinbase miner-cut over the trailing window W
     WindowedProduction = 44,
 
+    /// Fast-sync catch-up: virtual selected-chain index at which `WindowedProduction` was last reset
+    /// by a pruning-point UTXO import (see `import_pruning_point_utxo_set`). Single value, no key.
+    ProductionIndexSeededAt = 45,
+
     // ---- Retention Period Root ----
     RetentionPeriodRoot = 50,
 


### PR DESCRIPTION
Problem
-------
`import_pruning_point_utxo_set` (fast sync) clears `windowed_production_store`
instead of seeding it, on the assumption that the whole `ratio_reward_window`
of selected-chain history lies above the imported pruning point and gets
rebuilt exactly by the body-IBD that follows. That assumption only holds while
the pruning point itself is still before the ratio-reward activation height.

Once the chain advances more than `pruning_depth` past that activation height,
every fresh fast sync lands its import after activation and starts its
windowed-production index at zero while ratio-reward verification is already
live. Until the index organically refills, the node computes a different
`ratio_bps` than long-running peers for the same blocks and disqualifies
every ratio-reward coinbase it sees — it cannot pass body-IBD past that point
without manually setting `KERYX_TRUST_COINBASE`.

Solution (Option A)
--------------------
Generalize the old fixed `trust_coinbase: bool` field (true only for
archival nodes / env override) into a `trust_coinbase()` method, OR-ing three
independently-justified, live-reevaluated conditions:

  - `is_archival` (renamed from the old field) — permanent, unchanged behavior.
  - `KERYX_TRUST_COINBASE` env override — permanent, unchanged behavior.
  - `in_production_catchup_window()` — NEW. True while fewer than
    `ratio_reward_window` selected-chain blocks have passed since the last
    pruning-point UTXO import. Self-expires once the window refills, with no
    operator action.

Backed by a new persisted single-value store, `ProductionIndexSeededAt`
(`production_seed.rs`, DB prefix 45), recording the selected-chain index at
the moment `windowed_production_store` was last reset. `trust_coinbase()`
reads it on every call (cheap: one cached env lookup + at most one store
read) rather than fixing the decision at construction, which is what lets
the relaxation expire automatically.

In all three cases the header `utxo_commitment` (verified unconditionally,
before this check) already pins the block's resulting UTXO set to the
canonical chain, so trusting its coinbase outputs carries no new risk beyond
what archival/env-override trust already accepted.

Files changed
-------------
  - consensus/src/model/stores/production_seed.rs (new): store + traits.
  - consensus/src/model/stores/mod.rs: declare the new module.
  - database/src/registry.rs: new `ProductionIndexSeededAt = 45` DB prefix
    (no collision with neighboring prefixes 44/50).
  - consensus/src/consensus/storage.rs: wire the new store into
    `ConsensusStorage`.
  - consensus/src/pipeline/virtual_processor/processor.rs: `is_archival`
    field rename, `trust_coinbase()` / `in_production_catchup_window()`
    methods, and the `import_pruning_point_utxo_set` seed-write + log line.
  - consensus/src/pipeline/virtual_processor/utxo_validation.rs: single call
    site updated to the method form, doc comment updated.
  - consensus/src/pipeline/virtual_processor/tests.rs: new unit test (below).

Test results
------------
New test `fastsync_catchup_window_trusts_then_expires` (uses a shrunk
`ratio_reward_window = 3` to exercise the full catch-up-then-expiry cycle in
a handful of blocks):
  - A from-genesis node (never imported a snapshot) never gets the
    relaxation, regardless of chain progress.
  - Immediately after a simulated pruning-point import at genesis,
    `trust_coinbase()` is true.
  - It stays true for `ratio_reward_window - 1` further blocks.
  - It is false again once a full `ratio_reward_window` of blocks has
    passed since the import.

Full crate suite: `cargo test -p keryx-consensus --lib` — 69/69 passed,
0 failed (includes all pre-existing `pipeline::virtual_processor::tests::`
and `processes::coinbase::tests::` coverage — no regressions observed).
`cargo check -p keryx-consensus --tests` — clean.

Risks / things a reviewer should weigh
---------------------------------------
  - The new test simulates the import at genesis rather than a real
    non-genesis pruning point, because `import_pruning_point_utxo_set`
    unconditionally recomputes virtual with the imported hash as its sole
    parent — constructing a realistic non-genesis snapshot with a correctly
    matching multiset needs the full integration-test machinery (see
    `ratio_reward_balance_index_reconstruction_matches_incremental` /
    `testing/integration/src/consensus_integration_tests.rs`), which was out
    of scope for this unit-level test of the windowing arithmetic itself.
    The end-to-end fast-sync path through real IBD is not covered by this
    patch's tests.
  - `in_production_catchup_window()` adds one extra store read to
    `trust_coinbase()` on the hot coinbase-verification path; the store is
    a single cached value (`CachedDbItem<u64>`), so the steady-state cost
    after the first read is a lock + cache hit, not a DB hit.
  - This widens (not narrows) the conditions under which coinbase
    ratio/tier verification is skipped. The added window is bounded and
    self-expiring by construction, but it is still a deliberate trust
    relaxation and should be reviewed with that in mind.

Rollback
--------
Revert this commit; no schema migration is required (the new DB prefix is
simply never written/read by older binaries, and is additive — no existing
prefix was renumbered).
