### PR TITLE
align coinbase output limit with reward builder

### DIFF
--- a/consensus/src/processes/transaction_validator/tx_validation_in_isolation.rs
+++ b/consensus/src/processes/transaction_validator/tx_validation_in_isolation.rs
@@ -1,8 +1,7 @@
 use crate::constants::{MAX_SOMPI, TX_VERSION};
 use keryx_consensus_core::tx::Transaction;
 use keryx_inference::{
-    AiChallengePayload, AiResponsePayload,
-    MAX_AI_CHALLENGE_PAYLOAD_LEN, MAX_AI_REQUEST_PAYLOAD_LEN, MAX_AI_RESPONSE_PAYLOAD_LEN,
+    AiChallengePayload, AiResponsePayload, MAX_AI_CHALLENGE_PAYLOAD_LEN, MAX_AI_REQUEST_PAYLOAD_LEN, MAX_AI_RESPONSE_PAYLOAD_LEN,
     MIN_AI_CHALLENGE_PAYLOAD_LEN, MIN_AI_REQUEST_PAYLOAD_LEN, MIN_AI_RESPONSE_PAYLOAD_LEN,
 };
 use std::collections::HashSet;
@@ -11,6 +10,12 @@ use super::{
     TransactionValidator,
     errors::{TxResult, TxRuleError},
 };
+
+// Each merge-set blue can contribute a fee-burn output plus miner and escrow/burn
+// subsidy outputs. Reds can add aggregate fee-burn and subsidy outputs, followed
+// by aggregate R&D and reward-burn outputs.
+const MAX_COINBASE_OUTPUTS_PER_BLUE: u64 = 3;
+const MAX_COINBASE_AGGREGATE_OUTPUTS: u64 = 4;
 
 impl TransactionValidator {
     /// Performs a variety of transaction validation checks which are independent of any
@@ -55,7 +60,10 @@ impl TransactionValidator {
             return Err(TxRuleError::CoinbaseNonZeroMassCommitment);
         }
 
-        let outputs_limit = self.ghostdag_k as u64 + 2;
+        // GHOSTDAG bounds merge-set blues at K + 1 (including the selected
+        // parent). Keep this limit aligned with the outputs emitted by the
+        // coinbase builder.
+        let outputs_limit = MAX_COINBASE_OUTPUTS_PER_BLUE * (self.ghostdag_k as u64 + 1) + MAX_COINBASE_AGGREGATE_OUTPUTS;
         if tx.outputs.len() as u64 > outputs_limit {
             return Err(TxRuleError::CoinbaseTooManyOutputs(tx.outputs.len(), outputs_limit));
         }
@@ -70,7 +78,8 @@ impl TransactionValidator {
 
     fn check_transaction_outputs_count(&self, tx: &Transaction) -> TxResult<()> {
         if tx.is_coinbase() {
-            // We already check coinbase outputs count vs. Ghostdag K + 2
+            // Coinbase has a tighter structural limit based on Ghostdag K and
+            // the outputs emitted per merge-set reward.
             return Ok(());
         }
         if tx.outputs.len() > self.max_tx_outputs {
@@ -262,6 +271,18 @@ mod tests {
         );
 
         tv.validate_tx_in_isolation(&valid_cb).unwrap();
+
+        let coinbase_outputs_limit = 3 * (params.ghostdag_k() as usize + 1) + 4;
+        let mut max_outputs_cb = valid_cb.clone();
+        max_outputs_cb.outputs = vec![valid_cb.outputs[0].clone(); coinbase_outputs_limit];
+        tv.validate_tx_in_isolation(&max_outputs_cb).unwrap();
+
+        max_outputs_cb.outputs.push(valid_cb.outputs[0].clone());
+        assert_match!(
+            tv.validate_tx_in_isolation(&max_outputs_cb),
+            Err(TxRuleError::CoinbaseTooManyOutputs(actual, limit))
+                if actual == coinbase_outputs_limit + 1 && limit == coinbase_outputs_limit as u64
+        );
 
         let valid_tx = Transaction::new(
             0,


### PR DESCRIPTION
## What changed

- Replace the stale `K + 2` coinbase output cap with a structural bound matching the current reward builder: `3 * (K + 1) + 4`.
- Document how the bound is derived from per-blue fee/miner/escrow outputs and aggregate red-fee, red-subsidy, R&D, and reward-burn outputs.
- Add boundary coverage proving the maximum is accepted and one output above it is rejected.

## Root cause

GHOSTDAG permits up to `K + 1` merge-set blues. The current coinbase builder can emit up to three outputs per blue (fee burn, miner subsidy, escrow/burn), plus four aggregate outputs. The isolation validator still enforced the older `K + 2` layout. On mainnet (`K = 124`) the node constructed a 147-output coinbase and rejected it against the stale 126-output cap, blocking block processing and IBD.

## Impact

The validator now accepts every coinbase shape the current builder can produce while retaining a deterministic structural upper bound (379 outputs on mainnet). This unblocks affected nodes without relaxing validation to the generic transaction output limit.

## Validation

- `cargo test -j 2 -p keryx-consensus validate_tx_in_isolation_test --lib -- --nocapture`
  - 1 passed, 0 failed
- Full optimized `keryxd` Docker release build completed successfully.
- Production recovery using the existing DataDir:
  - block/header gap closed (`1,595,480` blocks vs `1,744,997` headers to equal block/header counts)
  - IBD completed successfully
  - `GetSyncStatus.isSynced = true`
  - steady UTXO validation resumed
  - local miner recovered to ~27–28 MH/s
  - blocks `f97ea68d9b7a1797e5317e7b9df8d969a245bc700e253ffd20dd21a0350fce0c` and `5d1e4a1273a1e2efbee583b36ecbe2a2e98a7158c18030969b33073e2e597d09` were submitted successfully
