### PR TITLE
fix(consensus): join PoM GC thread before staging DB cleanup

### DIFF
--- a/consensus/src/pipeline/pruning_processor/processor.rs
+++ b/consensus/src/pipeline/pruning_processor/processor.rs
@@ -131,16 +131,16 @@ impl PruningProcessor {
         // bootstrap datadir. The sweep is cursor-based and idempotent, so running it concurrently
         // with pruning (which deletes proofs too) is safe: deletes of the same key commute.
         let gc = self.clone();
-        std::thread::Builder::new()
+        let gc_handle = std::thread::Builder::new()
             .name("pom-proof-gc".to_string())
             .spawn(move || {
                 while !gc.is_consensus_exiting.load(Ordering::Relaxed) {
                     // Drain the whole backlog batch by batch, pausing briefly between batches to
                     // stay gentle on the DB, then idle until new chain blocks exit the window.
                     while gc.gc_old_pom_proofs() && !gc.is_consensus_exiting.load(Ordering::Relaxed) {
-                        std::thread::sleep(Duration::from_millis(50));
+                        std::thread::park_timeout(Duration::from_millis(50));
                     }
-                    std::thread::sleep(Duration::from_secs(5));
+                    std::thread::park_timeout(Duration::from_secs(5));
                 }
             })
             .expect("spawning the PoM proof GC thread");
@@ -165,6 +165,12 @@ impl PruningProcessor {
             self.advance_pruning_point_if_possible(sink_ghostdag_data);
             self.gc_collapse_ratio_prefix();
         }
+
+        // The GC thread owns an Arc<PruningProcessor>, which indirectly keeps
+        // the RocksDB connection alive. Join it before the staging consensus
+        // is dropped so cleanup can close the DB and release its FD budget.
+        gc_handle.thread().unpark();
+        gc_handle.join().expect("joining the PoM proof GC thread");
     }
 
     /// Collapse ratio-reward prefix-index entries the consensus can no longer read into the per-SPK


### PR DESCRIPTION
﻿## Summary

Fix a reproducible Windows first-run crash that occurs when headers-proof IBD fails and the node immediately starts another staging consensus.

The dedicated `pom-proof-gc` thread remains detached and retains an `Arc<PruningProcessor>`, indirectly keeping the staging RocksDB connection open after the main pruning worker exits.

On Windows, the open RocksDB handles prevent removal of the staging consensus directory. The following IBD attempt then exceeds the global file-descriptor budget and panics.

## Fix

- retain the PoM GC thread `JoinHandle`
- replace `sleep()` with interruptible `park_timeout()`
- unpark the GC thread during pruning-worker shutdown
- join the thread before staging consensus cleanup

## Reproduction

Tested on:

- Windows 10, build 19045.6466
- upstream commit `d812e7827a18e4ff95a89db2950cdc3f51020985`
- default configuration, without command-line arguments
- `%LOCALAPPDATA%\keryx-labs` deleted before each test

The unmodified binary reproduced:

```text
IBD with headers proof ... was unsuccessful
Error deleting staging consensus entry 2:
The process cannot access the file because it is being used by another process. (os error 32)
```

The next IBD attempt then panicked:

```text
Error { acquired: 7933, limit: 8192 }
```

## Validation

The patched binary was built with:

```text
cargo build --release -p keryxd --bin keryxd
```

The patched build was tested from another completely clean default datadir.

It encountered the same failed headers-proof IBD from the same peer, but:

- staging consensus cleanup completed without an error
- no file-descriptor budget panic occurred
- IBD immediately restarted with another peer
- the pruning proof was applied and rebuilt successfully
- trusted blocks were processed
- normal header synchronization continued

Both binaries were tested from independent clean datadirs.
