### PR TITLE
fix(consensus): relaunch H4 and restore pruned-node IBD

### DIFF
--- a/consensus/core/src/config/params.rs
+++ b/consensus/core/src/config/params.rs
@@ -134,6 +134,8 @@ pub const INFERENCE_REWARD_MINIMUMS_V2_H2: &[([u8; 32], u64)] = &[
 /// `never()`). Set this to the chosen H4 DAA score at release — it drives BOTH mainnet coin-age
 /// gates (`coin_age_activation` + `coin_age_verification_activation`) in one edit. The miner's
 /// `COIN_AGE_VERIFICATION_ACTIVATION_DAA` MUST be set to the exact same value (node↔miner lockstep).
+/// At this score miners and pools MUST also switch to header version 2 and the
+/// `POM_H4_RELAUNCH_PPH_SALT` fold; version-1 H4 headers are intentionally invalid.
 /// NOTE: the H4 difficulty reset is a SEPARATE entry (see `difficulty_reset_activations`), because
 /// the existing H2 reset at 38_951_445 is load-bearing history that must not move.
 pub const H4_ACTIVATION_DAA: u64 = 54_766_000;

--- a/consensus/core/src/constants.rs
+++ b/consensus/core/src/constants.rs
@@ -1,5 +1,13 @@
-/// BLOCK_VERSION represents the current block version
+/// Block version used before the H4 relaunch boundary.
 pub const BLOCK_VERSION: u16 = 1;
+
+/// Block version required by the H4 relaunch and all later blocks.
+pub const H4_RELAUNCH_BLOCK_VERSION: u16 = BLOCK_VERSION + 1;
+
+#[inline]
+pub const fn block_version_for_h4_relaunch(daa_score: u64, h4_relaunch_activation_daa: u64) -> u16 {
+    if daa_score >= h4_relaunch_activation_daa { H4_RELAUNCH_BLOCK_VERSION } else { BLOCK_VERSION }
+}
 
 /// TX_VERSION is the current latest supported transaction version.
 pub const TX_VERSION: u16 = 0;
@@ -39,3 +47,16 @@ pub const SEQUENCE_LOCK_TIME_DISABLED: u64 = 1 << 63;
 /// UNACCEPTED_DAA_SCORE is used to for UtxoEntries that were created by
 /// transactions in the mempool, or otherwise not-yet-accepted transactions.
 pub const UNACCEPTED_DAA_SCORE: u64 = u64::MAX;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn h4_relaunch_version_switches_at_the_exact_boundary() {
+        const H4_DAA: u64 = 54_766_000;
+
+        assert_eq!(block_version_for_h4_relaunch(H4_DAA - 1, H4_DAA), BLOCK_VERSION);
+        assert_eq!(block_version_for_h4_relaunch(H4_DAA, H4_DAA), H4_RELAUNCH_BLOCK_VERSION);
+    }
+}

--- a/consensus/core/src/errors/block.rs
+++ b/consensus/core/src/errors/block.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, fmt::Display};
 
 use crate::{
-    BlueWorkType, constants,
+    BlueWorkType,
     errors::{coinbase::CoinbaseError, tx::TxRuleError},
     tx::{TransactionId, TransactionOutpoint},
 };
@@ -27,8 +27,8 @@ impl<T: Display + Clone> Display for TwoDimVecDisplay<T> {
 
 #[derive(Error, Debug, Clone)]
 pub enum RuleError {
-    #[error("wrong block version: got {0} but expected {}", constants::BLOCK_VERSION)]
-    WrongBlockVersion(u16),
+    #[error("wrong block version: got {actual} but expected {expected}")]
+    WrongBlockVersion { actual: u16, expected: u16 },
 
     #[error("the block timestamp is too far into the future: block timestamp is {0} but maximum timestamp allowed is {1}")]
     TimeTooFarIntoTheFuture(u64, u64),

--- a/consensus/core/src/errors/config.rs
+++ b/consensus/core/src/errors/config.rs
@@ -17,6 +17,12 @@ pub enum ConfigError {
     #[error("Configuration: --max-tracked-addresses cannot be set above {0}")]
     MaxTrackedAddressesTooHigh(usize),
 
+    #[error("Configuration: --stash-blocks must be greater than zero")]
+    StashBlocksZero,
+
+    #[error("Configuration: only one of --stash-blocks, --rollback-h4, and --reset-db may be used")]
+    ConflictingRecoveryOptions,
+
     #[cfg(feature = "devnet-prealloc")]
     #[error("Cannot preallocate UTXOs on any network except devnet")]
     PreallocUtxosOnNonDevnet,

--- a/consensus/core/src/pom.rs
+++ b/consensus/core/src/pom.rs
@@ -270,10 +270,25 @@ fn pph_words(pre_pow_hash: &[u8; 32]) -> [u64; 4] {
 /// Derivation: sha256("keryx-h3-pom-pph-salt") read as 4 little-endian u64 words.
 pub const POM_H3_PPH_SALT: [u64; 4] = [0x7C99D381176D4EC4, 0xC2E28E3E28118C36, 0xD496CE1B129B76CA, 0x47CF0979FA580BCE];
 
+/// H4 relaunch domain salt, layered on top of the H3 fold. It is a consensus
+/// separator rather than a model change: a block built on the aborted H4 branch
+/// must not remain valid after nodes return to the H4 boundary and re-mine it.
+/// Derivation: sha256("keryx-h4-relaunch-pom-pph-salt-v1") as little-endian u64 words.
+pub const POM_H4_RELAUNCH_PPH_SALT: [u64; 4] = [0x841889637DD00109, 0x2C462821E692095A, 0xB686260E241D9F3E, 0x7F5848D211D48879];
+
 #[inline]
 fn pph_words_h3(pre_pow_hash: &[u8; 32]) -> [u64; 4] {
     let mut w = pph_words(pre_pow_hash);
     for (wi, si) in w.iter_mut().zip(POM_H3_PPH_SALT.iter()) {
+        *wi ^= si;
+    }
+    w
+}
+
+#[inline]
+fn pph_words_h4_relaunch(pre_pow_hash: &[u8; 32]) -> [u64; 4] {
+    let mut w = pph_words_h3(pre_pow_hash);
+    for (wi, si) in w.iter_mut().zip(POM_H4_RELAUNCH_PPH_SALT.iter()) {
         *wi ^= si;
     }
     w
@@ -302,6 +317,11 @@ pub fn pom_block_seed_h3(pre_pow_hash: &[u8; 32], timestamp: u64, nonce: u64) ->
     pom_block_seed_from_words(&pph_words_h3(pre_pow_hash), timestamp, nonce)
 }
 
+/// H4-relaunch seed: H3's fold with an additional forced-update domain separator.
+pub fn pom_block_seed_h4_relaunch(pre_pow_hash: &[u8; 32], timestamp: u64, nonce: u64) -> u64 {
+    pom_block_seed_from_words(&pph_words_h4_relaunch(pre_pow_hash), timestamp, nonce)
+}
+
 #[inline]
 fn pom_pow_value_from_words(final_state: u64, p: &[u64; 4]) -> [u8; 32] {
     let o0 = mix64(final_state ^ p[0] ^ 0x9E3779B97F4A7C15);
@@ -326,6 +346,11 @@ pub fn pom_pow_value(final_state: u64, pre_pow_hash: &[u8; 32]) -> [u8; 32] {
 /// H3-era pow value: same fold over the salted pre_pow_hash words.
 pub fn pom_pow_value_h3(final_state: u64, pre_pow_hash: &[u8; 32]) -> [u8; 32] {
     pom_pow_value_from_words(final_state, &pph_words_h3(pre_pow_hash))
+}
+
+/// H4-relaunch PoM value: H3's fold with the relaunch domain separator.
+pub fn pom_pow_value_h4_relaunch(final_state: u64, pre_pow_hash: &[u8; 32]) -> [u8; 32] {
+    pom_pow_value_from_words(final_state, &pph_words_h4_relaunch(pre_pow_hash))
 }
 
 #[inline]
@@ -634,6 +659,25 @@ mod verify_tests {
 
     fn fh(s: u64) -> [u8; 32] {
         trace_leaf(s)
+    }
+
+    #[test]
+    fn h4_relaunch_fold_is_distinct_from_h3() {
+        let pre_pow_hash = blake(b"h4-relaunch-pre-pow-hash");
+        let timestamp = 1_719_000_000_000;
+        let nonce = 0xfeed_cafe;
+        let final_state = 0x0123_4567_89ab_cdef;
+
+        assert_ne!(
+            pom_block_seed_h3(&pre_pow_hash, timestamp, nonce),
+            pom_block_seed_h4_relaunch(&pre_pow_hash, timestamp, nonce),
+            "the relaunch must produce a new possession-walk trajectory"
+        );
+        assert_ne!(
+            pom_pow_value_h3(final_state, &pre_pow_hash),
+            pom_pow_value_h4_relaunch(final_state, &pre_pow_hash),
+            "the relaunch must make aborted-H4 header PoW invalid"
+        );
     }
 
     #[test]

--- a/consensus/pow/src/lib.rs
+++ b/consensus/pow/src/lib.rs
@@ -118,7 +118,15 @@ pub fn calc_level_from_pow(pow: Uint256, max_block_level: BlockLevel) -> BlockLe
 /// `proof.final_state == header.pom_final_state`.
 pub fn calc_pom_pow(header: &Header) -> Uint256 {
     let pre_pow_hash = hashing::header::hash_override_nonce_time(header, 0, 0);
-    Uint256::from_le_bytes(keryx_consensus_core::pom::pom_pow_value_h3(header.pom_final_state, &pre_pow_hash.as_bytes()))
+    // The H4 relaunch marker is part of the header and therefore needs no global
+    // network state here. Header validation enforces that version 2 starts at
+    // the configured H4 DAA boundary before this PoW check runs.
+    let pow = if header.version == keryx_consensus_core::constants::H4_RELAUNCH_BLOCK_VERSION {
+        keryx_consensus_core::pom::pom_pow_value_h4_relaunch(header.pom_final_state, &pre_pow_hash.as_bytes())
+    } else {
+        keryx_consensus_core::pom::pom_pow_value_h3(header.pom_final_state, &pre_pow_hash.as_bytes())
+    };
+    Uint256::from_le_bytes(pow)
 }
 
 /// H3 block level + target check from the header alone. The exact PoM-era mirror of
@@ -131,4 +139,24 @@ pub fn calc_pom_block_level_check_pow(header: &Header, max_block_level: BlockLev
     let pow = calc_pom_pow(header);
     let passed = pow <= Uint256::from_compact_target_bits(header.bits);
     (calc_level_from_pow(pow, max_block_level), passed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use keryx_consensus_core::constants::{BLOCK_VERSION, H4_RELAUNCH_BLOCK_VERSION};
+    use keryx_hashes::Hash;
+
+    #[test]
+    fn h4_relaunch_marker_selects_a_distinct_pom_pow_fold() {
+        let mut header = Header::from_precomputed_hash(Hash::from_bytes([1; 32]), vec![Hash::from_bytes([2; 32])]);
+        header.pom_final_state = 0x0123_4567_89ab_cdef;
+
+        header.version = BLOCK_VERSION;
+        let h3_pow = calc_pom_pow(&header);
+        header.version = H4_RELAUNCH_BLOCK_VERSION;
+        let h4_pow = calc_pom_pow(&header);
+
+        assert_ne!(h3_pow, h4_pow);
+    }
 }

--- a/consensus/pow/src/matrix.rs
+++ b/consensus/pow/src/matrix.rs
@@ -391,7 +391,7 @@ mod tests {
     /// This is the key property guaranteeing Kaspa ↔ Keryx network isolation.
     #[test]
     fn test_keryx_salt_isolates_from_kaspa() {
-        use super::{KERYX_MATRIX_SALT, Matrix};
+        use super::{KERYX_MATRIX_SALT_V1, Matrix};
         use crate::xoshiro::XoShiRo256PlusPlus;
 
         let seed = Hash::from_bytes([42; 32]);
@@ -418,7 +418,7 @@ mod tests {
             Hash::from_bytes(bytes)
         };
         assert_eq!(zero_salt_seed, seed, "XOR with zero must be identity");
-        let _ = KERYX_MATRIX_SALT; // referenced to confirm salt is accessible from tests
+        let _ = KERYX_MATRIX_SALT_V1; // referenced to confirm salt is accessible from tests
     }
 
     /// Helper: prints the Keryx PoW vectors (keryx_hash and generate) so that

--- a/consensus/src/consensus/factory.rs
+++ b/consensus/src/consensus/factory.rs
@@ -1,6 +1,6 @@
 #[cfg(feature = "devnet-prealloc")]
 use super::utxo_set_override::{set_genesis_utxo_commitment_from_config, set_initial_utxo_set};
-use super::{Consensus, ctl::Ctl};
+use super::{Consensus, StartupRecovery, ctl::Ctl};
 use crate::{model::stores::U64Key, pipeline::ProcessingCounters};
 use itertools::Itertools;
 use keryx_consensus_core::{api::ConsensusApi, config::Config, mining_rules::MiningRules};
@@ -17,7 +17,7 @@ use keryx_database::{
 
 use keryx_txscript::caches::TxScriptCacheCounters;
 use keryx_utils::mem_size::MemSizeEstimator;
-use parking_lot::RwLock;
+use parking_lot::{Mutex, RwLock};
 use rocksdb::WriteBatch;
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, error::Error, fs, path::PathBuf, sync::Arc};
@@ -259,6 +259,7 @@ pub struct Factory {
     rocksdb_preset: RocksDbPreset,
     wal_dir: Option<PathBuf>,
     cache_budget: Option<usize>,
+    startup_recovery: Mutex<Option<StartupRecovery>>,
 }
 
 impl Factory {
@@ -276,6 +277,7 @@ impl Factory {
         rocksdb_preset: RocksDbPreset,
         wal_dir: Option<PathBuf>,
         cache_budget: Option<usize>,
+        startup_recovery: Option<StartupRecovery>,
     ) -> Self {
         assert!(fd_budget > 0, "fd_budget has to be positive");
         let mut config = config.clone();
@@ -297,6 +299,7 @@ impl Factory {
             rocksdb_preset,
             wal_dir,
             cache_budget,
+            startup_recovery: Mutex::new(startup_recovery),
         };
         factory.delete_inactive_consensus_entries();
         factory
@@ -333,6 +336,7 @@ impl ConsensusFactory for Factory {
             .build()
             .unwrap();
 
+        let startup_recovery = self.startup_recovery.lock().take();
         let session_lock = SessionLock::new();
         let consensus = Arc::new(Consensus::new(
             db.clone(),
@@ -343,7 +347,9 @@ impl ConsensusFactory for Factory {
             self.tx_script_cache_counters.clone(),
             entry.creation_timestamp,
             self.mining_rules.clone(),
-        ));
+            startup_recovery,
+        )
+        .unwrap_or_else(|err| panic!("startup recovery failed before consensus processors began: {err}")));
 
         // We write the new active entry only once the instance was created successfully.
         // This way we can safely avoid processing genesis in future process runs
@@ -381,7 +387,9 @@ impl ConsensusFactory for Factory {
             self.tx_script_cache_counters.clone(),
             entry.creation_timestamp,
             self.mining_rules.clone(),
-        ));
+            None,
+        )
+        .expect("staging consensus initialization must not require recovery"));
 
         // The default for the body_missing_anticone_set is an empty vector, which corresponds precisely to the state before a consensus commit
         // But The default value for the pruning_utxoset_stable_flag is true, but a staging consensus does not have a utxo and hence the flag is dropped explicitly

--- a/consensus/src/consensus/mod.rs
+++ b/consensus/src/consensus/mod.rs
@@ -152,6 +152,17 @@ pub struct Consensus {
     is_consensus_exiting: Arc<AtomicBool>,
 }
 
+/// A destructive local recovery requested before consensus workers start.
+///
+/// `StashBlocks` is intentionally measured in selected-chain blocks. `RollbackH4` derives that
+/// count from the local selected chain so operators can recover exactly to the H4 boundary without
+/// treating a DAG DAA score as a linear block height.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StartupRecovery {
+    StashBlocks(u64),
+    RollbackH4,
+}
+
 impl Deref for Consensus {
     type Target = ConsensusStorage;
 
@@ -170,7 +181,8 @@ impl Consensus {
         tx_script_cache_counters: Arc<TxScriptCacheCounters>,
         creation_timestamp: u64,
         mining_rules: Arc<MiningRules>,
-    ) -> Self {
+        startup_recovery: Option<StartupRecovery>,
+    ) -> Result<Self, String> {
         let params = &config.params;
         let perf_params = &config.perf;
         let is_consensus_exiting: Arc<AtomicBool> = Arc::new(AtomicBool::new(false));
@@ -181,7 +193,6 @@ impl Consensus {
         // Same pattern for the PoM block-level fork (H3): header hashing commits to
         // `pom_final_state` from this score on and has no access to Params.
         keryx_consensus_core::pom::init_pom_level_activation(params.pom_level_activation.daa_score());
-
         //
         // Storage layer
         //
@@ -327,6 +338,14 @@ impl Consensus {
         // Run database upgrades if any
         this.run_database_upgrades();
 
+        if let Some(recovery) = startup_recovery {
+            this.apply_startup_recovery(recovery)?;
+        }
+        // A generic --stash-blocks recovery must not become a way to bypass the forced H4
+        // relaunch. It either rewinds past the bad branch or this check stops startup and asks
+        // the operator to use a larger stash (or --rollback-h4).
+        this.ensure_h4_relaunch_compatible_chain()?;
+
         // Invariant the prefix-sum production index depends on for determinism: the ratio-reward
         // window never reaches below the pruning point, so every in-window block AND the `cum(b−W)`
         // floor baseline are always on disk for every node (archival or pruned). If a future param
@@ -355,7 +374,7 @@ impl Consensus {
         // run — the startup-time counterpart of the maturation-queue promotions.
         this.virtual_processor.rebuild_age_buckets_index();
 
-        this
+        Ok(this)
     }
 
     /// A procedure for calling database upgrades which are self-contained (i.e., do not require knowing the DB version)
@@ -363,6 +382,116 @@ impl Consensus {
         // Upgrade to initialize the new retention root field correctly
         self.retention_root_database_upgrade();
         self.consensus_transitional_flags_upgrade();
+    }
+
+    fn apply_startup_recovery(&self, recovery: StartupRecovery) -> Result<(), String> {
+        let outcome = match recovery {
+            StartupRecovery::StashBlocks(blocks) => self.virtual_processor.stash_selected_chain_blocks(blocks)?,
+            StartupRecovery::RollbackH4 => {
+                let h4_daa = self.config.params.coin_age_verification_activation.daa_score();
+                if h4_daa == u64::MAX {
+                    return Err("H4 is not scheduled for this network, so --rollback-h4 cannot be used".to_string());
+                }
+                self.virtual_processor.stash_selected_chain_to_before_daa(h4_daa)?
+            }
+        };
+        info!(
+            "stash-blocks recovery committed: removed {} selected-chain blocks, target {} at index {}, quarantined {} descendants",
+            outcome.removed_selected_chain_blocks,
+            outcome.target,
+            outcome.target_index,
+            outcome.invalidated_descendants,
+        );
+        Ok(())
+    }
+
+    /// A stored header is normally not revalidated when a node starts. That is unsafe at a
+    /// forced-update boundary: an old H4 branch can otherwise remain selected forever even though
+    /// a newly received copy of the same header would fail the replacement PoM fold. Locate the
+    /// first retained H4 block before workers start and require an explicit local rewind when it
+    /// contains a pre-relaunch solution.
+    fn ensure_h4_relaunch_compatible_chain(&self) -> Result<(), String> {
+        if self.config.params.skip_proof_of_work {
+            return Ok(());
+        }
+        let h4_daa = self.config.params.coin_age_verification_activation.daa_score();
+        if h4_daa == u64::MAX {
+            return Ok(());
+        }
+
+        let selected_chain = self.selected_chain_store.read();
+        let Ok((tip_index, _)) = selected_chain.get_tip() else {
+            return Ok(());
+        };
+
+        let retained_floor = self
+            .pruning_point_store
+            .read()
+            .pruning_point()
+            .map_err(|err| format!("cannot read pruning point for H4 relaunch check: {err}"))?;
+        let mut low = selected_chain
+            .get_by_hash(retained_floor)
+            .map_err(|err| format!("cannot locate retained selected-chain floor {retained_floor} for H4 relaunch: {err}"))?;
+        let tip = selected_chain
+            .get_by_index(tip_index)
+            .map_err(|err| format!("cannot inspect selected-chain tip {tip_index} for H4 relaunch: {err}"))?;
+        let tip_daa = self
+            .headers_store
+            .get_daa_score(tip)
+            .map_err(|err| format!("cannot read selected-chain tip {tip} for H4 relaunch: {err}"))?;
+        if tip_daa < h4_daa {
+            return Ok(());
+        }
+
+        let floor = selected_chain
+            .get_by_index(low)
+            .map_err(|err| format!("cannot inspect retained selected-chain floor {low} for H4 relaunch: {err}"))?;
+        let floor_daa = self
+            .headers_store
+            .get_daa_score(floor)
+            .map_err(|err| format!("cannot read retained selected-chain floor {floor} for H4 relaunch: {err}"))?;
+        if floor_daa < h4_daa {
+            let mut high = tip_index;
+            while low < high {
+                let mid = low + (high - low) / 2;
+                let hash = selected_chain
+                    .get_by_index(mid)
+                    .map_err(|err| format!("cannot inspect selected-chain block {mid} for H4 relaunch: {err}"))?;
+                let daa = self
+                    .headers_store
+                    .get_daa_score(hash)
+                    .map_err(|err| format!("cannot read selected-chain header {hash} for H4 relaunch: {err}"))?;
+                if daa < h4_daa {
+                    low = mid + 1;
+                } else {
+                    high = mid;
+                }
+            }
+        }
+
+        let hash = selected_chain
+            .get_by_index(low)
+            .map_err(|err| format!("cannot inspect first retained H4 block {low}: {err}"))?;
+        let header = self
+            .headers_store
+            .get_header(hash)
+            .map_err(|err| format!("cannot read first retained H4 header {hash}: {err}"))?;
+        let expected_version = keryx_consensus_core::constants::block_version_for_h4_relaunch(header.daa_score, h4_daa);
+        if header.version != expected_version {
+            return Err(format!(
+                "detected pre-relaunch H4 block {hash} at DAA {} with header version {}; run keryxd --rollback-h4 --yes before connecting to peers",
+                header.daa_score, header.version
+            ));
+        }
+        let (_, passes) = keryx_pow::calc_pom_block_level_check_pow(&header, self.config.params.max_block_level);
+        if !passes {
+            return Err(format!(
+                "detected pre-relaunch H4 block {hash} at DAA {}; run keryxd --rollback-h4 --yes before connecting to peers",
+                header.daa_score
+            ));
+        }
+
+        Ok(())
     }
 
     fn retention_root_database_upgrade(&self) {

--- a/consensus/src/consensus/services.rs
+++ b/consensus/src/consensus/services.rs
@@ -186,6 +186,7 @@ impl ConsensusServices {
             params.skip_proof_of_work,
             params.pom_activation,
             params.pom_level_activation,
+            params.coin_age_verification_activation,
             is_consensus_exiting,
         ));
 

--- a/consensus/src/consensus/test_consensus.rs
+++ b/consensus/src/consensus/test_consensus.rs
@@ -20,7 +20,7 @@ use crate::pipeline::virtual_processor::test_block_builder::TestBlockBuilder;
 use crate::processes::window::WindowManager;
 use crate::{
     config::Config,
-    constants::TX_VERSION,
+    constants::{TX_VERSION, block_version_for_h4_relaunch},
     errors::BlockProcessResult,
     model::{
         services::reachability::MTReachabilityService,
@@ -59,7 +59,9 @@ impl TestConsensus {
             tx_script_cache_counters,
             0,
             Arc::new(MiningRules::default()),
-        ));
+            None,
+        )
+        .expect("test consensus initialization must succeed"));
         let block_builder = TestBlockBuilder::new(consensus.virtual_processor.clone());
 
         Self { params: config.params.clone(), consensus, block_builder, _db_lifetime: Default::default() }
@@ -80,7 +82,9 @@ impl TestConsensus {
             tx_script_cache_counters,
             0,
             Arc::new(MiningRules::default()),
-        ));
+            None,
+        )
+        .expect("test consensus initialization must succeed"));
         let block_builder = TestBlockBuilder::new(consensus.virtual_processor.clone());
 
         Self { consensus, block_builder, params: config.params.clone(), _db_lifetime: db_lifetime }
@@ -102,7 +106,9 @@ impl TestConsensus {
             tx_script_cache_counters,
             0,
             Arc::new(MiningRules::default()),
-        ));
+            None,
+        )
+        .expect("test consensus initialization must succeed"));
         let block_builder = TestBlockBuilder::new(consensus.virtual_processor.clone());
 
         Self { consensus, block_builder, params: config.params.clone(), _db_lifetime: db_lifetime }
@@ -125,6 +131,10 @@ impl TestConsensus {
         let daa_window = self.consensus.services.window_manager.block_daa_window(&ghostdag_data).unwrap();
         header.bits = self.consensus.services.window_manager.calculate_difficulty_bits(&ghostdag_data, &daa_window);
         header.daa_score = daa_window.daa_score;
+        header.version = block_version_for_h4_relaunch(
+            header.daa_score,
+            self.params.coin_age_verification_activation.daa_score(),
+        );
         header.timestamp = self.consensus.services.window_manager.calc_past_median_time(&ghostdag_data).unwrap().0 + 1;
         header.blue_score = ghostdag_data.blue_score;
         header.blue_work = ghostdag_data.blue_work;

--- a/consensus/src/model/stores/production_seed.rs
+++ b/consensus/src/model/stores/production_seed.rs
@@ -48,6 +48,13 @@ impl DbProductionIndexSeedStore {
     pub fn get_optional(&self) -> Option<u64> {
         self.access.read().optional().unwrap()
     }
+
+    /// Clears the fast-sync catch-up marker when a selected-chain rewind rebuilds the prefix
+    /// index from its retained chain. Keeping the old marker would unnecessarily trust coinbases
+    /// after recovery, even though the rebuilt index is already authoritative.
+    pub fn clear_batch(&mut self, batch: &mut WriteBatch) -> StoreResult<()> {
+        self.access.delete_all(BatchDbWriter::new(batch))
+    }
 }
 
 impl ProductionIndexSeedStoreReader for DbProductionIndexSeedStore {

--- a/consensus/src/pipeline/body_processor/body_validation_in_isolation.rs
+++ b/consensus/src/pipeline/body_processor/body_validation_in_isolation.rs
@@ -9,7 +9,10 @@ use keryx_consensus_core::{
     hashing::header::hash_override_nonce_time,
     mass::{ContextualMasses, Mass, NonContextualMasses},
     merkle::calc_hash_merkle_root,
-    pom::{pom_block_seed, pom_block_seed_h3, pom_pow_value, pom_pow_value_h3, verify_pom_proof, verify_pom_proof_v2},
+    pom::{
+        pom_block_seed, pom_block_seed_h3, pom_block_seed_h4_relaunch, pom_pow_value, pom_pow_value_h3,
+        pom_pow_value_h4_relaunch, verify_pom_proof, verify_pom_proof_v2,
+    },
     tx::TransactionOutpoint,
 };
 use keryx_math::Uint256;
@@ -176,6 +179,7 @@ impl BlockBodyProcessor {
         // derive from it) — pin it to the proof so a miner cannot claim a level it did not earn.
         // H3 also salts the pph words feeding both folds (forced update — see POM_H3_PPH_SALT).
         let h3 = self.pom_level_activation.is_active(header.daa_score);
+        let h4_relaunch = self.coin_age_verification_activation.is_active(header.daa_score);
         if h3 && proof.final_state != header.pom_final_state {
             return Err(RuleError::PomFinalStateMismatch(header.pom_final_state, proof.final_state));
         }
@@ -191,13 +195,23 @@ impl BlockBodyProcessor {
 
         // pre_pow_hash commits everything except nonce/time (same as the legacy PoW front-end).
         let pre_pow_hash = hash_override_nonce_time(header, 0, 0).as_bytes();
-        let seed = if h3 {
+        let seed = if h4_relaunch {
+            pom_block_seed_h4_relaunch(&pre_pow_hash, header.timestamp, header.nonce)
+        } else if h3 {
             pom_block_seed_h3(&pre_pow_hash, header.timestamp, header.nonce)
         } else {
             pom_block_seed(&pre_pow_hash, header.timestamp, header.nonce)
         };
         let target = Uint256::from_compact_target_bits(header.bits).to_le_bytes();
-        let final_hash = |s: u64| if h3 { pom_pow_value_h3(s, &pre_pow_hash) } else { pom_pow_value(s, &pre_pow_hash) };
+        let final_hash = |s: u64| {
+            if h4_relaunch {
+                pom_pow_value_h4_relaunch(s, &pre_pow_hash)
+            } else if h3 {
+                pom_pow_value_h3(s, &pre_pow_hash)
+            } else {
+                pom_pow_value(s, &pre_pow_hash)
+            }
+        };
 
         // H4: recompute-from-chunks verifier (all K transitions re-walked, `final_state` derived).
         // Replaces the 32/256 spot-check, which accepted a forged `final_state` ~88% of the time.

--- a/consensus/src/pipeline/header_processor/pre_ghostdag_validation.rs
+++ b/consensus/src/pipeline/header_processor/pre_ghostdag_validation.rs
@@ -15,10 +15,6 @@ impl HeaderProcessor {
     /// Validates the header in isolation including pow check against header declared bits.
     /// Returns the block level as computed from pow state or a rule error if such was encountered
     pub(super) fn validate_header_in_isolation(&self, header: &Header) -> BlockProcessResult<BlockLevel> {
-        // Sync ceiling (env KERYX_SYNC_CEILING_DAA) is enforced inside the IBD header download
-        // (`sync_headers`), not here: rejecting at header-isolation level errors the relay flow and
-        // disconnects the very peer we need to sync from. Relay blocks above the ceiling are left to
-        // normal orphan handling, which triggers a (ceiling-capped) IBD.
         self.check_header_version(header)?;
         self.check_block_timestamp_in_isolation(header)?;
         self.check_parents_limit(header)?;
@@ -33,8 +29,9 @@ impl HeaderProcessor {
     }
 
     fn check_header_version(&self, header: &Header) -> BlockProcessResult<()> {
-        if header.version != constants::BLOCK_VERSION {
-            return Err(RuleError::WrongBlockVersion(header.version));
+        let expected = constants::block_version_for_h4_relaunch(header.daa_score, self.h4_relaunch_activation.daa_score());
+        if header.version != expected {
+            return Err(RuleError::WrongBlockVersion { actual: header.version, expected });
         }
         Ok(())
     }

--- a/consensus/src/pipeline/header_processor/processor.rs
+++ b/consensus/src/pipeline/header_processor/processor.rs
@@ -114,6 +114,8 @@ pub struct HeaderProcessor {
     /// the PoW value is re-checked against the target header-only and the block level is
     /// derived from it again (see `check_pow_and_calc_block_level`).
     pub(super) pom_level_activation: ForkActivation,
+    /// H4 relaunch requires a new header version at the same DAA boundary as the PoM v2 verifier.
+    pub(super) h4_relaunch_activation: ForkActivation,
     pub(super) max_block_level: BlockLevel,
 
     // DB
@@ -202,6 +204,7 @@ impl HeaderProcessor {
             skip_proof_of_work: params.skip_proof_of_work,
             pom_activation: params.pom_activation,
             pom_level_activation: params.pom_level_activation,
+            h4_relaunch_activation: params.coin_age_verification_activation,
             max_block_level: params.max_block_level,
         }
     }

--- a/consensus/src/pipeline/virtual_processor/processor.rs
+++ b/consensus/src/pipeline/virtual_processor/processor.rs
@@ -6,7 +6,7 @@ use crate::{
         },
         storage::ConsensusStorage,
     },
-    constants::BLOCK_VERSION,
+    constants::block_version_for_h4_relaunch,
     errors::RuleError,
     model::{
         services::{
@@ -22,6 +22,7 @@ use crate::{
             depth::{DbDepthStore, DepthStoreReader},
             ghostdag::{DbGhostdagStore, GhostdagData, GhostdagStoreReader},
             headers::{DbHeadersStore, HeaderStoreReader},
+            headers_selected_tip::DbHeadersSelectedTipStore,
             address_amount::DbAddressAmountStore,
             age_buckets::{AgeBuckets, DbAgeBucketsStore},
             maturation_queue::{DbMaturationQueueStore, MaturationEntry},
@@ -36,7 +37,7 @@ use crate::{
             relations::{DbRelationsStore, RelationsStoreReader},
             selected_chain::{DbSelectedChainStore, SelectedChainStore, SelectedChainStoreReader},
             statuses::{DbStatusesStore, StatusesStore, StatusesStoreBatchExtensions, StatusesStoreReader},
-            tips::{DbTipsStore, TipsStoreReader},
+            tips::{DbTipsStore, TipsStore, TipsStoreReader},
             utxo_diffs::{DbUtxoDiffsStore, UtxoDiffsStoreReader},
             utxo_multisets::{DbUtxoMultisetsStore, UtxoMultisetsStoreReader},
             virtual_state::{LkgVirtualState, VirtualState, VirtualStateStoreReader, VirtualStores},
@@ -59,7 +60,7 @@ use keryx_consensus_core::{
     acceptance_data::AcceptanceData,
     api::args::{TransactionValidationArgs, TransactionValidationBatchArgs},
     block::{BlockTemplate, MutableBlock, TemplateBuildMode, TemplateTransactionSelector},
-    blockstatus::BlockStatus::{StatusDisqualifiedFromChain, StatusUTXOValid},
+    blockstatus::BlockStatus::{StatusDisqualifiedFromChain, StatusInvalid, StatusUTXOValid},
     coinbase::MinerData,
     config::{genesis::GenesisBlock, params::ForkActivation},
     header::Header,
@@ -106,6 +107,15 @@ use std::{
     sync::{Arc, atomic::Ordering},
 };
 
+/// Outcome of a startup-only selected-chain rewind.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct StashBlocksResult {
+    pub target: Hash,
+    pub target_index: u64,
+    pub removed_selected_chain_blocks: u64,
+    pub invalidated_descendants: usize,
+}
+
 pub struct VirtualStateProcessor {
     // Channels
     receiver: CrossbeamReceiver<VirtualStateProcessingMessage>,
@@ -125,8 +135,10 @@ pub struct VirtualStateProcessor {
 
     // Stores
     pub(super) statuses_store: Arc<RwLock<DbStatusesStore>>,
+    pub(super) relations_store: Arc<RwLock<DbRelationsStore>>,
     pub(super) ghostdag_store: Arc<DbGhostdagStore>,
     pub(super) headers_store: Arc<DbHeadersStore>,
+    pub(super) headers_selected_tip_store: Arc<RwLock<DbHeadersSelectedTipStore>>,
     pub(super) daa_excluded_store: Arc<DbDaaStore>,
     pub(super) block_transactions_store: Arc<DbBlockTransactionsStore>,
     /// Proven PoM tier per block, read to scale the tier-reward coinbase split.
@@ -238,6 +250,9 @@ pub struct VirtualStateProcessor {
     // FIFO-inherited `effective_daa` anchors (see `UtxoDiff::add_transaction`) and the ratio
     // numerator switches to the per-coin-capped effective balance. Dormant (`never()`) until H4.
     pub(super) coin_age_activation: ForkActivation,
+    // H4 relaunch marker for block templates. This is deliberately the verification gate: it
+    // must remain in lockstep with the PoM v2 salt and header validation.
+    pub(super) h4_relaunch_activation: ForkActivation,
     // Coin-age maturity period (DAA score): the mature/immature bucket boundary (see `apply_age_diff`).
     pub(super) coin_age_maturity_w: u64,
     // Retention horizon (DAA score) for PROMOTED maturation-queue entries, enabling read-path
@@ -309,7 +324,9 @@ impl VirtualStateProcessor {
 
             db,
             statuses_store: storage.statuses_store.clone(),
+            relations_store: storage.relations_store.clone(),
             headers_store: storage.headers_store.clone(),
+            headers_selected_tip_store: storage.headers_selected_tip_store.clone(),
             ghostdag_store: storage.ghostdag_store.clone(),
             daa_excluded_store: storage.daa_excluded_store.clone(),
             block_transactions_store: storage.block_transactions_store.clone(),
@@ -372,6 +389,7 @@ impl VirtualStateProcessor {
             ratio_reward_window: params.ratio_reward_window,
             ratio_reward_window_daa: params.ratio_reward_window_daa,
             coin_age_activation: params.coin_age_activation,
+            h4_relaunch_activation: params.coin_age_verification_activation,
             coin_age_maturity_w: params.coin_age_maturity_w,
             coin_age_retention: params.finality_depth(),
             is_archival,
@@ -385,6 +403,284 @@ impl VirtualStateProcessor {
     /// construction, so the fast-sync catch-up relaxation auto-expires once the window refills.
     pub(super) fn trust_coinbase(&self) -> bool {
         self.is_archival || self.trust_coinbase_env || self.in_production_catchup_window()
+    }
+
+    /// Atomically rewinds the selected chain by `blocks` and quarantines every DAG descendant of
+    /// the new tip. This is deliberately startup-only: callers must invoke it before processor
+    /// workers or P2P begin using the consensus stores.
+    ///
+    /// Retaining the discarded records lets RocksDB avoid a huge destructive rewrite, while
+    /// `StatusInvalid` prevents an old side branch from ever becoming a parent or a virtual tip.
+    pub(crate) fn stash_selected_chain_blocks(&self, blocks: u64) -> Result<StashBlocksResult, String> {
+        self.stash_selected_chain_blocks_with_quarantine(blocks, BlockHashSet::default())
+    }
+
+    fn stash_selected_chain_blocks_with_quarantine(
+        &self,
+        blocks: u64,
+        additional_invalidated: BlockHashSet,
+    ) -> Result<StashBlocksResult, String> {
+        if blocks == 0 {
+            return Err("--stash-blocks must be greater than zero".to_string());
+        }
+
+        let (tip_index, selected_tip) = self
+            .selected_chain_store
+            .read()
+            .get_tip()
+            .map_err(|err| format!("cannot read selected-chain tip for stash: {err}"))?;
+        if blocks > tip_index {
+            return Err(format!(
+                "cannot stash {blocks} selected-chain blocks from index {tip_index}; refusing to cross the available chain boundary"
+            ));
+        }
+
+        let target_index = tip_index - blocks;
+        let retained_floor = self
+            .pruning_point_store
+            .read()
+            .pruning_point()
+            .map_err(|err| format!("cannot read pruning point for stash: {err}"))?;
+        let retained_floor_index = self
+            .selected_chain_store
+            .read()
+            .get_by_hash(retained_floor)
+            .map_err(|err| format!("cannot locate pruning point {retained_floor} on the selected chain for stash: {err}"))?;
+        if target_index < retained_floor_index {
+            return Err(format!(
+                "cannot stash to selected-chain index {target_index}: it is below retained pruning point {retained_floor} at index {retained_floor_index}; reset and resync is required"
+            ));
+        }
+        let (target, removed) = {
+            let selected_chain = self.selected_chain_store.read();
+            let target = selected_chain
+                .get_by_index(target_index)
+                .map_err(|err| format!("cannot read selected-chain rollback target at index {target_index}: {err}"))?;
+            let removed = ((target_index + 1)..=tip_index)
+                .map(|index| {
+                    selected_chain
+                        .get_by_index(index)
+                        .map_err(|err| format!("cannot read selected-chain block at index {index}: {err}"))
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+            (target, removed)
+        };
+
+        let mut invalidated = self.collect_descendants(target)?;
+        invalidated.extend(additional_invalidated);
+        let virtual_read = self.virtual_stores.upgradable_read();
+        let previous_state = virtual_read
+            .state
+            .get()
+            .map_err(|err| format!("cannot read virtual state for stash: {err}"))?;
+        let previous_sink = previous_state.ghostdag_data.selected_parent;
+        if previous_sink != selected_tip {
+            return Err(format!(
+                "selected-chain tip {selected_tip} differs from virtual selected parent {previous_sink}; refusing unsafe stash"
+            ));
+        }
+        if !self.reachability_service.is_chain_ancestor_of(target, previous_sink) {
+            return Err(format!("rollback target {target} is not an ancestor of virtual selected parent {previous_sink}"));
+        }
+
+        // Reconstruct the target's UTXO state relative to the current virtual UTXO set, then
+        // construct the next virtual state with the target as its only parent. Do this directly
+        // over the selected-chain suffix rather than through the normal reorg helper: recovery
+        // must never repair a missing diff by writing intermediate state before its one atomic
+        // rollback batch is ready.
+        let mut accumulated_diff = previous_state.utxo_diff.clone().to_reversed();
+        for current in removed.iter().rev().copied() {
+            let mergeset_diff = self
+                .utxo_diffs_store
+                .get(current)
+                .map_err(|err| format!("cannot read UTXO diff for discarded selected-chain block {current}: {err}"))?;
+            accumulated_diff
+                .with_diff_in_place(&mergeset_diff.as_reversed())
+                .map_err(|err| format!("cannot reverse UTXO diff for discarded selected-chain block {current}: {err}"))?;
+        }
+        let target_multiset = self
+            .utxo_multisets_store
+            .get(target)
+            .map_err(|err| format!("cannot read UTXO multiset for rollback target {target}: {err}"))?;
+        let virtual_parents = vec![target];
+        let virtual_ghostdag_data = self.ghostdag_manager.ghostdag(&virtual_parents);
+        let new_virtual_state = self
+            .calculate_virtual_state(
+                &virtual_read,
+                virtual_parents,
+                virtual_ghostdag_data,
+                target_multiset,
+                &mut accumulated_diff,
+            )
+            .map_err(|err| format!("cannot calculate virtual state for rollback target {target}: {err}"))?;
+
+        let mut batch = WriteBatch::default();
+        let mut virtual_write = RwLockUpgradableReadGuard::upgrade(virtual_read);
+        let mut selected_chain_write = self.selected_chain_store.write();
+
+        virtual_write
+            .utxo_set
+            .write_diff_batch(&mut batch, &accumulated_diff)
+            .map_err(|err| format!("cannot stage virtual UTXO rollback: {err}"))?;
+        virtual_write
+            .state
+            .set_batch(&mut batch, new_virtual_state)
+            .map_err(|err| format!("cannot stage virtual-state rollback: {err}"))?;
+        selected_chain_write
+            .apply_changes(&mut batch, &ChainPath { added: vec![], removed })
+            .map_err(|err| format!("cannot stage selected-chain rollback: {err}"))?;
+
+        {
+            let mut body_tips = self.body_tips_store.write();
+            body_tips.delete_all_tips(&mut batch).map_err(|err| format!("cannot clear body tips for stash: {err}"))?;
+            body_tips.init_batch(&mut batch, &[target]).map_err(|err| format!("cannot set rollback body tip: {err}"))?;
+        }
+        let target_blue_work = self
+            .ghostdag_store
+            .get_blue_work(target)
+            .map_err(|err| format!("cannot read blue work for rollback target {target}: {err}"))?;
+        self.headers_selected_tip_store
+            .write()
+            .set_batch(&mut batch, SortableBlock::new(target, target_blue_work))
+            .map_err(|err| format!("cannot stage headers selected-tip rollback: {err}"))?;
+
+        {
+            let mut statuses = self.statuses_store.write();
+            for hash in invalidated.iter().copied() {
+                statuses
+                    .set_batch(&mut batch, hash, StatusInvalid)
+                    .map_err(|err| format!("cannot quarantine discarded block {hash}: {err}"))?;
+            }
+        }
+
+        // These aggregates are derived solely from the virtual UTXO set and selected chain. Clear
+        // them in the same batch so the normal startup rebuild cannot observe stale H4-era values.
+        self.address_balance_store.clear(&mut batch).map_err(|err| format!("cannot clear balance index for stash: {err}"))?;
+        self.age_buckets_store.clear(&mut batch).map_err(|err| format!("cannot clear age buckets for stash: {err}"))?;
+        self.maturation_queue_store.clear(&mut batch).map_err(|err| format!("cannot clear maturation queue for stash: {err}"))?;
+        self.windowed_production_prefix_store.clear(&mut batch);
+        self.production_index_seed_store
+            .write()
+            .clear_batch(&mut batch)
+            .map_err(|err| format!("cannot clear production-index seed for stash: {err}"))?;
+
+        self.db.write(batch).map_err(|err| format!("cannot commit atomic stash: {err}"))?;
+        drop(selected_chain_write);
+        drop(virtual_write);
+        self.block_production_cache.write().clear();
+
+        Ok(StashBlocksResult {
+            target,
+            target_index,
+            removed_selected_chain_blocks: blocks,
+            invalidated_descendants: invalidated.len(),
+        })
+    }
+
+    /// Finds the last selected-chain block strictly before `daa_score` and stashes everything
+    /// above it. This is used by the H4 recovery command so operators never need to guess a chain
+    /// index from a DAA score in a DAG.
+    pub(crate) fn stash_selected_chain_to_before_daa(&self, daa_score: u64) -> Result<StashBlocksResult, String> {
+        let (tip_index, _) = self
+            .selected_chain_store
+            .read()
+            .get_tip()
+            .map_err(|err| format!("cannot read selected-chain tip for DAA rollback: {err}"))?;
+        let selected_chain = self.selected_chain_store.read();
+        let retained_floor = self
+            .pruning_point_store
+            .read()
+            .pruning_point()
+            .map_err(|err| format!("cannot read pruning point for DAA rollback: {err}"))?;
+        let retained_floor_index = selected_chain
+            .get_by_hash(retained_floor)
+            .map_err(|err| format!("cannot locate pruning point {retained_floor} on selected chain for DAA rollback: {err}"))?;
+        let mut target_index = None;
+        for index in (retained_floor_index..=tip_index).rev() {
+            let hash = selected_chain
+                .get_by_index(index)
+                .map_err(|err| format!("cannot read selected-chain block at index {index}: {err}"))?;
+            let block_daa = self
+                .headers_store
+                .get_daa_score(hash)
+                .map_err(|err| format!("cannot read DAA score for selected-chain block {hash}: {err}"))?;
+            if block_daa < daa_score {
+                target_index = Some(index);
+                break;
+            }
+        }
+        drop(selected_chain);
+
+        let target_index = target_index.ok_or_else(|| {
+            format!("cannot roll back to DAA {daa_score}: the retained selected chain has no earlier block; reset and resync is required")
+        })?;
+        if target_index == tip_index {
+            return Err(format!("selected chain has not reached DAA {daa_score}; no blocks were stashed"));
+        }
+        // Body tips include every active body branch. Walk them backwards through the H4 region so
+        // an old branch that forked before `target` cannot remain a valid parent after the forced
+        // relaunch. Header-only remnants are harmless: their body is still checked against the new
+        // H4 PoM fold before they can enter the body DAG.
+        let legacy_h4_blocks = self.collect_active_blocks_at_or_after_daa(daa_score)?;
+        self.stash_selected_chain_blocks_with_quarantine(tip_index - target_index, legacy_h4_blocks)
+    }
+
+    fn collect_active_blocks_at_or_after_daa(&self, daa_score: u64) -> Result<BlockHashSet, String> {
+        let tips = {
+            let body_tips = self.body_tips_store.read();
+            let tips = body_tips.get().map_err(|err| format!("cannot read body tips for H4 rollback: {err}"))?;
+            tips.read().iter().copied().collect_vec()
+        };
+
+        let mut visited = BlockHashSet::default();
+        let mut matched = BlockHashSet::default();
+        let mut queue = VecDeque::from_iter(tips);
+        while let Some(current) = queue.pop_front() {
+            if !visited.insert(current) {
+                continue;
+            }
+
+            let current_daa = self
+                .headers_store
+                .get_daa_score(current)
+                .map_err(|err| format!("cannot read DAA score for active block {current} during H4 rollback: {err}"))?;
+            if current_daa < daa_score {
+                continue;
+            }
+            matched.insert(current);
+
+            let parents = {
+                let relations = self.relations_store.read();
+                relations
+                    .get_parents(current)
+                    .map_err(|err| format!("cannot traverse active H4 branch at {current}: {err}"))?
+            };
+            queue.extend(parents.iter().copied());
+        }
+        Ok(matched)
+    }
+
+    fn collect_descendants(&self, root: Hash) -> Result<BlockHashSet, String> {
+        let mut descendants = BlockHashSet::default();
+        let mut queue = VecDeque::from([root]);
+        while let Some(current) = queue.pop_front() {
+            let children = {
+                let relations = self.relations_store.read();
+                relations
+                    .get_children(current)
+                    .map_err(|err| format!("cannot traverse descendants of {current} for stash: {err}"))?
+                    .read()
+                    .iter()
+                    .copied()
+                    .collect_vec()
+            };
+            for child in children {
+                if descendants.insert(child) {
+                    queue.push_back(child);
+                }
+            }
+        }
+        Ok(descendants)
     }
 
     /// True while we're still inside our own post-import catch-up window: fewer than
@@ -1411,7 +1707,10 @@ impl VirtualStateProcessor {
             )
             .unwrap();
         txs.insert(0, coinbase.tx);
-        let version = BLOCK_VERSION;
+        let version = block_version_for_h4_relaunch(
+            virtual_state.daa_score,
+            self.h4_relaunch_activation.daa_score(),
+        );
         let parents_by_level = self.parents_manager.calc_block_parents(pruning_point, &virtual_state.parents);
         let hash_merkle_root = calc_hash_merkle_root(txs.iter());
 

--- a/consensus/src/pipeline/virtual_processor/tests.rs
+++ b/consensus/src/pipeline/virtual_processor/tests.rs
@@ -2,7 +2,7 @@ use crate::{
     consensus::test_consensus::TestConsensus,
     model::{
         services::reachability::ReachabilityService,
-        stores::ai_slash::AiResponseStoreReader,
+        stores::{ai_slash::AiResponseStoreReader, headers::HeaderStoreReader, selected_chain::SelectedChainStoreReader},
     },
 };
 use keryx_inference::{self, AiResponsePayload, compute_ai_commitment};
@@ -176,6 +176,83 @@ async fn template_mining_sanity_test() {
             .assert_virtual_parents_subset()
             .assert_valid_utxo_tip();
     }
+}
+
+#[tokio::test]
+async fn stash_blocks_rewinds_selected_chain_and_quarantines_discarded_descendants() {
+    let config = ConfigBuilder::new(MAINNET_PARAMS).skip_proof_of_work().build();
+    let mut ctx = TestContext::new(TestConsensus::new(&config));
+
+    for _ in 0..5 {
+        ctx.build_block_template_row(0..1).validate_and_insert_row().await;
+    }
+    let target = ctx.consensus.get_sink();
+    let target_index = ctx.consensus.virtual_processor().selected_chain_store.read().get_tip().unwrap().0;
+
+    for _ in 0..3 {
+        ctx.build_block_template_row(0..1).validate_and_insert_row().await;
+    }
+    let vp = ctx.consensus.virtual_processor().clone();
+    let (tip_index, _) = vp.selected_chain_store.read().get_tip().unwrap();
+    let discarded = {
+        let selected_chain = vp.selected_chain_store.read();
+        ((target_index + 1)..=tip_index).map(|index| selected_chain.get_by_index(index).unwrap()).collect::<Vec<_>>()
+    };
+
+    ctx.consensus.shutdown(std::mem::take(&mut ctx.join_handles));
+    let outcome = vp.stash_selected_chain_blocks(3).unwrap();
+
+    assert_eq!(outcome.target, target);
+    assert_eq!(outcome.target_index, target_index);
+    assert_eq!(outcome.removed_selected_chain_blocks, 3);
+    assert_eq!(ctx.consensus.get_sink(), target);
+    assert_eq!(ctx.consensus.body_tips(), BlockHashSet::from_iter([target]));
+    for hash in discarded {
+        assert_eq!(ctx.consensus.block_status(hash), BlockStatus::StatusInvalid);
+    }
+    assert!(vp.stash_selected_chain_blocks(0).is_err());
+}
+
+#[tokio::test]
+async fn h4_stash_quarantines_active_side_branch_that_forks_before_target() {
+    let config = ConfigBuilder::new(MAINNET_PARAMS).skip_proof_of_work().build();
+    let mut ctx = TestContext::new(TestConsensus::new(&config));
+
+    for _ in 0..2 {
+        ctx.build_block_template_row(0..1).validate_and_insert_row().await;
+    }
+    let vp = ctx.consensus.virtual_processor().clone();
+    let (target_index, target) = vp.selected_chain_store.read().get_tip().unwrap();
+
+    for _ in 0..3 {
+        ctx.build_block_template_row(0..1).validate_and_insert_row().await;
+    }
+    let selected_tip = ctx.consensus.get_sink();
+    let h4_boundary = {
+        let selected_chain = vp.selected_chain_store.read();
+        let first_h4_block = selected_chain.get_by_index(target_index + 1).unwrap();
+        vp.headers_store.get_daa_score(first_h4_block).unwrap()
+    };
+
+    // Build a separate body branch from genesis. It has active H4 blocks but is not a descendant
+    // of `target`, so a selected-chain-only rewind would otherwise leave it usable as a parent.
+    let mut side_parents = vec![ctx.consensus.params().genesis.hash];
+    for _ in 0..6 {
+        ctx.simulated_time += ctx.consensus.params().target_time_per_block();
+        let block = ctx.build_block_with_parents(side_parents, 0, ctx.simulated_time);
+        side_parents = vec![block.header.hash];
+        ctx.validate_and_insert_block(block.to_immutable()).await;
+    }
+    let side_tip = side_parents[0];
+    assert_eq!(ctx.consensus.get_sink(), selected_tip);
+    assert!(vp.headers_store.get_daa_score(side_tip).unwrap() >= h4_boundary);
+
+    ctx.consensus.shutdown(std::mem::take(&mut ctx.join_handles));
+    let outcome = vp.stash_selected_chain_to_before_daa(h4_boundary).unwrap();
+
+    assert_eq!(outcome.target, target);
+    assert_eq!(ctx.consensus.get_sink(), target);
+    assert_eq!(ctx.consensus.block_status(side_tip), BlockStatus::StatusInvalid);
 }
 
 #[tokio::test]

--- a/consensus/src/processes/pruning_proof/apply.rs
+++ b/consensus/src/processes/pruning_proof/apply.rs
@@ -45,6 +45,13 @@ impl PruningProofManager {
     pub fn apply_proof(&self, proof: PruningPointProof, trusted_set: &[TrustedBlock]) -> PruningImportResult<()> {
         // Following validation of a pruning proof, various consensus storages must be updated
 
+        for header in proof.iter().flatten() {
+            self.validate_h4_header_version(header)?;
+        }
+        for trusted in trusted_set {
+            self.validate_h4_header_version(&trusted.block.header)?;
+        }
+
         let pruning_point_header = proof[0].last().unwrap().clone();
         let pruning_point = pruning_point_header.hash;
 

--- a/consensus/src/processes/pruning_proof/mod.rs
+++ b/consensus/src/processes/pruning_proof/mod.rs
@@ -18,7 +18,9 @@ use keryx_consensus_core::{
     BlockHashMap, BlockHashSet, BlockLevel, HashMapCustomHasher, KType,
     blockhash::{self, BlockHashExtensions},
     config::params::ForkActivation,
+    constants::block_version_for_h4_relaunch,
     errors::{
+        block::RuleError,
         consensus::{ConsensusError, ConsensusResult},
         pruning::{PruningImportError, PruningImportResult},
     },
@@ -122,8 +124,10 @@ pub struct PruningProofManager {
     // per-level PoW check must skip them — mirror `pre_ghostdag_validation::check_pow_and_calc_block_level`.
     pom_activation: ForkActivation,
     // H3: from this score headers commit to `pom_final_state` and the PoW value / block level
-    // are header-only derivable again — see `pom_aware_block_level`.
+    // are header-only derivable again - see `pom_aware_block_level`.
     pom_level_activation: ForkActivation,
+    // H4 relaunch changes both the PoM fold and the required header version.
+    h4_relaunch_activation: ForkActivation,
 
     is_consensus_exiting: Arc<AtomicBool>,
 }
@@ -146,6 +150,7 @@ impl PruningProofManager {
         skip_proof_of_work: bool,
         pom_activation: ForkActivation,
         pom_level_activation: ForkActivation,
+        h4_relaunch_activation: ForkActivation,
         is_consensus_exiting: Arc<AtomicBool>,
     ) -> Self {
         Self {
@@ -182,9 +187,18 @@ impl PruningProofManager {
             skip_proof_of_work,
             pom_activation,
             pom_level_activation,
+            h4_relaunch_activation,
 
             is_consensus_exiting,
         }
+    }
+
+    fn validate_h4_header_version(&self, header: &Header) -> PruningImportResult<()> {
+        let expected = block_version_for_h4_relaunch(header.daa_score, self.h4_relaunch_activation.daa_score());
+        if header.version != expected {
+            return Err(RuleError::WrongBlockVersion { actual: header.version, expected }.into());
+        }
+        Ok(())
     }
 
     pub fn import_pruning_points(&self, pruning_points: &[Arc<Header>]) -> PruningImportResult<()> {
@@ -193,6 +207,7 @@ impl PruningProofManager {
             return Err(PruningImportError::DuplicatedPastPruningPoints(pruning_points.len() - unique_count));
         }
         for (i, header) in pruning_points.iter().enumerate() {
+            self.validate_h4_header_version(header)?;
             self.past_pruning_points_store.set(i as u64, header.hash).unwrap();
 
             if i > 0 {

--- a/consensus/src/processes/pruning_proof/validate.rs
+++ b/consensus/src/processes/pruning_proof/validate.rs
@@ -165,6 +165,7 @@ impl ProofContext {
         }
 
         let proof_pp_header = proof[0].last().expect("checked if empty").clone();
+        ppm.validate_h4_header_version(&proof_pp_header)?;
         // Must mirror the builder's `pp_header.block_level` (headers_store, PoM-aware): the
         // level anchoring checks below compare against the level the builder actually used.
         let proof_pp_level =
@@ -189,6 +190,7 @@ impl ProofContext {
             let mut selected_tip =
                 proof[level as usize].first().map(|header| header.hash).ok_or(PruningImportError::PruningProofNotEnoughHeaders)?;
             for (i, header) in proof[level as usize].iter().enumerate() {
+                ppm.validate_h4_header_version(header)?;
                 // `header_level` keeps the PoW-derived level so it stays consistent with the
                 // builder's per-level placement (`pom_aware_block_level`), across the three eras:
                 // - H3 (`pom_level_activation`): the header commits to the walk's final state, so

--- a/keryxd/src/args.rs
+++ b/keryxd/src/args.rs
@@ -54,6 +54,8 @@ pub struct Args {
     pub user_agent_comments: Vec<String>,
     pub utxoindex: bool,
     pub reset_db: bool,
+    pub stash_blocks: Option<u64>,
+    pub rollback_h4: bool,
     #[serde(rename = "outpeers")]
     pub outbound_target: usize,
     #[serde(rename = "maxinpeers")]
@@ -110,6 +112,8 @@ impl Default for Args {
             async_threads: num_cpus::get(),
             utxoindex: false,
             reset_db: false,
+            stash_blocks: None,
+            rollback_h4: false,
             outbound_target: 8,
             inbound_limit: 128,
             rpc_max_clients: 128,
@@ -201,6 +205,22 @@ impl Args {
             (false, false, true) => NetworkId::new(NetworkType::Simnet),
             _ => panic!("only a single net should be activated"),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Args;
+
+    #[test]
+    fn parses_stash_blocks_with_underscore_alias() {
+        let args = Args::parse(["keryxd", "--stash_blocks", "7"]).unwrap();
+        assert_eq!(args.stash_blocks, Some(7));
+    }
+
+    #[test]
+    fn rejects_zero_stash_blocks() {
+        assert!(Args::parse(["keryxd", "--stash-blocks", "0"]).is_err());
     }
 }
 
@@ -330,6 +350,26 @@ pub fn cli() -> Command {
                 .help("Max number of RPC clients for standard connections (default: 128)."),
         )
         .arg(arg!(--"reset-db" "Reset database before starting node. It's needed when switching between subnetworks.").env("KERYXD_RESET_DB"))
+        .arg(
+            Arg::new("stash-blocks")
+                .long("stash-blocks")
+                .visible_alias("stash_blocks")
+                .env("KERYXD_STASH_BLOCKS")
+                .value_name("N")
+                .value_parser(clap::value_parser!(u64).range(1..))
+                .conflicts_with("reset-db")
+                .conflicts_with("rollback-h4")
+                .help("Atomically rewind N selected-chain blocks and quarantine their descendants before the node starts."),
+        )
+        .arg(
+            Arg::new("rollback-h4")
+                .long("rollback-h4")
+                .env("KERYXD_ROLLBACK_H4")
+                .action(ArgAction::SetTrue)
+                .conflicts_with("reset-db")
+                .conflicts_with("stash-blocks")
+                .help("Atomically rewind to the last selected-chain block before the configured H4 DAA boundary."),
+        )
         .arg(arg!(--"enable-unsynced-mining" "Allow the node to accept blocks from RPC while not synced (this flag is mainly used for testing)").env("KERYXD_ENABLE_UNSYNCED_MINING"))
         .arg(
             Arg::new("enable-mainnet-mining")
@@ -504,6 +544,8 @@ impl Args {
             rpc_max_clients: arg_match_unwrap_or::<usize>(&m, "rpcmaxclients", defaults.rpc_max_clients),
             max_tracked_addresses: arg_match_unwrap_or::<usize>(&m, "max-tracked-addresses", defaults.max_tracked_addresses),
             reset_db: arg_match_unwrap_or::<bool>(&m, "reset-db", defaults.reset_db),
+            stash_blocks: m.get_one::<u64>("stash-blocks").copied().or(defaults.stash_blocks),
+            rollback_h4: arg_match_unwrap_or::<bool>(&m, "rollback-h4", defaults.rollback_h4),
             enable_unsynced_mining: arg_match_unwrap_or::<bool>(&m, "enable-unsynced-mining", defaults.enable_unsynced_mining),
             enable_mainnet_mining: arg_match_unwrap_or::<bool>(&m, "enable-mainnet-mining", defaults.enable_mainnet_mining),
             utxoindex: arg_match_unwrap_or::<bool>(&m, "utxoindex", defaults.utxoindex),

--- a/keryxd/src/daemon.rs
+++ b/keryxd/src/daemon.rs
@@ -27,7 +27,8 @@ use keryx_utils_tower::counters::TowerConnectionCounters;
 
 use keryx_addressmanager::AddressManager;
 use keryx_consensus::{
-    consensus::factory::MultiConsensusManagementStore, model::stores::headers::DbHeadersStore, pipeline::monitor::ConsensusMonitor,
+    consensus::{StartupRecovery, factory::MultiConsensusManagementStore}, model::stores::headers::DbHeadersStore,
+    pipeline::monitor::ConsensusMonitor,
 };
 use keryx_consensus::{
     consensus::factory::{Factory as ConsensusFactory, LATEST_DB_VERSION},
@@ -112,6 +113,13 @@ pub fn validate_args(args: &Args) -> ConfigResult<()> {
     }
     if args.max_tracked_addresses > Tracker::MAX_ADDRESS_UPPER_BOUND {
         return Err(ConfigError::MaxTrackedAddressesTooHigh(Tracker::MAX_ADDRESS_UPPER_BOUND));
+    }
+    if args.stash_blocks == Some(0) {
+        return Err(ConfigError::StashBlocksZero);
+    }
+    let recovery_options = args.stash_blocks.is_some() as u8 + args.rollback_h4 as u8 + args.reset_db as u8;
+    if recovery_options > 1 {
+        return Err(ConfigError::ConflictingRecoveryOptions);
     }
     Ok(())
 }
@@ -540,6 +548,30 @@ Do you confirm? (y/n)";
         );
     }
 
+    let startup_recovery = match (args.stash_blocks, args.rollback_h4) {
+        (Some(blocks), false) => {
+            get_user_approval_or_exit(
+                &format!(
+                    "--stash-blocks={blocks} will atomically rewind the selected chain, quarantine every discarded DAG descendant, and rebuild derived indexes. Do you confirm? (y/n)"
+                ),
+                args.yes,
+            );
+            Some(StartupRecovery::StashBlocks(blocks))
+        }
+        (None, true) => {
+            let h4_daa = config.params.coin_age_verification_activation.daa_score();
+            get_user_approval_or_exit(
+                &format!(
+                    "--rollback-h4 will atomically rewind to the last selected-chain block before H4 DAA {h4_daa}, quarantine every discarded DAG descendant, and rebuild derived indexes. Do you confirm? (y/n)"
+                ),
+                args.yes,
+            );
+            Some(StartupRecovery::RollbackH4)
+        }
+        (None, false) => None,
+        (Some(_), true) => unreachable!("argument validation rejects conflicting recovery flags"),
+    };
+
     let connect_peers = args.connect_peers.iter().map(|x| x.normalize(config.default_p2p_port())).collect::<Vec<_>>();
     let add_peers = args.add_peers.iter().map(|x| x.normalize(config.default_p2p_port())).collect();
     let p2p_server_addr = args.listen.unwrap_or(ContextualNetAddress::unspecified()).normalize(config.default_p2p_port());
@@ -589,6 +621,7 @@ Do you confirm? (y/n)";
         rocksdb_preset,
         wal_dir.clone(),
         cache_budget,
+        startup_recovery,
     ));
     let consensus_manager = Arc::new(ConsensusManager::new(consensus_factory));
     let consensus_monitor = Arc::new(ConsensusMonitor::new(processing_counters.clone(), tick_service.clone()));

--- a/protocol/flows/src/ibd/flow.rs
+++ b/protocol/flows/src/ibd/flow.rs
@@ -126,9 +126,8 @@ impl IbdFlow {
                 negotiation_output.syncer_pruning_point,
             )
             .await?;
-        // Body-sync target: normally the syncer's sink, but the highest header below the sync ceiling
-        // when one is set (the Sync path updates it from `sync_headers`).
-        let mut body_target = negotiation_output.syncer_virtual_selected_parent;
+        // Bodies are synchronized to the syncer's selected tip after all headers pass validation.
+        let body_target = negotiation_output.syncer_virtual_selected_parent;
         match ibd_type {
             IbdType::Sync { highest_known_syncer_chain_hash, is_utxo_stable, is_pp_anticone_synced } => {
                 let pruning_point = session.async_pruning_point().await;
@@ -156,14 +155,13 @@ impl IbdFlow {
                     self.sync_new_utxo_set(&session, pruning_point).await?;
                 }
                 // Once utxo is valid, simply sync missing headers
-                body_target = self
-                    .sync_headers(
-                        &session,
-                        negotiation_output.syncer_virtual_selected_parent,
-                        highest_known_syncer_chain_hash,
-                        &relay_block,
-                    )
-                    .await?;
+                self.sync_headers(
+                    &session,
+                    negotiation_output.syncer_virtual_selected_parent,
+                    highest_known_syncer_chain_hash,
+                    &relay_block,
+                )
+                .await?;
             }
             IbdType::DownloadHeadersProof => {
                 drop(session); // Avoid holding the previous consensus throughout the staging IBD
@@ -208,14 +206,12 @@ impl IbdFlow {
             }
         }
 
-        // Sync missing bodies in the past of the (possibly ceiling-capped) sync target
+        // Sync missing bodies in the past of the sync target.
         self.sync_missing_block_bodies(&session, body_target).await?;
 
-        // Relay block might be in the antipast of syncer sink, thus check its past for missing bodies
-        // as well — but skip it under a sync ceiling (the relay block is the corrupted tip above it).
-        if self.sync_ceiling().is_none() {
-            self.sync_missing_block_bodies(&session, relay_block.hash()).await?;
-        }
+        // Relay block might be in the antipast of syncer sink, thus check its past for missing
+        // bodies as well.
+        self.sync_missing_block_bodies(&session, relay_block.hash()).await?;
 
         // Following IBD we revalidate orphans since many of them might have been processed during the IBD
         // or are now processable
@@ -307,22 +303,9 @@ impl IbdFlow {
             return Err(ProtocolError::Other("peer is in a finality conflict with the local pruning point"));
         }
 
-        // Option B (KERYX_TRUST_SYNC_FROM_TIP): no shared chain block was found because our tip is
-        // below the trusted peer's pruning point. The standard fallback below is headers-proof IBD,
-        // which is broken across the PoM/diff-reset hardfork. Instead, trust the `--connect`'d
-        // archival peer and catch up forward from our own sink (it serves the blocks below its
-        // pruning point). See `trust_sync_from_tip` — gated by env, unsafe for public P2P.
-        if self.trust_sync_from_tip() {
-            let local_sink = consensus.async_get_sink().await;
-            let is_utxo_stable = consensus.async_is_pruning_utxoset_stable().await;
-            let is_pp_anticone_synced = consensus.async_is_pruning_point_anticone_fully_synced().await;
-            warn!(
-                "KERYX_TRUST_SYNC_FROM_TIP: no shared chain block with {} (our tip is below its pruning point) — trusting peer, catching up forward from local sink {}",
-                self.router, local_sink
-            );
-            return Ok(IbdType::Sync { highest_known_syncer_chain_hash: local_sink, is_utxo_stable, is_pp_anticone_synced });
-        }
-
+        // No shared chain block means the peer has pruned past our local history. Fall back to
+        // proof-based IBD: post-H3 headers commit to `pom_final_state`, so pruning-proof import
+        // performs the same header-only PoM target check as normal header processing.
         let hst_header = consensus.async_get_header(consensus.async_get_headers_selected_tip().await).await.unwrap();
         let pruning_depth = self.ctx.config.pruning_depth();
         if relay_header.blue_score >= hst_header.blue_score + pruning_depth && relay_header.blue_work > hst_header.blue_work {
@@ -558,38 +541,14 @@ impl IbdFlow {
         Ok(proof_pruning_point)
     }
 
-    /// Optional relaunch sync ceiling (env `KERYX_SYNC_CEILING_DAA`): when set, IBD ingests only
-    /// headers/blocks with `daa_score < ceiling` and stops there, so a pre-fork datadir can be synced
-    /// up to the last clean block without pulling the corrupted fork-era blocks. Unset = normal IBD.
-    fn sync_ceiling(&self) -> Option<u64> {
-        static SYNC_CEILING: std::sync::OnceLock<Option<u64>> = std::sync::OnceLock::new();
-        *SYNC_CEILING.get_or_init(|| std::env::var("KERYX_SYNC_CEILING_DAA").ok().and_then(|s| s.parse().ok()))
-    }
-
-    /// Option B (env `KERYX_TRUST_SYNC_FROM_TIP=1`): when syncing from a trusted, `--connect`'d
-    /// archival source whose pruning point is ABOVE our tip, the standard negotiation finds no
-    /// shared chain block (it only searches the peer's chain down to its pruning point) and falls
-    /// back to headers-proof IBD — which is broken across the PoM/difficulty-reset hardfork
-    /// (post-PoM blocks have no kHeavyHash PoW, and the reset collapses post-reset blue work). With
-    /// this set we instead trust the peer and catch up forward from our own sink (the archival has
-    /// the blocks below its pruning point and serves them). UNSAFE for public P2P — it skips
-    /// proof-based chain selection — use only against a known-good `--connect` peer.
-    fn trust_sync_from_tip(&self) -> bool {
-        static TRUST_SYNC: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-        *TRUST_SYNC.get_or_init(|| matches!(std::env::var("KERYX_TRUST_SYNC_FROM_TIP").as_deref(), Ok("1")))
-    }
-
-    /// Downloads and validates headers from the shared point up to the syncer's sink. Returns the
-    /// effective body-sync target — normally the syncer's virtual selected parent, but the highest
-    /// header below the sync ceiling when one is set (see [`sync_ceiling`]).
+    /// Downloads and validates headers from the shared point up to the syncer's sink.
     async fn sync_headers(
         &mut self,
         consensus: &ConsensusProxy,
         syncer_virtual_selected_parent: Hash,
         highest_known_syncer_chain_hash: Hash,
         relay_block: &Block,
-    ) -> Result<Hash, ProtocolError> {
-        let ceiling = self.sync_ceiling();
+    ) -> Result<(), ProtocolError> {
         let highest_shared_header_score = consensus.async_get_header(highest_known_syncer_chain_hash).await?.daa_score;
         let mut progress_reporter = ProgressReporter::new(highest_shared_header_score, relay_block.header.daa_score, "block headers");
 
@@ -604,11 +563,7 @@ impl IbdFlow {
             .await?;
         let mut chunk_stream = HeadersChunkStream::new(&self.router, &mut self.incoming_route, self.header_format);
 
-        // Pipelined: while the previous chunk is validating we receive the next one. When a ceiling is
-        // set, headers at/above it are dropped (not inserted), but the stream is still drained to its
-        // `DoneHeaders` terminator — the syncer doesn't know our ceiling and keeps streaming headers up
-        // to its own tip, and those messages must be consumed or the following body sync desyncs.
-        let mut ceiling_hit = false;
+        // Pipelined: while the previous chunk is validating we receive the next one.
         let mut prev: Option<(Vec<BlockValidationFuture>, u64, u64)> = None;
         loop {
             let chunk = match chunk_stream.next().await? {
@@ -619,38 +574,19 @@ impl IbdFlow {
                 let last_header = chunk.last().expect("chunk is never empty");
                 (last_header.daa_score, last_header.timestamp)
             };
-            let current_jobs: Vec<BlockValidationFuture> = chunk
-                .into_iter()
-                .filter(|h| match ceiling {
-                    Some(c) if h.daa_score >= c => {
-                        ceiling_hit = true;
-                        false
-                    }
-                    _ => true,
-                })
-                .map(|h| consensus.validate_and_insert_block(Block::from_header_arc(h)).virtual_state_task)
-                .collect();
+            let current_jobs: Vec<BlockValidationFuture> =
+                chunk.into_iter().map(|h| consensus.validate_and_insert_block(Block::from_header_arc(h)).virtual_state_task).collect();
             if let Some((prev_jobs, prev_daa_score, prev_timestamp)) = prev.take() {
                 let prev_chunk_len = prev_jobs.len();
                 try_join_all(prev_jobs).await?;
                 progress_reporter.report(prev_chunk_len, prev_daa_score, prev_timestamp);
             }
-            // Clamp the reported score below the ceiling (the last header may have been dropped).
-            let reported_daa = ceiling.map(|c| current_daa_score.min(c.saturating_sub(1))).unwrap_or(current_daa_score);
-            prev = Some((current_jobs, reported_daa, current_timestamp));
+            prev = Some((current_jobs, current_daa_score, current_timestamp));
         }
         if let Some((prev_jobs, _, _)) = prev {
             let prev_chunk_len = prev_jobs.len();
             try_join_all(prev_jobs).await?;
             progress_reporter.report_completion(prev_chunk_len);
-        }
-
-        // Ceiling reached: stop at the highest accepted header (the syncer's sink is above the ceiling
-        // and is intentionally never received). Skip the syncer-sink and relay-past checks.
-        if ceiling_hit {
-            let tip = consensus.async_get_headers_selected_tip().await;
-            info!("sync ceiling reached during header download; stopping at headers selected tip {}", tip);
-            return Ok(tip);
         }
 
         if consensus.async_get_block_status(syncer_virtual_selected_parent).await.is_none() {
@@ -663,7 +599,7 @@ impl IbdFlow {
 
         self.sync_missing_relay_past_headers(consensus, syncer_virtual_selected_parent, relay_block.hash()).await?;
 
-        Ok(syncer_virtual_selected_parent)
+        Ok(())
     }
 
     async fn sync_new_utxo_set(&mut self, consensus: &ConsensusProxy, pruning_point: Hash) -> Result<(), ProtocolError> {

--- a/simpa/src/main.rs
+++ b/simpa/src/main.rs
@@ -255,7 +255,9 @@ fn main_impl(mut args: Args) {
             Default::default(),
             unix_now(),
             Arc::new(MiningRules::default()),
-        ));
+            None,
+        )
+        .expect("simulator consensus initialization must succeed"));
         (consensus, lifetime)
     } else {
         let until = if args.target_blocks.is_none() { config.genesis.timestamp + args.sim_time * 1000 } else { u64::MAX }; // milliseconds
@@ -337,7 +339,9 @@ fn main_impl(mut args: Args) {
         Default::default(),
         unix_now(),
         Arc::new(MiningRules::default()),
-    ));
+        None,
+    )
+    .expect("simulator consensus initialization must succeed"));
     let handles2 = consensus2.run_processors();
     if args.headers_first {
         rt.block_on(validate(&consensus, &consensus2, &config, args.delay, args.bps, true));

--- a/simpa/src/simulator/network.rs
+++ b/simpa/src/simulator/network.rs
@@ -88,7 +88,9 @@ impl KaspaNetworkSimulator {
                 Default::default(),
                 unix_now(),
                 Arc::new(MiningRules::default()),
-            ));
+                None,
+            )
+            .expect("simulator consensus initialization must succeed"));
             let handles = consensus.run_processors();
             let (sk, pk) = secp.generate_keypair(&mut rng);
             let miner_process = Box::new(Miner::new(

--- a/testing/integration/src/consensus_integration_tests.rs
+++ b/testing/integration/src/consensus_integration_tests.rs
@@ -27,7 +27,7 @@ use keryx_consensus_core::block::Block;
 use keryx_consensus_core::blockhash::{self, new_unique};
 use keryx_consensus_core::blockstatus::BlockStatus;
 use keryx_consensus_core::coinbase::MinerData;
-use keryx_consensus_core::constants::{BLOCK_VERSION, SOMPI_PER_KASPA, TRANSIENT_BYTE_TO_MASS_FACTOR};
+use keryx_consensus_core::constants::{BLOCK_VERSION, H4_RELAUNCH_BLOCK_VERSION, SOMPI_PER_KASPA, TRANSIENT_BYTE_TO_MASS_FACTOR};
 use keryx_consensus_core::errors::block::{BlockProcessResult, RuleError};
 use keryx_consensus_core::hashing;
 use keryx_consensus_core::header::Header;
@@ -415,11 +415,27 @@ async fn header_in_isolation_validation_test() {
         let block_version = BLOCK_VERSION - 1;
         block.header.version = block_version;
         match consensus.validate_and_insert_block(block.to_immutable()).virtual_state_task.await {
-            Err(RuleError::WrongBlockVersion(wrong_version)) => {
-                assert_eq!(wrong_version, block_version)
+            Err(RuleError::WrongBlockVersion { actual, expected }) => {
+                assert_eq!(actual, block_version);
+                assert_eq!(expected, BLOCK_VERSION)
             }
             res => {
                 panic!("Unexpected result: {res:?}")
+            }
+        }
+    }
+
+    {
+        let mut block = consensus.build_header_only_block_with_parents(2.into(), vec![config.genesis.hash]);
+        block.header.daa_score = config.params.coin_age_verification_activation.daa_score();
+        block.header.version = BLOCK_VERSION;
+        match consensus.validate_and_insert_block(block.to_immutable()).virtual_state_task.await {
+            Err(RuleError::WrongBlockVersion { actual, expected }) => {
+                assert_eq!(actual, BLOCK_VERSION);
+                assert_eq!(expected, H4_RELAUNCH_BLOCK_VERSION)
+            }
+            res => {
+                panic!("Unexpected H4 version result: {res:?}")
             }
         }
     }
@@ -1391,6 +1407,7 @@ async fn staging_consensus_test() {
         200,
         Arc::new(MiningRules::default()),
         keryx_database::prelude::RocksDbPreset::Default,
+        None,
         None,
         None,
     ));


### PR DESCRIPTION
## Problem

H4 at DAA score 54,766,000 can leave nodes and pools following incompatible post-fork chains. A node that retained old H4 blocks may continue advertising a branch that upgraded nodes must not accept, making recovery non-deterministic and risking fragmented pool and node views of the network.

The normal IBD route was also constrained by `KERYX_SYNC_CEILING_DAA` and `KERYX_TRUST_SYNC_FROM_TIP` escape hatches. Non-archival nodes therefore did not have a reliable bounded-storage path to bootstrap from zero through pruning proof and snapshot data.

## What this PR changes

- Introduces a deterministic H4 relaunch marker: at and after DAA 54,766,000, headers must use version 2 and the dedicated H4 PoM PPH salt. Version-1 H4 blocks are rejected in header validation, template creation, proof verification, and pruning-proof import.
- Adds a startup branch guard plus `--rollback-h4 --yes` and `--stash_blocks N --yes` recovery commands (`--stash-blocks` remains supported). Rewind updates the virtual state atomically, invalidates discarded descendants, clears derived indexes, and refuses to cross the local pruning boundary.
- Restores standard pruning-proof and snapshot IBD, removing the environment-controlled ceiling and trust bypasses.
- Updates simulation and integration coverage, including tests for the H4 marker, the distinct PoM fold, atomic stash, and side-branch quarantine.

## Operational impact

Operators retaining the old post-H4 chain must run:

```text
keryxd --rollback-h4 --yes
```

before connecting to peers. If the local pruning point is already ahead of the required boundary, reset and re-sync are required.

All nodes and pools must upgrade: post-activation version-1 H4 blocks are intentionally rejected. Non-archival nodes remain bounded by pruning retention while bootstrapping from zero through pruning-proof and snapshot exchange.

## Validation

- `cargo test -p keryx-consensus-core` - 55 passed
- `cargo test -p keryx-pow` - 6 passed
- `git diff --check`

The focused consensus test is blocked locally before project compilation because `librocksdb-sys` requires `libclang.dll`. It should be rerun in an environment with LLVM/libclang installed.