### PR TITLE
fix(ibd): trusted blocks fail IBD with PoM possession proof missing

### DIFF
--- a/consensus/src/pipeline/deps_manager.rs
+++ b/consensus/src/pipeline/deps_manager.rs
@@ -69,9 +69,16 @@ impl BlockTask {
         matches!(self, BlockTask::Trusted { .. })
     }
 
-    /// Whether the PoM possession proof check should be skipped for this block (IBD body sync only).
+    /// Whether the PoM possession proof check should be skipped for this block.
+    ///
+    /// Trusted blocks belong to a pruning proof whose accumulated work was already
+    /// validated. Their historical PoM proofs may also have been garbage-collected,
+    /// so requiring an individual possession proof here would make fresh IBD fail.
     pub fn skip_pom_proof(&self) -> bool {
-        matches!(self, BlockTask::Ordinary { skip_pom_proof: true, .. })
+        match self {
+            BlockTask::Ordinary { skip_pom_proof, .. } => *skip_pom_proof,
+            BlockTask::Trusted { .. } => true,
+        }
     }
 
     pub fn requires_virtual_processing(&self) -> bool {
@@ -158,6 +165,22 @@ impl TaskQueue {
             TaskQueue::Single(_) => false,
             TaskQueue::Many(q) => q.is_empty(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_block() -> Block {
+        Block::from_precomputed_hash(Hash::from_bytes([1; 32]), vec![])
+    }
+
+    #[test]
+    fn pom_proof_skip_policy_distinguishes_live_and_ibd_tasks() {
+        assert!(!BlockTask::Ordinary { block: test_block(), skip_pom_proof: false }.skip_pom_proof());
+        assert!(BlockTask::Ordinary { block: test_block(), skip_pom_proof: true }.skip_pom_proof());
+        assert!(BlockTask::Trusted { block: test_block() }.skip_pom_proof());
     }
 }
 

--- a/protocol/flows/src/ibd/flow.rs
+++ b/protocol/flows/src/ibd/flow.rs
@@ -792,6 +792,14 @@ staging selected tip ({}) is too small or negative. Aborting IBD...",
 
             for &hash in chunk.iter() {
                 let msg = dequeue_with_timeout!(self.incoming_route, Payload::BlockBody)?;
+                let pom_tier = msg.pom_tier.map(|tier| tier as u8);
+                let pom_proof = msg
+                    .pom_proof
+                    .as_deref()
+                    .map(borsh::from_slice::<PomProof>)
+                    .transpose()
+                    .map_err(|_| ProtocolError::OtherOwned(format!("invalid pom_proof for trusted block {}", hash)))?
+                    .map(Arc::new);
                 let blk_body: BlockBody = msg.try_into()?;
                 // TODO (relaxed): make header queries in a batch.
                 let blk_header = consensus.async_get_header(hash).await.map_err(|err| {
@@ -802,9 +810,7 @@ staging selected tip ({}) is too small or negative. Aborting IBD...",
                 if blk_body.is_empty() {
                     return Err(ProtocolError::OtherOwned(format!("sent empty block body for block {}", hash)));
                 }
-                // Trusted pruning-anticone blocks are pre-pom (pruning point precedes pom_activation),
-                // so there is no tier to carry.
-                let block = Block { header: blk_header, transactions: blk_body.into(), pom_proof: None, pom_tier: None };
+                let block = Block { header: blk_header, transactions: blk_body.into(), pom_proof, pom_tier };
                 // TODO (relaxed): sending ghostdag data may be redundant, especially when the headers were already verified.
                 // Consider sending empty ghostdag data, simplifying a great deal. The result should be the same -
                 // a trusted task is sent, however the header is already verified, and hence only the block body will be verified.


### PR DESCRIPTION
## Problem

Fresh nodes can fail headers-proof IBD while processing trusted blocks with:

```text
PoM possession proof missing
```

The trusted-block path is validated by the accumulated work of the pruning proof, but it still required an individual PoM possession proof for each trusted block. The trusted-body download path also discarded `pom_proof` and `pom_tier` received from the peer.

## Root cause

Two pieces were missing on current `master`:

1. `BlockTask::Trusted` was not exempted by `skip_pom_proof()`.
2. `sync_missing_trusted_bodies` constructed trusted blocks with `pom_proof: None` and `pom_tier: None`.

## Fix

- Treat `BlockTask::Trusted` as `skip_pom_proof = true`. Trusted chains have already been validated through the accumulated-work pruning proof, and historical per-block PoM proofs may have been garbage-collected.
- Decode and preserve `pom_proof` and `pom_tier` from trusted-body peer messages before consuming the message body.
- Add a focused unit test covering the skip policy for ordinary and trusted block tasks.

The branch is rebased directly on current `master`. It intentionally does not duplicate the existing `KERYX_TRUST_SYNC_FROM_TIP` or ordinary body-download PoM handling.

## Validation

- Production Docker build of `keryxd`: passed.
- Targeted unit test `pom_proof_skip_policy_distinguishes_live_and_ibd_tasks`: passed (`1 passed; 0 failed`).
- `rustfmt --check` for both changed files: passed.
- `git diff --check`: passed.
