### PR TITLE
warn when connect mode isolates the node

### DIFF
--- a/keryxd/src/args.rs
+++ b/keryxd/src/args.rs
@@ -277,7 +277,11 @@ pub fn cli() -> Command {
                 .action(ArgAction::Append)
                 .require_equals(true)
                 .value_parser(clap::value_parser!(ContextualNetAddress))
-                .help("Connect only to the specified peers at startup."),
+                .help(
+                    "Connect exclusively to the specified peers. This disables DNS discovery, regular outbound peer selection, \
+                     and inbound P2P connections for the lifetime of the process. Use --addpeer for preferred peers without \
+                     isolating the node.",
+                ),
         )
         .arg(
             Arg::new("add-peers")

--- a/keryxd/src/daemon.rs
+++ b/keryxd/src/daemon.rs
@@ -8,7 +8,7 @@ use keryx_consensus_core::{
     mining_rules::MiningRules,
 };
 use keryx_consensus_notify::{root::ConsensusNotificationRoot, service::NotifyService};
-use keryx_core::{core::Core, debug, info};
+use keryx_core::{core::Core, debug, info, warn};
 use keryx_core::{kaspad_env::version, task::tick::TickService};
 use keryx_database::{
     prelude::{CachePolicy, DbWriter, DirectDbWriter, RocksDbPreset},
@@ -544,6 +544,12 @@ Do you confirm? (y/n)";
     let add_peers = args.add_peers.iter().map(|x| x.normalize(config.default_p2p_port())).collect();
     let p2p_server_addr = args.listen.unwrap_or(ContextualNetAddress::unspecified()).normalize(config.default_p2p_port());
     // connect_peers means no DNS seeding and no outbound/inbound peers
+    if !connect_peers.is_empty() {
+        warn!(
+            "Exclusive --connect mode enabled: DNS discovery, regular outbound peer selection, and inbound P2P connections are disabled. \
+             The node will have no peers if all configured connections become unavailable; use --addpeer for preferred peers with fallback."
+        );
+    }
     let outbound_target = if connect_peers.is_empty() { args.outbound_target } else { 0 };
     let inbound_limit = if connect_peers.is_empty() { args.inbound_limit } else { 0 };
     let dns_seeders = if connect_peers.is_empty() && !args.disable_dns_seeding { config.dns_seeders } else { &[] };


### PR DESCRIPTION
## What changed

- Clarify in `--help` that `--connect` is an exclusive peer mode.
- Emit a startup warning when the mode disables DNS discovery, regular outbound peer selection, and inbound P2P.
- Point operators who only want preferred peers to `--addpeer`.

## Why

`--connect` silently sets the normal outbound target and inbound limit to zero and disables DNS seeders. If every configured peer disappears, the node remains running but has no fallback path to the network. This happened during a real fresh-node IBD recovery when the sole configured peer went offline; removing `--connect` immediately restored DNS discovery and multiple outbound peers.

The patch intentionally does not change the existing isolation semantics, because callers may rely on them. It only makes the operational consequence visible both before launch and in container logs.

## Validation

- `git diff --check`
- Full official release build: `docker build --target builder -f docker/Dockerfile.kaspad ...` (Rust 1.90)
- CLI smoke check confirms the expanded `--connect` help text