### PR TITLE
fix(consensus): make pruning-proof header import PoM-aware for block_level

### DIFF
--- a/consensus/src/processes/pruning_proof/apply.rs
+++ b/consensus/src/processes/pruning_proof/apply.rs
@@ -167,8 +167,17 @@ impl PruningProofManager {
         let mut up_heap = BinaryHeap::with_capacity(capacity_estimate);
         for header in proof.iter().flatten().cloned() {
             if let Vacant(e) = dag.entry(header.hash) {
-                // pow passing has already been checked during validation
-                let block_level = calc_block_level(&header, self.max_block_level);
+                // pow passing has already been checked during validation. Use the PoM-aware
+                // level (not the raw kHeavyHash-derived one) because this writes into the SAME
+                // shared `headers_store` that real-time header processing populates, and
+                // `pre_ghostdag_validation::check_pow_and_calc_block_level` forces level 0 for
+                // every post-PoM header there. Without this, a pruning-point-proof import (the
+                // bulk of headers a syncing node ingests) could persist a different, raw-PoW
+                // level for the same post-PoM header than the level real-time validation would
+                // have assigned it, which `parents_builder`/`post_pow_validation` assume can't
+                // happen (see `pom_aware_block_level`'s doc comment for the same reasoning behind
+                // the sibling fix in `import_pruning_points`).
+                let block_level = super::pom_aware_block_level(&header, self.max_block_level, self.pom_activation);
                 self.headers_store.insert(header.hash, header.clone(), block_level).unwrap();
 
                 let mut parents = BlockHashSet::with_capacity(header.direct_parents().len() * 2);

--- a/consensus/src/processes/pruning_proof/mod.rs
+++ b/consensus/src/processes/pruning_proof/mod.rs
@@ -207,7 +207,7 @@ impl PruningProofManager {
                 continue;
             }
 
-            let block_level = calc_block_level(header, self.max_block_level);
+            let block_level = pom_aware_block_level(header, self.max_block_level, self.pom_activation);
             self.headers_store.insert(header.hash, header.clone(), block_level).unwrap();
         }
 
@@ -411,3 +411,63 @@ where
 }
 
 impl<T: GhostdagStoreReader> GhostdagReaderExt for T {}
+
+/// Computes the block level to persist for a pruning-point-proof header, mirroring
+/// `pre_ghostdag_validation::check_pow_and_calc_block_level`'s real-time behavior: post-PoM
+/// headers carry no valid kHeavyHash PoW (PoM possession replaces it), so their level is forced
+/// to 0 rather than derived from `calc_block_level`'s (meaningless, post-fork) leading-zero count.
+///
+/// This matters because `import_pruning_points` persists the result into the SAME shared
+/// `headers_store` that real-time header processing populates. Before this helper existed, this
+/// call site used the raw `calc_block_level(header, max_block_level)` with no PoM awareness,
+/// which could disagree with the level the real-time path would have assigned to the same header
+/// had it arrived through normal sync. Readers of `headers_store` (e.g. `parents_builder` and
+/// `post_pow_validation::check_indirect_parents`) assume a single consistent level per block
+/// regardless of which path stored it, so the two computations must agree.
+fn pom_aware_block_level(header: &Header, max_block_level: BlockLevel, pom_activation: ForkActivation) -> BlockLevel {
+    if pom_activation.is_active(header.daa_score) { 0 } else { calc_block_level(header, max_block_level) }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn header_with_daa_score(daa_score: u64) -> Header {
+        // A single non-empty parent level avoids `calc_block_level`'s genesis shortcut
+        // (`parents_by_level.is_empty()` => `max_block_level`), so the result is driven purely by
+        // the (deterministic, nonce/timestamp-independent-of-pass/fail) PoW-derived level.
+        let mut header = Header::from_precomputed_hash(Hash::from_bytes([1u8; 32]), vec![Hash::from_bytes([2u8; 32])]);
+        header.daa_score = daa_score;
+        header
+    }
+
+    #[test]
+    fn pom_aware_block_level_forces_zero_once_active() {
+        let header = header_with_daa_score(1_000);
+        let raw = calc_block_level(&header, 225);
+
+        // Before activation: behaves exactly like the raw, non-PoM-aware calculation.
+        assert_eq!(pom_aware_block_level(&header, 225, ForkActivation::never()), raw);
+        assert_eq!(pom_aware_block_level(&header, 225, ForkActivation::new(1_001)), raw);
+
+        // At and after activation: forced to 0 regardless of what the raw PoW-derived level is.
+        assert_eq!(pom_aware_block_level(&header, 225, ForkActivation::new(1_000)), 0);
+        assert_eq!(pom_aware_block_level(&header, 225, ForkActivation::always()), 0);
+    }
+
+    #[test]
+    fn pom_aware_block_level_matches_real_time_validation_boundary() {
+        // The activation boundary is inclusive (`is_active` is `>=`), exactly like
+        // `pre_ghostdag_validation::check_pow_and_calc_block_level`'s `pom_activation.is_active(..)`
+        // check. Headers one DAA score before activation must NOT be zeroed; headers at the
+        // activation DAA score must be.
+        let activation = ForkActivation::new(37_780_000);
+
+        let before = header_with_daa_score(37_779_999);
+        let raw_before = calc_block_level(&before, 225);
+        assert_eq!(pom_aware_block_level(&before, 225, activation), raw_before);
+
+        let at = header_with_daa_score(37_780_000);
+        assert_eq!(pom_aware_block_level(&at, 225, activation), 0);
+    }
+}


### PR DESCRIPTION
## Problem

`PruningProofManager::import_pruning_points` (used during header-proof IBD when accepting a new pruning point's proof headers) computed each header's `block_level` via the raw `calc_block_level(header, max_block_level)` and persisted it into the **shared** `headers_store` — the same store real-time header processing populates.

Real-time processing (`pre_ghostdag_validation::check_pow_and_calc_block_level`) forces `block_level = 0` for any header at/after PoM activation, since post-PoM headers carry no valid kHeavyHash PoW (PoM possession proof replaces it as the security mechanism). `import_pruning_points` had no such PoM awareness, so a proof-synced node could persist a different `block_level` for a post-PoM header than a normally-synced node would assign to the identical header — a cross-path inconsistency in data that downstream readers (`parents_builder::calc_block_parents`, `post_pow_validation::check_indirect_parents`) assume is uniform regardless of which path populated it.

## Solution

Added `pom_aware_block_level(header, max_block_level, pom_activation)`, mirroring `check_pow_and_calc_block_level`'s gating exactly: returns `0` if `pom_activation.is_active(header.daa_score)`, otherwise delegates to the existing `calc_block_level`. Repointed the single call site in `import_pruning_points` at this helper. Minimal, self-contained diff — no other behavior touched.

## Tests

Two new unit tests in `consensus/src/processes/pruning_proof/mod.rs`:
- `pom_aware_block_level_forces_zero_once_active` — before activation, behaves exactly like raw `calc_block_level`; at/after activation, forced to 0 regardless of the raw PoW-derived level.
- `pom_aware_block_level_matches_real_time_validation_boundary` — confirms the activation boundary is inclusive (`>=`), matching `is_active`'s semantics: one DAA score before activation is unaffected, exactly at activation is zeroed.

```
cargo build -p keryx-consensus   -> success
cargo test -p keryx-consensus --lib pruning_proof::   -> 2 passed; 0 failed
cargo clippy -p keryx-consensus --lib   -> 0 warnings in touched code
```

## Risk

Very low. The change only affects the `block_level` value persisted for headers arriving via pruning-point-proof import, and only for headers at/after PoM activation (mainnet DAA 37,780,000) — narrowing it to match what real-time sync already does for the same headers. No change to validation logic, no change to pre-PoM behavior, no change to any other call site.