### PR TITLE
perf(storage): RocksDB BlobDB, shared budgets, and virtual-commit read caches

### DIFF
--- a/consensus/core/Cargo.toml
+++ b/consensus/core/Cargo.toml
@@ -34,6 +34,7 @@ keryx-merkle.workspace = true
 keryx-muhash.workspace = true
 keryx-txscript-errors.workspace = true
 keryx-utils.workspace = true
+rayon.workspace = true
 rand.workspace = true
 secp256k1.workspace = true
 serde_json.workspace = true

--- a/consensus/core/src/api/counters.rs
+++ b/consensus/core/src/api/counters.rs
@@ -11,6 +11,18 @@ pub struct ProcessingCounters {
     pub chain_block_counts: AtomicU64,
     pub chain_disqualified_counts: AtomicU64,
     pub mass_counts: AtomicU64,
+    /// App-cache hits for the address-balance index (virtual-commit RMW path).
+    pub address_balance_cache_hits: AtomicU64,
+    /// App-cache misses for the address-balance index — each miss is a RocksDB point read.
+    pub address_balance_cache_misses: AtomicU64,
+    /// App-cache hits for the coin-age bucket index.
+    pub age_buckets_cache_hits: AtomicU64,
+    /// App-cache misses for the coin-age bucket index.
+    pub age_buckets_cache_misses: AtomicU64,
+    /// Hits on the windowed-production prefix SeekForPrev cache.
+    pub windowed_prefix_cache_hits: AtomicU64,
+    /// Misses that fall through to a RocksDB `SeekForPrev` on the production prefix index.
+    pub windowed_prefix_cache_misses: AtomicU64,
 }
 
 impl ProcessingCounters {
@@ -25,6 +37,12 @@ impl ProcessingCounters {
             chain_block_counts: self.chain_block_counts.load(Ordering::Relaxed),
             chain_disqualified_counts: self.chain_disqualified_counts.load(Ordering::Relaxed),
             mass_counts: self.mass_counts.load(Ordering::Relaxed),
+            address_balance_cache_hits: self.address_balance_cache_hits.load(Ordering::Relaxed),
+            address_balance_cache_misses: self.address_balance_cache_misses.load(Ordering::Relaxed),
+            age_buckets_cache_hits: self.age_buckets_cache_hits.load(Ordering::Relaxed),
+            age_buckets_cache_misses: self.age_buckets_cache_misses.load(Ordering::Relaxed),
+            windowed_prefix_cache_hits: self.windowed_prefix_cache_hits.load(Ordering::Relaxed),
+            windowed_prefix_cache_misses: self.windowed_prefix_cache_misses.load(Ordering::Relaxed),
         }
     }
 }
@@ -40,6 +58,12 @@ pub struct ProcessingCountersSnapshot {
     pub chain_block_counts: u64,
     pub chain_disqualified_counts: u64,
     pub mass_counts: u64,
+    pub address_balance_cache_hits: u64,
+    pub address_balance_cache_misses: u64,
+    pub age_buckets_cache_hits: u64,
+    pub age_buckets_cache_misses: u64,
+    pub windowed_prefix_cache_hits: u64,
+    pub windowed_prefix_cache_misses: u64,
 }
 
 impl core::ops::Sub for &ProcessingCountersSnapshot {
@@ -56,6 +80,12 @@ impl core::ops::Sub for &ProcessingCountersSnapshot {
             chain_block_counts: self.chain_block_counts.saturating_sub(rhs.chain_block_counts),
             chain_disqualified_counts: self.chain_disqualified_counts.saturating_sub(rhs.chain_disqualified_counts),
             mass_counts: self.mass_counts.saturating_sub(rhs.mass_counts),
+            address_balance_cache_hits: self.address_balance_cache_hits.saturating_sub(rhs.address_balance_cache_hits),
+            address_balance_cache_misses: self.address_balance_cache_misses.saturating_sub(rhs.address_balance_cache_misses),
+            age_buckets_cache_hits: self.age_buckets_cache_hits.saturating_sub(rhs.age_buckets_cache_hits),
+            age_buckets_cache_misses: self.age_buckets_cache_misses.saturating_sub(rhs.age_buckets_cache_misses),
+            windowed_prefix_cache_hits: self.windowed_prefix_cache_hits.saturating_sub(rhs.windowed_prefix_cache_hits),
+            windowed_prefix_cache_misses: self.windowed_prefix_cache_misses.saturating_sub(rhs.windowed_prefix_cache_misses),
         }
     }
 }

--- a/consensus/core/src/pom.rs
+++ b/consensus/core/src/pom.rs
@@ -504,19 +504,57 @@ pub fn verify_pom_proof<Hf: Fn(u64) -> [u8; 32]>(
         return Err(PomVerifyError::BadFinalTracePath);
     }
     let chs = fs_challenges(pre_pow_hash, nonce, &proof.trace_root, &proof.pow_value, t, k);
-    for (op, &i) in proof.openings.iter().zip(chs.iter()) {
-        let i = i as u64;
-        if !verify_merkle(trace_leaf(op.state_before), i, &op.trace_path_before, &proof.trace_root) {
-            return Err(PomVerifyError::BadStateBeforePath);
+    // Each opening's three Merkle checks (+ transition) are independent of the others.
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        use rayon::prelude::*;
+        let bad = proof.openings.par_iter().zip(chs.par_iter()).any(|(op, &i)| {
+            let i = i as u64;
+            if !verify_merkle(trace_leaf(op.state_before), i, &op.trace_path_before, &proof.trace_root) {
+                return true;
+            }
+            let off = op.state_before % n_chunks;
+            if !verify_merkle(blake(&op.chunk), off, &op.weight_path, r_t) {
+                return true;
+            }
+            let state_after = transition_v1(op.state_before, &chunk_to_words(&op.chunk));
+            !verify_merkle(trace_leaf(state_after), i + 1, &op.trace_path_after, &proof.trace_root)
+        });
+        if bad {
+            // Distinguish error kinds with a sequential re-check so callers still see the precise
+            // variant (parallel path only answers "any bad").
+            for (op, &i) in proof.openings.iter().zip(chs.iter()) {
+                let i = i as u64;
+                if !verify_merkle(trace_leaf(op.state_before), i, &op.trace_path_before, &proof.trace_root) {
+                    return Err(PomVerifyError::BadStateBeforePath);
+                }
+                let off = op.state_before % n_chunks;
+                if !verify_merkle(blake(&op.chunk), off, &op.weight_path, r_t) {
+                    return Err(PomVerifyError::BadWeightPath);
+                }
+                let state_after = transition_v1(op.state_before, &chunk_to_words(&op.chunk));
+                if !verify_merkle(trace_leaf(state_after), i + 1, &op.trace_path_after, &proof.trace_root) {
+                    return Err(PomVerifyError::BadStateAfterPath);
+                }
+            }
         }
-        let off = op.state_before % n_chunks;
-        if !verify_merkle(blake(&op.chunk), off, &op.weight_path, r_t) {
-            return Err(PomVerifyError::BadWeightPath);
-        }
-        // Pre-H4 spot-check path — only ever runs for pre-H4 (hence pre-H5) blocks, always walk v1.
-        let state_after = transition_v1(op.state_before, &chunk_to_words(&op.chunk));
-        if !verify_merkle(trace_leaf(state_after), i + 1, &op.trace_path_after, &proof.trace_root) {
-            return Err(PomVerifyError::BadStateAfterPath);
+    }
+    #[cfg(target_arch = "wasm32")]
+    {
+        for (op, &i) in proof.openings.iter().zip(chs.iter()) {
+            let i = i as u64;
+            if !verify_merkle(trace_leaf(op.state_before), i, &op.trace_path_before, &proof.trace_root) {
+                return Err(PomVerifyError::BadStateBeforePath);
+            }
+            let off = op.state_before % n_chunks;
+            if !verify_merkle(blake(&op.chunk), off, &op.weight_path, r_t) {
+                return Err(PomVerifyError::BadWeightPath);
+            }
+            // Pre-H4 spot-check path — only ever runs for pre-H4 (hence pre-H5) blocks, always walk v1.
+            let state_after = transition_v1(op.state_before, &chunk_to_words(&op.chunk));
+            if !verify_merkle(trace_leaf(state_after), i + 1, &op.trace_path_after, &proof.trace_root) {
+                return Err(PomVerifyError::BadStateAfterPath);
+            }
         }
     }
     Ok(())
@@ -557,13 +595,29 @@ pub fn verify_pom_proof_v2<Hf: Fn(u64) -> [u8; 32]>(
     // H5 era selection: `walk_v2` (from `h5_activation` on the block's daa_score) picks the
     // non-foldable mix64-chained transition; pre-H5 blocks re-walk with the frozen v1 fold.
     let transition = if walk_v2 { transition_v2 } else { transition_v1 };
+    // Walk transitions are sequential (each chunk index depends on prior state), but the Merkle
+    // inclusion checks are independent once `(leaf, index, path)` are known — parallelise them.
     let mut state = seed;
+    let mut checks: Vec<([u8; 32], u64, &[[u8; 32]])> = Vec::with_capacity(steps.len());
     for step in steps.iter() {
         let off = state % n_chunks;
-        if !verify_merkle(blake(&step.chunk), off, &step.weight_path, r_t) {
+        checks.push((blake(&step.chunk), off, step.weight_path.as_slice()));
+        state = transition(state, &chunk_to_words(&step.chunk));
+    }
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        use rayon::prelude::*;
+        if checks.par_iter().any(|(leaf, off, path)| !verify_merkle(*leaf, *off, path, r_t)) {
             return Err(PomVerifyError::BadWeightPath);
         }
-        state = transition(state, &chunk_to_words(&step.chunk));
+    }
+    #[cfg(target_arch = "wasm32")]
+    {
+        for (leaf, off, path) in &checks {
+            if !verify_merkle(*leaf, *off, path, r_t) {
+                return Err(PomVerifyError::BadWeightPath);
+            }
+        }
     }
     if state != proof.final_state {
         return Err(PomVerifyError::FinalStateMismatch);

--- a/consensus/src/consensus/factory.rs
+++ b/consensus/src/consensus/factory.rs
@@ -9,8 +9,8 @@ use keryx_consensusmanager::{ConsensusFactory, ConsensusInstance, DynConsensusCt
 use keryx_core::{debug, time::unix_now, warn};
 use keryx_database::{
     prelude::{
-        BatchDbWriter, CachePolicy, CachedDbAccess, CachedDbItem, DB, DirectDbWriter, RocksDbPreset, StoreError, StoreResult,
-        StoreResultExt,
+        BatchDbWriter, CachePolicy, CachedDbAccess, CachedDbItem, DB, DirectDbWriter, RocksDbPreset, RocksDbResources, StoreError,
+        StoreResult, StoreResultExt,
     },
     registry::DatabaseStorePrefixes,
 };
@@ -258,7 +258,7 @@ pub struct Factory {
     mining_rules: Arc<MiningRules>,
     rocksdb_preset: RocksDbPreset,
     wal_dir: Option<PathBuf>,
-    cache_budget: Option<usize>,
+    resources: Option<RocksDbResources>,
 }
 
 impl Factory {
@@ -275,7 +275,7 @@ impl Factory {
         mining_rules: Arc<MiningRules>,
         rocksdb_preset: RocksDbPreset,
         wal_dir: Option<PathBuf>,
-        cache_budget: Option<usize>,
+        resources: Option<RocksDbResources>,
     ) -> Self {
         assert!(fd_budget > 0, "fd_budget has to be positive");
         let mut config = config.clone();
@@ -296,7 +296,7 @@ impl Factory {
             mining_rules,
             rocksdb_preset,
             wal_dir,
-            cache_budget,
+            resources,
         };
         factory.delete_inactive_consensus_entries();
         factory
@@ -329,7 +329,7 @@ impl ConsensusFactory for Factory {
             .with_files_limit(self.fd_budget / 2) // active and staging consensuses should have equal budgets
             .with_preset(self.rocksdb_preset)
             .with_wal_dir(self.wal_dir.clone())
-            .with_cache_budget(self.cache_budget)
+            .with_resources(self.resources.clone())
             .build()
             .unwrap();
 
@@ -367,7 +367,7 @@ impl ConsensusFactory for Factory {
             .with_files_limit(self.fd_budget / 2) // active and staging consensuses should have equal budgets
             .with_preset(self.rocksdb_preset)
             .with_wal_dir(self.wal_dir.clone())
-            .with_cache_budget(self.cache_budget)
+            .with_resources(self.resources.clone())
             .build()
             .unwrap();
 

--- a/consensus/src/consensus/mod.rs
+++ b/consensus/src/consensus/mod.rs
@@ -187,6 +187,7 @@ impl Consensus {
         //
 
         let storage = ConsensusStorage::new(db.clone(), config.clone());
+        storage.windowed_production_prefix_store.attach_counters(counters.clone());
 
         //
         // Services and managers

--- a/consensus/src/consensus/storage.rs
+++ b/consensus/src/consensus/storage.rs
@@ -128,6 +128,16 @@ impl ConsensusStorage {
         let utxo_diffs_budget = scaled(40_000_000);
         let block_window_budget = scaled(200_000_000); // x 2 for difficulty and median time
         let acceptance_data_budget = scaled(40_000_000);
+        // PoM proofs are ~228 KB each (K=256 walk steps, each with a Merkle path). A count-based
+        // policy of 10_000 items — what this store used to share with the header-data caches —
+        // reaches ~2.3 GB and, since item counts are not scaled, ignores `--ram-scale` entirely.
+        let pom_proof_budget = scaled(64_000_000);
+        // Ratio-reward / coin-age indexes are SPK-keyed over a UTXO-scale keyspace. The old
+        // Count(10_000) shared with the UTXO set cache had near-zero hit rate; every virtual-commit
+        // RMW then paid a random HDD read (~9 ms). Budget by bytes so `--ram-scale` actually grows
+        // the hot set. ~80 B/entry ≈ SPK key + u64/AgeBuckets + IndexMap overhead.
+        let address_index_budget = scaled(128_000_000);
+        let address_index_unit_bytes = 80;
 
         // Unit sizes in bytes
         let daa_excluded_bytes = size_of::<Hash>() + size_of::<BlockHashSet>(); // Expected empty sets
@@ -189,9 +199,16 @@ impl ConsensusStorage {
         let block_data_builder = PolicyBuilder::new().max_items(perf_params.block_data_cache_size).untracked();
         let header_data_builder = PolicyBuilder::new().max_items(perf_params.header_data_cache_size).untracked();
         let utxo_set_builder = PolicyBuilder::new().max_items(perf_params.utxo_set_cache_size).untracked();
+        let address_index_builder = PolicyBuilder::new()
+            .bytes_budget(address_index_budget)
+            .unit_bytes(address_index_unit_bytes)
+            .min_items(1024)
+            .untracked();
         let transactions_builder = PolicyBuilder::new().bytes_budget(transactions_budget).tracked_bytes();
         let acceptance_data_builder = PolicyBuilder::new().bytes_budget(acceptance_data_budget).tracked_bytes();
         let past_pruning_points_builder = PolicyBuilder::new().max_items(1024).untracked();
+        // Tracked by bytes (`PomProof::estimate_mem_bytes`), never by count — see `pom_proof_budget`.
+        let pom_proof_builder = PolicyBuilder::new().bytes_budget(pom_proof_budget).min_items(16).tracked_bytes();
 
         // TODO: consider tracking UtxoDiff byte sizes more accurately including the exact size of ScriptPublicKey
 
@@ -224,7 +241,7 @@ impl ConsensusStorage {
         ));
         let daa_excluded_store = Arc::new(DbDaaStore::new(db.clone(), daa_excluded_builder.build()));
         let pom_tier_store = Arc::new(DbPomTierStore::new(db.clone(), header_data_builder.build()));
-        let pom_proof_store = Arc::new(DbPomProofStore::new(db.clone(), header_data_builder.build()));
+        let pom_proof_store = Arc::new(DbPomProofStore::new(db.clone(), pom_proof_builder.build()));
         let headers_store = Arc::new(DbHeadersStore::new(db.clone(), headers_builder.build(), headers_compact_builder.build()));
         let depth_store = Arc::new(DbDepthStore::new(db.clone(), header_data_builder.build()));
         let selected_chain_store = Arc::new(RwLock::new(DbSelectedChainStore::new(db.clone(), header_data_builder.build())));
@@ -240,14 +257,15 @@ impl ConsensusStorage {
         let utxo_multisets_store = Arc::new(DbUtxoMultisetsStore::new(db.clone(), block_data_builder.build()));
         let acceptance_data_store = Arc::new(DbAcceptanceDataStore::new(db.clone(), acceptance_data_builder.build()));
 
-        // Ratio-reward indexes (Stage 2): balance keyspace is ~all addresses (utxo-set scale),
-        // windowed production is small (only recently-active miners) but shares the same shape.
+        // Ratio-reward indexes (Stage 2): balance keyspace is ~all addresses (utxo-set scale).
+        // Dedicated byte-budget cache (honours `--ram-scale`) — not the tiny Count(10k) UTXO policy.
         let address_balance_store =
-            Arc::new(DbAddressAmountStore::new(db.clone(), utxo_set_builder.build(), DatabaseStorePrefixes::AddressBalance.into()));
+            Arc::new(DbAddressAmountStore::new(db.clone(), address_index_builder.build(), DatabaseStorePrefixes::AddressBalance.into()));
         // Coin-age (v3) bucket aggregates: same keyspace scale and cache class as the balance index.
-        let age_buckets_store = Arc::new(DbAgeBucketsStore::new(db.clone(), utxo_set_builder.build()));
+        let age_buckets_store = Arc::new(DbAgeBucketsStore::new(db.clone(), address_index_builder.build()));
         let maturation_queue_store = Arc::new(DbMaturationQueueStore::new(db.clone()));
-        let windowed_production_prefix_store = Arc::new(DbWindowedProductionPrefixStore::new(db.clone()));
+        let windowed_production_prefix_store =
+            Arc::new(DbWindowedProductionPrefixStore::new(db.clone(), scaled(64_000_000)));
 
         // OPoI slash stores
         let ai_response_store = Arc::new(DbAiResponseStore::new(db.clone(), header_data_builder.build()));

--- a/consensus/src/model/stores/address_amount.rs
+++ b/consensus/src/model/stores/address_amount.rs
@@ -140,6 +140,16 @@ impl AddressAmountStoreReader for DbAddressAmountStore {
     }
 }
 
+impl DbAddressAmountStore {
+    /// Batch-read aggregates for `script_public_keys`. Absent keys yield `0`. Returns
+    /// `(values, cache_hits, cache_misses)` so the virtual processor can feed ProcessingCounters.
+    pub fn get_many(&self, script_public_keys: &[ScriptPublicKey]) -> Result<(Vec<u64>, u64, u64), StoreError> {
+        let keys: Vec<ScriptPublicKeyBucket> = script_public_keys.iter().map(ScriptPublicKeyBucket::from).collect();
+        let (raw, hits, misses) = self.access.read_many(&keys)?;
+        Ok((raw.into_iter().map(|v| v.unwrap_or(0)).collect(), hits, misses))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/consensus/src/model/stores/age_buckets.rs
+++ b/consensus/src/model/stores/age_buckets.rs
@@ -99,6 +99,16 @@ impl AgeBucketsStoreReader for DbAgeBucketsStore {
     }
 }
 
+impl DbAgeBucketsStore {
+    /// Batch-read bucket aggregates. Absent keys yield empty buckets. Returns
+    /// `(values, cache_hits, cache_misses)` for ProcessingCounters.
+    pub fn get_many(&self, script_public_keys: &[ScriptPublicKey]) -> Result<(Vec<AgeBuckets>, u64, u64), StoreError> {
+        let keys: Vec<ScriptPublicKeyBucket> = script_public_keys.iter().map(ScriptPublicKeyBucket::from).collect();
+        let (raw, hits, misses) = self.access.read_many(&keys)?;
+        Ok((raw.into_iter().map(|v| v.unwrap_or_default()).collect(), hits, misses))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/consensus/src/model/stores/ghostdag.rs
+++ b/consensus/src/model/stores/ghostdag.rs
@@ -319,21 +319,21 @@ impl DbGhostdagStore {
 
 impl GhostdagStoreReader for DbGhostdagStore {
     fn get_blue_score(&self, hash: Hash) -> Result<u64, StoreError> {
-        if let Some(ghostdag_data) = self.access.read_from_cache(hash) {
+        if let Some(ghostdag_data) = self.access.read_from_cache(&hash) {
             return Ok(ghostdag_data.blue_score);
         }
         Ok(self.compact_access.read(hash)?.blue_score)
     }
 
     fn get_blue_work(&self, hash: Hash) -> Result<BlueWorkType, StoreError> {
-        if let Some(ghostdag_data) = self.access.read_from_cache(hash) {
+        if let Some(ghostdag_data) = self.access.read_from_cache(&hash) {
             return Ok(ghostdag_data.blue_work);
         }
         Ok(self.compact_access.read(hash)?.blue_work)
     }
 
     fn get_selected_parent(&self, hash: Hash) -> Result<Hash, StoreError> {
-        if let Some(ghostdag_data) = self.access.read_from_cache(hash) {
+        if let Some(ghostdag_data) = self.access.read_from_cache(&hash) {
             return Ok(ghostdag_data.selected_parent);
         }
         Ok(self.compact_access.read(hash)?.selected_parent)

--- a/consensus/src/model/stores/headers.rs
+++ b/consensus/src/model/stores/headers.rs
@@ -212,28 +212,28 @@ impl DbHeadersStore {
 
 impl HeaderStoreReader for DbHeadersStore {
     fn get_daa_score(&self, hash: Hash) -> Result<u64, StoreError> {
-        if let Some(header_with_block_level) = self.headers_access.read_from_cache(hash) {
+        if let Some(header_with_block_level) = self.headers_access.read_from_cache(&hash) {
             return Ok(header_with_block_level.header.daa_score);
         }
         Ok(self.compact_headers_access.read(hash)?.daa_score)
     }
 
     fn get_blue_score(&self, hash: Hash) -> Result<u64, StoreError> {
-        if let Some(header_with_block_level) = self.headers_access.read_from_cache(hash) {
+        if let Some(header_with_block_level) = self.headers_access.read_from_cache(&hash) {
             return Ok(header_with_block_level.header.blue_score);
         }
         Ok(self.compact_headers_access.read(hash)?.blue_score)
     }
 
     fn get_timestamp(&self, hash: Hash) -> Result<u64, StoreError> {
-        if let Some(header_with_block_level) = self.headers_access.read_from_cache(hash) {
+        if let Some(header_with_block_level) = self.headers_access.read_from_cache(&hash) {
             return Ok(header_with_block_level.header.timestamp);
         }
         Ok(self.compact_headers_access.read(hash)?.timestamp)
     }
 
     fn get_bits(&self, hash: Hash) -> Result<u32, StoreError> {
-        if let Some(header_with_block_level) = self.headers_access.read_from_cache(hash) {
+        if let Some(header_with_block_level) = self.headers_access.read_from_cache(&hash) {
             return Ok(header_with_block_level.header.bits);
         }
         Ok(self.compact_headers_access.read(hash)?.bits)
@@ -251,7 +251,7 @@ impl HeaderStoreReader for DbHeadersStore {
     }
 
     fn get_compact_header_data(&self, hash: Hash) -> Result<CompactHeaderData, StoreError> {
-        if let Some(header_with_block_level) = self.headers_access.read_from_cache(hash) {
+        if let Some(header_with_block_level) = self.headers_access.read_from_cache(&hash) {
             return Ok(header_with_block_level.header.as_ref().into());
         }
         self.compact_headers_access.read(hash)

--- a/consensus/src/model/stores/windowed_production_prefix.rs
+++ b/consensus/src/model/stores/windowed_production_prefix.rs
@@ -34,11 +34,14 @@
 //!   floor only ever serves as the `cum(b−W)` baseline, never as an in-window term.
 
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::sync::atomic::Ordering;
+use std::sync::{Arc, OnceLock};
 
+use keryx_consensus_core::api::counters::ProcessingCounters;
 use keryx_consensus_core::tx::ScriptPublicKey;
-use keryx_database::prelude::{StoreError, DB};
+use keryx_database::prelude::{Cache, CachePolicy, StoreError, DB};
 use keryx_database::registry::DatabaseStorePrefixes;
+use keryx_utils::mem_size::MemSizeEstimator;
 use rocksdb::{Direction, IteratorMode, ReadOptions, WriteBatch};
 
 use super::address_amount::ScriptPublicKeyBucket;
@@ -61,23 +64,77 @@ pub trait WindowedProductionPrefixStoreReader {
     }
 }
 
-/// A DB-backed prefix-sum production index. Reads hit committed state directly (no cache layer — the
-/// reverse seek is a single `SeekForPrev` and queries are ~one-per-reward-payout); writes go through
-/// the caller's consensus `WriteBatch` so they commit atomically with the selected-chain change.
+/// Cache key for a `cumulative_at(spk, index)` query. The value is the SeekForPrev result (or floor).
+#[derive(Clone, Hash, Eq, PartialEq)]
+struct CumulativeQueryKey {
+    spk: ScriptPublicKeyBucket,
+    index: u64,
+}
+
+impl MemSizeEstimator for CumulativeQueryKey {
+    fn estimate_mem_units(&self) -> usize {
+        1
+    }
+}
+
+/// A DB-backed prefix-sum production index with an app-level LRU in front of `SeekForPrev`.
+///
+/// The cache is invalidated per-SPK on `extend` / collapse / `clear` so reorgs cannot serve stale
+/// cumulatives. Writes go through the caller's consensus `WriteBatch` so they commit atomically
+/// with the selected-chain change.
 #[derive(Clone)]
 pub struct DbWindowedProductionPrefixStore {
     db: Arc<DB>,
     entries_prefix: u8,
     floor_prefix: u8,
+    /// `(spk, query_index) → cumulative`. Bounded by `cache_budget_bytes` via ~48 B/entry units.
+    cache: Cache<CumulativeQueryKey, u64>,
+    counters: OnceLock<Arc<ProcessingCounters>>,
 }
 
 impl DbWindowedProductionPrefixStore {
-    pub fn new(db: Arc<DB>) -> Self {
+    /// `cache_budget_bytes` is the soft RAM budget for the SeekForPrev result cache (honours the
+    /// caller's `--ram-scale` via `scaled(...)` in `ConsensusStorage`).
+    pub fn new(db: Arc<DB>, cache_budget_bytes: usize) -> Self {
+        // ~48 B per entry: SPK bucket (~34) + u64 index + u64 value + IndexMap overhead.
+        let max_items = (cache_budget_bytes / 48).max(256);
         Self {
             db,
             entries_prefix: DatabaseStorePrefixes::WindowedProductionPrefix.into(),
             floor_prefix: DatabaseStorePrefixes::WindowedProductionFloor.into(),
+            cache: Cache::new(CachePolicy::Count(max_items)),
+            counters: OnceLock::new(),
         }
+    }
+
+    /// Wire process-wide processing counters (called once from `Consensus::new`).
+    pub fn attach_counters(&self, counters: Arc<ProcessingCounters>) {
+        let _ = self.counters.set(counters);
+    }
+
+    fn record_hit(&self) {
+        if let Some(c) = self.counters.get() {
+            c.windowed_prefix_cache_hits.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    fn record_miss(&self) {
+        if let Some(c) = self.counters.get() {
+            c.windowed_prefix_cache_misses.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    fn cache_insert(&self, spk: &ScriptPublicKey, index: u64, value: u64) {
+        let bucket = ScriptPublicKeyBucket::from(spk);
+        self.cache.insert(CumulativeQueryKey { spk: bucket, index }, value);
+    }
+
+    /// Any mutation that changes entries for ≥1 SPK can affect SeekForPrev results for that SPK at
+    /// every query index. Full clear is correct and cheap relative to a disk seek; validation still
+    /// benefits because many rewarded blues re-read the same tip indices *within* one block before
+    /// the next extend.
+    fn invalidate_cache(&self) {
+        self.cache.remove_all();
     }
 
     /// On-disk entry key: `entries_prefix || SPK_bucket || be(index)`.
@@ -156,6 +213,9 @@ impl DbWindowedProductionPrefixStore {
             self.put_cumulative(batch, spk, *index, new_cum);
             acc.insert(spk.clone(), new_cum);
         }
+        if !removals.is_empty() || !additions.is_empty() {
+            self.invalidate_cache();
+        }
         Ok(())
     }
 
@@ -176,6 +236,9 @@ impl DbWindowedProductionPrefixStore {
             // collapsed max supersedes it; still take the max for total order-independence.
             let merged = self.read_floor(&spk)?.max(cumulative);
             self.put_floor(batch, &spk, merged);
+        }
+        if !items.is_empty() {
+            self.invalidate_cache();
         }
         Ok(())
     }
@@ -226,6 +289,9 @@ impl DbWindowedProductionPrefixStore {
             let existing = self.db.get(&fk)?.map(decode_u64).unwrap_or(0);
             batch.put(fk, existing.max(cumulative).to_le_bytes());
         }
+        if deleted > 0 {
+            self.invalidate_cache();
+        }
         Ok(deleted)
     }
 
@@ -243,11 +309,19 @@ impl DbWindowedProductionPrefixStore {
             // delete_range covers [prefix, prefix+1) — the whole single-byte-prefixed keyspace.
             batch.delete_range(vec![prefix], vec![prefix + 1]);
         }
+        self.invalidate_cache();
     }
 }
 
 impl WindowedProductionPrefixStoreReader for DbWindowedProductionPrefixStore {
     fn cumulative_at(&self, spk: &ScriptPublicKey, index: u64) -> Result<u64, StoreError> {
+        let qkey = CumulativeQueryKey { spk: ScriptPublicKeyBucket::from(spk), index };
+        if let Some(v) = self.cache.get(&qkey) {
+            self.record_hit();
+            return Ok(v);
+        }
+        self.record_miss();
+
         let range = self.spk_range(spk);
         // Seek key = range || be(index). Reverse direction ⇒ SeekForPrev: the largest key ≤ seek.
         let mut seek = range.clone();
@@ -255,13 +329,16 @@ impl WindowedProductionPrefixStoreReader for DbWindowedProductionPrefixStore {
         let mut opts = ReadOptions::default();
         opts.set_iterate_range(rocksdb::PrefixRange(range.as_slice()));
         let mut it = self.db.iterator_opt(IteratorMode::From(seek.as_slice(), Direction::Reverse), opts);
-        if let Some(item) = it.next() {
+        let value = if let Some(item) = it.next() {
             let (_key, value) = item?;
             // PrefixRange bounds the iterator to this SPK, so any hit is a real entry ≤ index.
-            return Ok(decode_u64(value.as_ref().to_vec()));
-        }
-        // No retained entry ≤ index for this SPK ⇒ the floor baseline (0 if never pruned/seen).
-        self.read_floor(spk)
+            decode_u64(value.as_ref().to_vec())
+        } else {
+            // No retained entry ≤ index for this SPK ⇒ the floor baseline (0 if never pruned/seen).
+            self.read_floor(spk)?
+        };
+        self.cache_insert(spk, index, value);
+        Ok(value)
     }
 }
 
@@ -298,7 +375,7 @@ mod tests {
     #[test]
     fn forward_matches_brute_force() {
         let (_lt, db) = create_temp_db!(ConnBuilder::default().with_files_limit(10));
-        let store = DbWindowedProductionPrefixStore::new(db.clone());
+        let store = DbWindowedProductionPrefixStore::new(db.clone(), 1_000_000);
         let w = 5u64;
         // A deliberately uneven production pattern across 3 SPKs over 20 blocks.
         let chain: Vec<(ScriptPublicKey, u64)> = (1..=20u64)
@@ -327,7 +404,7 @@ mod tests {
     #[test]
     fn reorg_matches_brute_force() {
         let (_lt, db) = create_temp_db!(ConnBuilder::default().with_files_limit(10));
-        let store = DbWindowedProductionPrefixStore::new(db.clone());
+        let store = DbWindowedProductionPrefixStore::new(db.clone(), 1_000_000);
         let w = 4u64;
 
         // Original chain, indices 1..=10.
@@ -371,7 +448,7 @@ mod tests {
     #[test]
     fn floor_collapse_preserves_queries() {
         let (_lt, db) = create_temp_db!(ConnBuilder::default().with_files_limit(10));
-        let store = DbWindowedProductionPrefixStore::new(db.clone());
+        let store = DbWindowedProductionPrefixStore::new(db.clone(), 1_000_000);
         let w = 6u64;
 
         // SPK 1 produces early then goes quiet; SPK 2 produces late — the exact case the floor exists
@@ -430,7 +507,7 @@ mod tests {
     #[test]
     fn collapse_below_preserves_queries() {
         let (_lt, db) = create_temp_db!(ConnBuilder::default().with_files_limit(10));
-        let store = DbWindowedProductionPrefixStore::new(db.clone());
+        let store = DbWindowedProductionPrefixStore::new(db.clone(), 1_000_000);
         let w = 6u64;
         let chain: Vec<(ScriptPublicKey, u64)> = vec![
             (spk(1), 10), (spk(1), 20), (spk(2), 5), (spk(2), 5), (spk(1), 30),
@@ -472,7 +549,7 @@ mod tests {
     #[test]
     fn cross_spk_isolation() {
         let (_lt, db) = create_temp_db!(ConnBuilder::default().with_files_limit(10));
-        let store = DbWindowedProductionPrefixStore::new(db.clone());
+        let store = DbWindowedProductionPrefixStore::new(db.clone(), 1_000_000);
         let mut batch = WriteBatch::default();
         // Two SPKs whose buckets are adjacent; only spk(2) has an entry at index 5.
         store.put_cumulative(&mut batch, &spk(2), 5, 999);

--- a/consensus/src/pipeline/monitor.rs
+++ b/consensus/src/pipeline/monitor.rs
@@ -62,6 +62,24 @@ impl ConsensusMonitor {
                 if delta.body_counts != 0 { delta.mass_counts as f64 / delta.body_counts as f64 } else { 0f64 },
             );
 
+            let index_reads = delta.address_balance_cache_hits
+                + delta.address_balance_cache_misses
+                + delta.age_buckets_cache_hits
+                + delta.age_buckets_cache_misses
+                + delta.windowed_prefix_cache_hits
+                + delta.windowed_prefix_cache_misses;
+            if index_reads > 0 {
+                info!(
+                    "Virtual-index cache: balance {}/{} hits/misses; age {}/{}; production-prefix {}/{}",
+                    delta.address_balance_cache_hits,
+                    delta.address_balance_cache_misses,
+                    delta.age_buckets_cache_hits,
+                    delta.age_buckets_cache_misses,
+                    delta.windowed_prefix_cache_hits,
+                    delta.windowed_prefix_cache_misses,
+                );
+            }
+
             if delta.chain_disqualified_counts > 0 {
                 warn!(
                     "Consensus detected UTXO-invalid blocks which are disqualified from the virtual selected chain (possibly due to inheritance): {} disqualified vs. {} valid chain blocks",

--- a/consensus/src/pipeline/virtual_processor/processor.rs
+++ b/consensus/src/pipeline/virtual_processor/processor.rs
@@ -191,7 +191,7 @@ pub struct VirtualStateProcessor {
     notification_root: Arc<ConsensusNotificationRoot>,
 
     // Counters
-    counters: Arc<ProcessingCounters>,
+    pub(super) counters: Arc<ProcessingCounters>,
 
     // Mining Rule
     _mining_rules: Arc<MiningRules>,

--- a/consensus/src/pipeline/virtual_processor/utxo_validation.rs
+++ b/consensus/src/pipeline/virtual_processor/utxo_validation.rs
@@ -941,12 +941,18 @@ impl VirtualStateProcessor {
         for entry in diff.remove.values() {
             *deltas.entry(entry.script_public_key.clone()).or_default() -= entry.amount as i128;
         }
-        for (spk, delta) in deltas {
-            if delta == 0 {
-                continue;
-            }
-            let new_balance = (self.address_balance_store.get(&spk).unwrap() as i128 + delta).max(0) as u64;
-            self.address_balance_store.set_batch(batch, &spk, new_balance).unwrap();
+        deltas.retain(|_, d| *d != 0);
+        if deltas.is_empty() {
+            return;
+        }
+        let spks: Vec<ScriptPublicKey> = deltas.keys().cloned().collect();
+        let (balances, hits, misses) = self.address_balance_store.get_many(&spks).unwrap();
+        self.counters.address_balance_cache_hits.fetch_add(hits, std::sync::atomic::Ordering::Relaxed);
+        self.counters.address_balance_cache_misses.fetch_add(misses, std::sync::atomic::Ordering::Relaxed);
+        for (spk, balance) in spks.iter().zip(balances) {
+            let delta = deltas[spk];
+            let new_balance = (balance as i128 + delta).max(0) as u64;
+            self.address_balance_store.set_batch(batch, spk, new_balance).unwrap();
         }
     }
 
@@ -990,17 +996,22 @@ impl VirtualStateProcessor {
                 self.maturation_queue_store.delete_batch(batch, entry.effective_daa + self.coin_age_maturity_w, outpoint).unwrap();
             }
         }
-        for (spk, (dm, div, dia)) in deltas {
-            if (dm, div, dia) == (0, 0, 0) {
-                continue;
-            }
-            let b = self.age_buckets_store.get(&spk).unwrap();
+        deltas.retain(|_, d| *d != (0, 0, 0));
+        if deltas.is_empty() {
+            return;
+        }
+        let spks: Vec<ScriptPublicKey> = deltas.keys().cloned().collect();
+        let (buckets, hits, misses) = self.age_buckets_store.get_many(&spks).unwrap();
+        self.counters.age_buckets_cache_hits.fetch_add(hits, std::sync::atomic::Ordering::Relaxed);
+        self.counters.age_buckets_cache_misses.fetch_add(misses, std::sync::atomic::Ordering::Relaxed);
+        for (spk, b) in spks.iter().zip(buckets) {
+            let (dm, div, dia) = deltas[spk];
             let next = AgeBuckets {
                 b_mat: (b.b_mat as i128 + dm).max(0) as u64,
                 b_imm: (b.b_imm as i128 + div).max(0) as u64,
                 a_imm: (b.a_imm as i128 + dia).max(0) as u128,
             };
-            self.age_buckets_store.set_batch(batch, &spk, next).unwrap();
+            self.age_buckets_store.set_batch(batch, spk, next).unwrap();
         }
     }
 

--- a/database/examples/rocksdb_workload_bench.rs
+++ b/database/examples/rocksdb_workload_bench.rs
@@ -1,0 +1,380 @@
+//! Comparative benchmark of the node's dominant RocksDB write pattern, old options vs new.
+//!
+//! The workload replays what a 10-BPS Keryx node actually does to its consensus DB on every block:
+//! one ~228 KB `PomProof` (K=256 walk steps, each with a Merkle path), a handful of small hot
+//! consensus records (header, ghostdag, statuses, reachability, utxo diff, acceptance data), a few
+//! point reads of those hot keys, and the proof-GC delete of the block that just left the retention
+//! window — all committed in a single `WriteBatch`, exactly as `commit_header` / the virtual
+//! processor do.
+//!
+//! It reports the numbers that decide whether a node fits on a spinning disk: write amplification
+//! (how many physical bytes RocksDB writes per logical byte the node hands it), on-disk footprint,
+//! wall-clock throughput, hot-read latency, and the index/filter memory that lives outside every
+//! configured budget.
+//!
+//! Variants:
+//! * `legacy-default` / `legacy-hdd` — the option sets as they were before the optimization patch,
+//!   copied verbatim from `rocksdb_preset.rs` at commit 95c338fd.
+//! * `opt-default` / `opt-hdd` — the current presets, applied through the real production code path
+//!   (`RocksDbPreset::apply_to_options`), including the shared cache / memtable budget.
+//!
+//! Usage:
+//!   cargo run --release -p keryx-database --example rocksdb_workload_bench -- \
+//!       <variant> <db_dir> [blocks] [retention]
+
+use keryx_database::prelude::{RocksDbPreset, RocksDbResources};
+use rocksdb::{BlockBasedOptions, Cache, DBCompressionType, DBWithThreadMode, MultiThreaded, Options, WriteBatch};
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+/// Size of one post-H4 PoM proof: 256 walk steps x (32 B chunk + ~31 x 32 B Merkle path).
+const POM_PROOF_BYTES: usize = 228 * 1024;
+/// Shared cache / memtable budgets handed to the optimized variants (the daemon's defaults at
+/// `--ram-scale=1.0`).
+const SHARED_CACHE_BYTES: usize = 256 * 1024 * 1024;
+const SHARED_MEMTABLE_BYTES_DEFAULT: usize = 256 * 1024 * 1024;
+const SHARED_MEMTABLE_BYTES_HDD: usize = 768 * 1024 * 1024;
+/// Same file budget for every variant, so the comparison isn't skewed by FD limits.
+const MAX_OPEN_FILES: i32 = 500;
+/// Hot-key prefixes, mirroring `DatabaseStorePrefixes`: (prefix, value size).
+const HOT_RECORDS: &[(u8, usize)] = &[
+    (0x01, 200),  // headers
+    (0x02, 500),  // ghostdag
+    (0x03, 1),    // statuses
+    (0x04, 80),   // reachability
+    (0x05, 1024), // utxo diffs
+    (0x06, 500),  // acceptance data
+    (0x07, 120),  // daa / depth
+    (0x08, 64),   // relations
+];
+const POM_PREFIX: u8 = 0xF0;
+
+type Db = DBWithThreadMode<MultiThreaded>;
+
+// ---------------------------------------------------------------------------------------------
+// Option sets
+// ---------------------------------------------------------------------------------------------
+
+/// Pre-patch `apply_default`: parallelism + level-style compaction, nothing else. No block cache
+/// is configured, so RocksDB falls back to its 8 MB per-DB default; index and filter blocks live
+/// outside it entirely.
+fn legacy_default(opts: &mut Options, parallelism: usize) {
+    if parallelism > 1 {
+        opts.increase_parallelism(parallelism as i32);
+    }
+    opts.optimize_level_style_compaction(64 * 1024 * 1024);
+}
+
+/// Pre-patch `apply_hdd`, verbatim.
+fn legacy_hdd(opts: &mut Options, parallelism: usize) {
+    if parallelism > 1 {
+        opts.increase_parallelism(parallelism as i32);
+    }
+    let write_buffer_size = 256 * 1024 * 1024;
+    opts.optimize_level_style_compaction(write_buffer_size);
+    opts.set_write_buffer_size(write_buffer_size);
+    opts.set_target_file_size_base(256 * 1024 * 1024);
+    opts.set_target_file_size_multiplier(1);
+    opts.set_max_bytes_for_level_base(1024 * 1024 * 1024);
+    opts.set_level_compaction_dynamic_level_bytes(true);
+    opts.set_level_zero_file_num_compaction_trigger(1);
+    opts.set_compaction_pri(rocksdb::CompactionPri::OldestSmallestSeqFirst);
+    opts.set_compaction_readahead_size(4 * 1024 * 1024);
+    opts.set_compression_type(DBCompressionType::Lz4);
+    opts.set_bottommost_compression_type(DBCompressionType::Zstd);
+    opts.set_compression_options(-1, 22, 0, 64 * 1024);
+    opts.set_zstd_max_train_bytes(8 * 1024 * 1024);
+    let mut block_opts = BlockBasedOptions::default();
+    block_opts.set_bloom_filter(18.0, false);
+    block_opts.set_partition_filters(true);
+    block_opts.set_format_version(5);
+    block_opts.set_index_type(rocksdb::BlockBasedIndexType::TwoLevelIndexSearch);
+    block_opts.set_cache_index_and_filter_blocks(true);
+    // A per-connection cache, as before: every DB the node opened built its own.
+    block_opts.set_block_cache(&Cache::new_lru_cache(256 * 1024 * 1024));
+    block_opts.set_block_size(256 * 1024);
+    opts.set_block_based_table_factory(&block_opts);
+    opts.set_ratelimiter(12 * 1024 * 1024, 100_000, 10);
+    opts.set_enable_blob_files(true);
+    opts.set_min_blob_size(512);
+    opts.set_blob_file_size(256 * 1024 * 1024);
+    opts.set_blob_compression_type(DBCompressionType::Zstd);
+    opts.set_enable_blob_gc(true);
+    opts.set_blob_gc_age_cutoff(0.9);
+    opts.set_blob_gc_force_threshold(0.1);
+    opts.set_blob_compaction_readahead_size(8 * 1024 * 1024);
+}
+
+fn build_options(variant: &str, parallelism: usize) -> Options {
+    let mut opts = Options::default();
+    match variant {
+        "legacy-default" => legacy_default(&mut opts, parallelism),
+        "legacy-hdd" => legacy_hdd(&mut opts, parallelism),
+        "opt-default" => {
+            let resources = RocksDbResources::new(SHARED_CACHE_BYTES, SHARED_MEMTABLE_BYTES_DEFAULT, None);
+            RocksDbPreset::Default.apply_to_options(&mut opts, parallelism, 64 * 1024 * 1024, Some(&resources));
+        }
+        "opt-hdd" => {
+            let resources = RocksDbResources::new(SHARED_CACHE_BYTES, SHARED_MEMTABLE_BYTES_HDD, None);
+            RocksDbPreset::Hdd.apply_to_options(&mut opts, parallelism, 64 * 1024 * 1024, Some(&resources));
+        }
+        // opt-hdd plus periodic compaction. With ~99.8% of the bytes in blob files the LSM holds
+        // almost no SST, so RocksDB's size-based compaction triggers rarely fire — and blob GC only
+        // runs inside an SST compaction. Periodic compaction gives it a time-based trigger instead,
+        // which is the only thing that can reclaim blob garbage in this shape. 30s here so the
+        // mechanism is observable inside a ~2 minute run; production would use minutes-to-hours.
+        "opt-hdd-periodic" => {
+            let resources = RocksDbResources::new(SHARED_CACHE_BYTES, SHARED_MEMTABLE_BYTES_HDD, None);
+            RocksDbPreset::Hdd.apply_to_options(&mut opts, parallelism, 64 * 1024 * 1024, Some(&resources));
+            opts.set_periodic_compaction_seconds(30);
+        }
+        "hdd-qd1" => {
+            let resources = RocksDbResources::new(SHARED_CACHE_BYTES, SHARED_MEMTABLE_BYTES_HDD, Some(30 * 1024 * 1024));
+            RocksDbPreset::HddQd1.apply_to_options(&mut opts, 1, 64 * 1024 * 1024, Some(&resources));
+        }
+        other => panic!("unknown variant '{other}' (legacy-default | legacy-hdd | opt-default | opt-hdd | hdd-qd1)"),
+    }
+    opts.enable_statistics();
+    // hdd-qd1 deliberately keeps every file open; the others share one budget for comparability.
+    if variant != "hdd-qd1" {
+        opts.set_max_open_files(MAX_OPEN_FILES);
+    }
+    opts.create_if_missing(true);
+    opts
+}
+
+// ---------------------------------------------------------------------------------------------
+// Workload
+// ---------------------------------------------------------------------------------------------
+
+/// Deterministic per-block key: prefix || 32-byte "hash" derived from the index.
+fn key(prefix: u8, index: u64) -> Vec<u8> {
+    let mut k = Vec::with_capacity(33);
+    k.push(prefix);
+    // Spread indices across the keyspace the way block hashes do, so writes are not append-ordered.
+    let scattered = index.wrapping_mul(0x9E37_79B9_7F4A_7C15);
+    k.extend_from_slice(&scattered.to_be_bytes());
+    k.extend_from_slice(&index.to_be_bytes());
+    k.extend_from_slice(&[0u8; 16]);
+    k
+}
+
+/// A proof-shaped payload: Merkle paths are hash bytes, i.e. incompressible. Deriving them from the
+/// index keeps the bytes pseudo-random rather than a compressible constant run.
+fn proof_payload(index: u64) -> Vec<u8> {
+    let mut v = vec![0u8; POM_PROOF_BYTES];
+    let mut state = index.wrapping_mul(0xD6E8_FEB8_6659_FD93).wrapping_add(1);
+    for chunk in v.chunks_mut(8) {
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        let bytes = state.to_le_bytes();
+        chunk.copy_from_slice(&bytes[..chunk.len()]);
+    }
+    v
+}
+
+struct Report {
+    wall: Duration,
+    logical_bytes: u64,
+    flush_write_bytes: u64,
+    compact_write_bytes: u64,
+    compact_read_bytes: u64,
+    on_disk_bytes: u64,
+    sst_bytes: u64,
+    blob_bytes: u64,
+    table_readers_mem: u64,
+    block_cache_usage: u64,
+    hot_read: Duration,
+    hot_reads: u64,
+    settle: Duration,
+    /// Footprint and physical writes as the run left them, before the forced full compaction.
+    on_disk_before_compact: u64,
+    physical_before_compact: u64,
+    full_compact: Duration,
+    /// True when compaction was still pending at the settle deadline — the run left unpaid
+    /// compaction debt, so its write-amplification and footprint numbers are optimistic.
+    settle_timed_out: bool,
+}
+
+fn run(variant: &str, db_dir: &Path, blocks: u64, retention: u64) -> Report {
+    let parallelism = num_cpus::get();
+    let opts = build_options(variant, parallelism);
+    let db = Db::open(&opts, db_dir).expect("failed to open DB");
+
+    let mut logical_bytes = 0u64;
+    let started = Instant::now();
+    let mut hot_read = Duration::ZERO;
+    let mut hot_reads = 0u64;
+
+    for index in 0..blocks {
+        let mut batch = WriteBatch::default();
+
+        // The block's PoM proof.
+        let proof = proof_payload(index);
+        batch.put(key(POM_PREFIX, index), &proof);
+        logical_bytes += (POM_PROOF_BYTES + 33) as u64;
+
+        // The small hot consensus records committed alongside it.
+        for &(prefix, size) in HOT_RECORDS {
+            let value = vec![(index % 251) as u8; size];
+            batch.put(key(prefix, index), &value);
+            logical_bytes += (size + 33) as u64;
+        }
+
+        // Proof GC: the block that just left the retention window.
+        if index >= retention {
+            batch.delete(key(POM_PREFIX, index - retention));
+        }
+
+        db.write(batch).expect("batch write failed");
+
+        // Point reads of recent hot keys, as validation of a new block does against its ancestors.
+        if index % 4 == 0 && index > 0 {
+            let read_started = Instant::now();
+            for &(prefix, _) in HOT_RECORDS.iter().take(4) {
+                let target = index.saturating_sub(1 + (index % 64));
+                let _ = db.get_pinned(key(prefix, target)).expect("read failed");
+                hot_reads += 1;
+            }
+            hot_read += read_started.elapsed();
+        }
+    }
+
+    // Let RocksDB settle so pending compactions are counted, not left as unpaid debt that would
+    // flatter whichever variant queued more of it.
+    db.flush().expect("flush failed");
+    let settle_deadline = Duration::from_secs(900);
+    let settle_started = Instant::now();
+    let mut settle_timed_out = true;
+    while settle_started.elapsed() < settle_deadline {
+        let pending = db.property_int_value("rocksdb.compaction-pending").ok().flatten().unwrap_or(0);
+        let running = db.property_int_value("rocksdb.num-running-compactions").ok().flatten().unwrap_or(0);
+        if pending == 0 && running == 0 {
+            settle_timed_out = false;
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(200));
+    }
+    let settle = settle_started.elapsed();
+    let wall = started.elapsed();
+
+    // Footprint and physical writes before reclaiming any deferred garbage.
+    let on_disk_before_compact = dir_size(db_dir, None);
+    let stats_before = opts.get_statistics().unwrap_or_default();
+    let physical_before_compact =
+        ticker(&stats_before, "rocksdb.flush.write.bytes") + ticker(&stats_before, "rocksdb.compact.write.bytes");
+
+    // A variant that defers compaction (and with it blob GC) shows a smaller amplification and a
+    // larger footprint than one that pays as it goes — the two are not comparable until the
+    // deferred work is done. Forcing a full compaction settles which of the two is happening: if
+    // the extra bytes are uncollected garbage they disappear here, and the I/O it took to collect
+    // them lands in the post-compaction amplification.
+    let compact_started = Instant::now();
+    db.compact_range::<&[u8], &[u8]>(None, None);
+    let full_compact = compact_started.elapsed();
+
+    // Ticker lines are `rocksdb.<name> COUNT : <value>`.
+    fn ticker(stats: &str, name: &str) -> u64 {
+        stats
+            .lines()
+            .find(|line| line.split_whitespace().next() == Some(name))
+            .and_then(|line| line.rsplit(':').next())
+            .and_then(|value| value.trim().parse().ok())
+            .unwrap_or(0)
+    }
+    let stats = opts.get_statistics().unwrap_or_default();
+    let ticker = |name: &str| ticker(&stats, name);
+
+    let report = Report {
+        wall,
+        logical_bytes,
+        flush_write_bytes: ticker("rocksdb.flush.write.bytes"),
+        compact_write_bytes: ticker("rocksdb.compact.write.bytes"),
+        compact_read_bytes: ticker("rocksdb.compact.read.bytes"),
+        on_disk_bytes: dir_size(db_dir, None),
+        sst_bytes: dir_size(db_dir, Some("sst")),
+        blob_bytes: dir_size(db_dir, Some("blob")),
+        table_readers_mem: db.property_int_value("rocksdb.estimate-table-readers-mem").ok().flatten().unwrap_or(0),
+        block_cache_usage: db.property_int_value("rocksdb.block-cache-usage").ok().flatten().unwrap_or(0),
+        hot_read,
+        hot_reads,
+        settle,
+        settle_timed_out,
+        on_disk_before_compact,
+        physical_before_compact,
+        full_compact,
+    };
+    drop(db);
+    report
+}
+
+/// Total size of `dir`, optionally restricted to files with the given extension.
+fn dir_size(dir: &Path, extension: Option<&str>) -> u64 {
+    let Ok(entries) = std::fs::read_dir(dir) else { return 0 };
+    entries
+        .filter_map(Result::ok)
+        .map(|entry| match entry.file_type() {
+            Ok(ft) if ft.is_dir() => dir_size(&entry.path(), extension),
+            Ok(_) => match extension {
+                Some(ext) if entry.path().extension().and_then(|e| e.to_str()) != Some(ext) => 0,
+                _ => entry.metadata().map(|m| m.len()).unwrap_or(0),
+            },
+            Err(_) => 0,
+        })
+        .sum()
+}
+
+fn mib(bytes: u64) -> f64 {
+    bytes as f64 / (1024.0 * 1024.0)
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() < 3 {
+        eprintln!("usage: {} <variant> <db_dir> [blocks] [retention]", args[0]);
+        eprintln!("  variant: legacy-default | opt-default | legacy-hdd | opt-hdd");
+        std::process::exit(2);
+    }
+    let variant = args[1].clone();
+    let db_dir = PathBuf::from(&args[2]);
+    let blocks: u64 = args.get(3).map(|v| v.parse().expect("blocks")).unwrap_or(2_000);
+    let retention: u64 = args.get(4).map(|v| v.parse().expect("retention")).unwrap_or(800);
+
+    if db_dir.exists() {
+        std::fs::remove_dir_all(&db_dir).expect("failed to clear db dir");
+    }
+    std::fs::create_dir_all(&db_dir).expect("failed to create db dir");
+
+    println!("variant={variant} blocks={blocks} retention={retention} dir={}", db_dir.display());
+    let r = run(&variant, &db_dir, blocks, retention);
+
+    let physical = r.flush_write_bytes + r.compact_write_bytes;
+    let amplification = if r.logical_bytes > 0 { physical as f64 / r.logical_bytes as f64 } else { 0.0 };
+    let amplification_before = if r.logical_bytes > 0 { r.physical_before_compact as f64 / r.logical_bytes as f64 } else { 0.0 };
+    let hot_read_us = if r.hot_reads > 0 { r.hot_read.as_secs_f64() * 1e6 / r.hot_reads as f64 } else { 0.0 };
+
+    println!("RESULT variant={variant}");
+    println!("  wall_seconds            {:.1}", r.wall.as_secs_f64());
+    println!("  write_seconds           {:.1}", (r.wall - r.settle).as_secs_f64());
+    println!(
+        "  settle_seconds          {:.1}{}",
+        r.settle.as_secs_f64(),
+        if r.settle_timed_out { " (TIMED OUT - unpaid compaction debt)" } else { "" }
+    );
+    println!("  blocks_per_second       {:.1}", blocks as f64 / (r.wall - r.settle).as_secs_f64());
+    println!("  logical_written_MiB     {:.1}", mib(r.logical_bytes));
+    println!("  flush_written_MiB       {:.1}", mib(r.flush_write_bytes));
+    println!("  compaction_written_MiB  {:.1}", mib(r.compact_write_bytes));
+    println!("  compaction_read_MiB     {:.1}", mib(r.compact_read_bytes));
+    println!("  physical_written_MiB    {:.1}", mib(physical));
+    println!("  write_amplification     {amplification:.2}x  (as-left: {amplification_before:.2}x)");
+    println!("  full_compact_seconds    {:.1}", r.full_compact.as_secs_f64());
+    println!("  on_disk_asleft_MiB      {:.1}", mib(r.on_disk_before_compact));
+    println!("  on_disk_MiB             {:.1}", mib(r.on_disk_bytes));
+    println!("  on_disk_sst_MiB         {:.1}", mib(r.sst_bytes));
+    println!("  on_disk_blob_MiB        {:.1}", mib(r.blob_bytes));
+    println!("  table_readers_mem_MiB   {:.1}", mib(r.table_readers_mem));
+    println!("  block_cache_usage_MiB   {:.1}", mib(r.block_cache_usage));
+    println!("  hot_read_latency_us     {hot_read_us:.1}");
+}

--- a/database/src/access.rs
+++ b/database/src/access.rs
@@ -34,11 +34,51 @@ where
         Self { db, cache: Cache::new(cache_policy), prefix }
     }
 
-    pub fn read_from_cache(&self, key: TKey) -> Option<TData>
+    pub fn read_from_cache(&self, key: &TKey) -> Option<TData> {
+        self.cache.get(key)
+    }
+
+    /// Batch read: serve hits from the app cache, then one RocksDB `multi_get` for the misses.
+    /// Returns one `Option` per input key (`None` = absent). Also returns `(hits, misses)` counts
+    /// so callers can feed `ProcessingCounters` without a second cache probe.
+    pub fn read_many(&self, keys: &[TKey]) -> Result<(Vec<Option<TData>>, u64, u64), StoreError>
     where
-        TKey: Copy + AsRef<[u8]>,
+        TKey: Clone + AsRef<[u8]> + ToString,
+        TData: DeserializeOwned,
     {
-        self.cache.get(&key)
+        let mut results: Vec<Option<TData>> = Vec::with_capacity(keys.len());
+        let mut miss_indices: Vec<usize> = Vec::new();
+        let mut miss_db_keys: Vec<DbKey> = Vec::new();
+        let mut hits = 0u64;
+
+        for (i, key) in keys.iter().enumerate() {
+            if let Some(data) = self.cache.get(key) {
+                results.push(Some(data));
+                hits += 1;
+            } else {
+                results.push(None);
+                miss_indices.push(i);
+                miss_db_keys.push(DbKey::new(&self.prefix, key.clone()));
+            }
+        }
+
+        let misses = miss_indices.len() as u64;
+        if !miss_db_keys.is_empty() {
+            let db_results = self.db.multi_get(miss_db_keys.iter());
+            for (slot, db_result) in miss_indices.into_iter().zip(db_results) {
+                match db_result {
+                    Ok(Some(slice)) => {
+                        let data: TData = bincode::deserialize(&slice)?;
+                        self.cache.insert(keys[slot].clone(), data.clone());
+                        results[slot] = Some(data);
+                    }
+                    Ok(None) => {}
+                    Err(e) => return Err(e.into()),
+                }
+            }
+        }
+
+        Ok((results, hits, misses))
     }
 
     pub fn has(&self, key: TKey) -> Result<bool, StoreError>
@@ -436,7 +476,7 @@ mod tests {
         assert_eq!(result, value);
 
         // Key should now be in the primary cache
-        assert_eq!(access.read_from_cache(key).unwrap(), value);
+        assert_eq!(access.read_from_cache(&key).unwrap(), value);
     }
 
     #[test]

--- a/database/src/db.rs
+++ b/database/src/db.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 
 pub use conn_builder::ConnBuilder;
 use keryx_utils::fd_budget::FDGuard;
-pub use rocksdb_preset::RocksDbPreset;
+pub use rocksdb_preset::{DEFAULT_HDD_RATE_LIMIT_BYTES_PER_SEC, RocksDbPreset, RocksDbResources};
 
 mod conn_builder;
 mod rocksdb_preset;

--- a/database/src/db/conn_builder.rs
+++ b/database/src/db/conn_builder.rs
@@ -1,4 +1,4 @@
-use super::rocksdb_preset::RocksDbPreset;
+use super::rocksdb_preset::{RocksDbPreset, RocksDbResources};
 use crate::db::DB;
 use rocksdb::{DBWithThreadMode, MultiThreaded};
 use std::{path::PathBuf, sync::Arc};
@@ -16,7 +16,7 @@ pub struct ConnBuilder<Path, const STATS_ENABLED: bool, StatsPeriod, FDLimit> {
     stats_period: StatsPeriod,
     preset: RocksDbPreset,
     wal_dir: Option<PathBuf>,
-    cache_budget: Option<usize>,
+    resources: Option<RocksDbResources>,
 }
 
 impl Default for ConnBuilder<Unspecified, false, Unspecified, Unspecified> {
@@ -30,7 +30,7 @@ impl Default for ConnBuilder<Unspecified, false, Unspecified, Unspecified> {
             files_limit: Unspecified,
             preset: RocksDbPreset::Default,
             wal_dir: None,
-            cache_budget: None,
+            resources: None,
         }
     }
 }
@@ -46,7 +46,7 @@ impl<Path, const STATS_ENABLED: bool, StatsPeriod, FDLimit> ConnBuilder<Path, ST
             stats_period: self.stats_period,
             preset: self.preset,
             wal_dir: self.wal_dir,
-            cache_budget: self.cache_budget,
+            resources: self.resources,
         }
     }
     pub fn with_create_if_missing(self, create_if_missing: bool) -> ConnBuilder<Path, STATS_ENABLED, StatsPeriod, FDLimit> {
@@ -68,7 +68,7 @@ impl<Path, const STATS_ENABLED: bool, StatsPeriod, FDLimit> ConnBuilder<Path, ST
             stats_period: self.stats_period,
             preset: self.preset,
             wal_dir: self.wal_dir,
-            cache_budget: self.cache_budget,
+            resources: self.resources,
         }
     }
     pub fn with_preset(self, preset: RocksDbPreset) -> ConnBuilder<Path, STATS_ENABLED, StatsPeriod, FDLimit> {
@@ -77,8 +77,10 @@ impl<Path, const STATS_ENABLED: bool, StatsPeriod, FDLimit> ConnBuilder<Path, ST
     pub fn with_wal_dir(self, wal_dir: Option<PathBuf>) -> ConnBuilder<Path, STATS_ENABLED, StatsPeriod, FDLimit> {
         ConnBuilder { wal_dir, ..self }
     }
-    pub fn with_cache_budget(self, cache_budget: Option<usize>) -> ConnBuilder<Path, STATS_ENABLED, StatsPeriod, FDLimit> {
-        ConnBuilder { cache_budget, ..self }
+    /// Attaches the process-wide RocksDB memory resources (shared block cache + memtable budget).
+    /// Every connection the node opens should be given the *same* instance — see [`RocksDbResources`].
+    pub fn with_resources(self, resources: Option<RocksDbResources>) -> ConnBuilder<Path, STATS_ENABLED, StatsPeriod, FDLimit> {
+        ConnBuilder { resources, ..self }
     }
 }
 
@@ -93,7 +95,7 @@ impl<Path, FDLimit> ConnBuilder<Path, false, Unspecified, FDLimit> {
             stats_period: self.stats_period,
             preset: self.preset,
             wal_dir: self.wal_dir,
-            cache_budget: self.cache_budget,
+            resources: self.resources,
         }
     }
 }
@@ -109,7 +111,7 @@ impl<Path, StatsPeriod, FDLimit> ConnBuilder<Path, true, StatsPeriod, FDLimit> {
             stats_period: Unspecified,
             preset: self.preset,
             wal_dir: self.wal_dir,
-            cache_budget: self.cache_budget,
+            resources: self.resources,
         }
     }
     pub fn with_stats_period(self, stats_period: impl Into<u32>) -> ConnBuilder<Path, true, u32, FDLimit> {
@@ -122,7 +124,7 @@ impl<Path, StatsPeriod, FDLimit> ConnBuilder<Path, true, StatsPeriod, FDLimit> {
             stats_period: stats_period.into(),
             preset: self.preset,
             wal_dir: self.wal_dir,
-            cache_budget: self.cache_budget,
+            resources: self.resources,
         }
     }
 }
@@ -132,7 +134,7 @@ macro_rules! default_opts {
         let mut opts = rocksdb::Options::default();
 
         // Apply the preset configuration (includes parallelism and compaction settings)
-        $self.preset.apply_to_options(&mut opts, $self.parallelism, $self.mem_budget, $self.cache_budget);
+        $self.preset.apply_to_options(&mut opts, $self.parallelism, $self.mem_budget, $self.resources.as_ref());
 
         // Configure WAL directory if specified (for RAM cache / tmpfs)
         // Auto-generate unique subdirectory from database path to avoid conflicts

--- a/database/src/db/rocksdb_preset.rs
+++ b/database/src/db/rocksdb_preset.rs
@@ -3,8 +3,79 @@
 //! This module provides pre-configured RocksDB option sets optimized for different
 //! deployment scenarios.
 
-use rocksdb::Options;
+use rocksdb::{Cache, Options, WriteBufferManager};
 use std::str::FromStr;
+
+/// Values at/above this size are written to blob files instead of being carried inline in the LSM
+/// (RocksDB key-value separation, aka BlobDB).
+///
+/// The node writes one ~228 KB `PomProof` per block at 10 BPS. Inline, every one of those is
+/// rewritten by every compaction that touches its SST — an order-of-magnitude write amplification
+/// on a value that is written once, read rarely (relay re-serve only) and deleted wholesale by the
+/// proof GC. Separated, the LSM carries only a small pointer, so compaction moves metadata instead
+/// of payload and the block cache stops being flushed by proof bytes.
+///
+/// 4 KiB keeps every hot consensus record (ghostdag, reachability, headers, UTXO entries) inline —
+/// only proofs and large block bodies cross the threshold.
+const BLOB_MIN_VALUE_BYTES: u64 = 4 * 1024;
+
+/// ZSTD level for the bottommost level of the HDD preset. Level 22 (the previous value) costs
+/// ~50x the CPU of level 6 for a few percent of size on already-compact binary records, and on a
+/// spinning disk the bottleneck is compaction throughput, not the last few percent of space.
+const HDD_BOTTOMMOST_ZSTD_LEVEL: i32 = 6;
+
+/// Default background-write rate limit for the HDD preset, in bytes/s.
+///
+/// The logical write rate of a 10-BPS node is ~2.5 MB/s; with compaction amplification the
+/// physical rate is several times that. The previous 12 MB/s limit sat below the sustained
+/// requirement, so compaction debt accumulated until RocksDB stalled writes. 48 MB/s still
+/// smooths I/O spikes on a spinning disk while leaving compaction able to keep up.
+/// Override with `--rocksdb-rate-limit-mb`.
+pub const DEFAULT_HDD_RATE_LIMIT_BYTES_PER_SEC: u64 = 48 * 1024 * 1024;
+
+/// Memory resources shared by **every** RocksDB instance the process opens (meta, active
+/// consensus, staging consensus, utxoindex).
+///
+/// Both RocksDB objects held here are handles over a single shared allocation, so passing one
+/// `RocksDbResources` to all connections gives the process **one** block-cache budget and **one**
+/// memtable budget. Building them per-connection (the previous behavior) multiplied whatever the
+/// operator asked for by the number of open databases — `--rocksdb-cache-size=2048` allocated 8 GB,
+/// and the HDD preset's 256 MB write buffer could reach 1.5 GB of memtables *per database*.
+#[derive(Clone)]
+pub struct RocksDbResources {
+    block_cache: Cache,
+    /// Dedicated blob cache so ~228 KB PoM proofs do not evict hot SST blocks from `block_cache`.
+    blob_cache: Cache,
+    write_buffer_manager: WriteBufferManager,
+    rate_limit_bytes_per_sec: Option<u64>,
+}
+
+// The RocksDB handles held here are opaque, so the only thing worth printing is the one tunable.
+impl std::fmt::Debug for RocksDbResources {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RocksDbResources").field("rate_limit_bytes_per_sec", &self.rate_limit_bytes_per_sec).finish_non_exhaustive()
+    }
+}
+
+impl RocksDbResources {
+    /// * `block_cache_bytes` — total block cache across all DBs (holds data blocks plus, since the
+    ///   presets set `cache_index_and_filter_blocks`, the SST index and filter blocks).
+    /// * `write_buffer_bytes` — total memtable allowance across all DBs. RocksDB flushes early
+    ///   rather than stalling writers when the budget is reached (`allow_stall = false`).
+    /// * `rate_limit_bytes_per_sec` — background-write rate limit (HDD presets only).
+    ///
+    /// The blob cache is sized at 1/4 of the block cache (min 64 MB) so proof bytes stay out of the
+    /// hot-block LRU without needing a separate operator flag.
+    pub fn new(block_cache_bytes: usize, write_buffer_bytes: usize, rate_limit_bytes_per_sec: Option<u64>) -> Self {
+        let blob_cache_bytes = (block_cache_bytes / 4).max(64 * 1024 * 1024);
+        Self {
+            block_cache: Cache::new_lru_cache(block_cache_bytes),
+            blob_cache: Cache::new_lru_cache(blob_cache_bytes),
+            write_buffer_manager: WriteBufferManager::new_write_buffer_manager(write_buffer_bytes, false),
+            rate_limit_bytes_per_sec,
+        }
+    }
+}
 
 /// Available RocksDB configuration presets
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -12,6 +83,7 @@ pub enum RocksDbPreset {
     /// Default configuration - balanced for general use on SSD/NVMe
     /// - 64MB write buffer
     /// - Standard compression
+    /// - BlobDB for large values (keeps PoM proofs out of LSM compaction)
     /// - Optimized for fast storage
     #[default]
     Default,
@@ -20,11 +92,16 @@ pub enum RocksDbPreset {
     /// - 256MB write buffer (4x default)
     /// - Aggressive compression (LZ4 + ZSTD)
     /// - BlobDB enabled for large values
-    /// - Rate limiting to prevent I/O spikes
+    /// - Autotuned rate limiting to prevent I/O spikes
     /// - Optimized for sequential writes and reduced write amplification
     ///
     /// Recommended for archival nodes on HDD storage.
     Hdd,
+
+    /// HDD tuned for queue-depth-1 transports (USB Bulk-Only Transport / no NCQ).
+    /// One flush + one compaction thread, larger readaheads, all files kept open.
+    /// Prefer plain `hdd` on native SATA where NCQ makes concurrency free.
+    HddQd1,
 }
 
 impl FromStr for RocksDbPreset {
@@ -34,7 +111,8 @@ impl FromStr for RocksDbPreset {
         match s.to_lowercase().as_str() {
             "default" => Ok(Self::Default),
             "hdd" => Ok(Self::Hdd),
-            _ => Err(format!("Unknown RocksDB preset: '{}'. Valid options: default, hdd", s)),
+            "hdd-qd1" | "hdd_qd1" => Ok(Self::HddQd1),
+            _ => Err(format!("Unknown RocksDB preset: '{}'. Valid options: default, hdd, hdd-qd1", s)),
         }
     }
 }
@@ -44,6 +122,7 @@ impl std::fmt::Display for RocksDbPreset {
         match self {
             Self::Default => write!(f, "default"),
             Self::Hdd => write!(f, "hdd"),
+            Self::HddQd1 => write!(f, "hdd-qd1"),
         }
     }
 }
@@ -54,26 +133,61 @@ impl RocksDbPreset {
     /// # Arguments
     /// * `opts` - RocksDB options to configure
     /// * `parallelism` - Number of background threads
-    /// * `mem_budget` - Memory budget (only used for Default preset, HDD uses fixed 256MB)
-    pub fn apply_to_options(&self, opts: &mut Options, parallelism: usize, mem_budget: usize, cache_budget: Option<usize>) {
+    /// * `mem_budget` - Memtable memory budget (only used for Default preset, HDD uses fixed 256MB)
+    /// * `resources` - Process-wide shared cache / memtable budget. `None` (tests, tooling) keeps
+    ///   the per-connection defaults.
+    pub fn apply_to_options(&self, opts: &mut Options, parallelism: usize, mem_budget: usize, resources: Option<&RocksDbResources>) {
         match self {
-            Self::Default => self.apply_default(opts, parallelism, mem_budget),
-            Self::Hdd => self.apply_hdd(opts, parallelism, cache_budget),
+            Self::Default => self.apply_default(opts, parallelism, mem_budget, resources),
+            Self::Hdd => self.apply_hdd(opts, parallelism, resources),
+            Self::HddQd1 => self.apply_hdd_qd1(opts, resources),
         }
     }
 
     /// Apply default preset configuration
-    fn apply_default(&self, opts: &mut Options, parallelism: usize, mem_budget: usize) {
+    fn apply_default(&self, opts: &mut Options, parallelism: usize, mem_budget: usize, resources: Option<&RocksDbResources>) {
         if parallelism > 1 {
             opts.increase_parallelism(parallelism as i32);
         }
 
         // Use the provided memory budget (typically 64MB)
         opts.optimize_level_style_compaction(mem_budget);
+
+        // `optimize_level_style_compaction` leaves `max_write_buffer_number` at 6, so the effective
+        // memtable ceiling is 6x the write buffer it just derived (`mem_budget / 4`). Pin it to a
+        // value that still allows a flush to overlap incoming writes without hoarding memory.
+        opts.set_max_write_buffer_number(4);
+
+        let mut block_opts = rocksdb::BlockBasedOptions::default();
+        block_opts.set_bloom_filter(10.0, false);
+        block_opts.set_format_version(5);
+        if let Some(resources) = resources {
+            // Index and filter blocks are only charged against the block cache when there *is* a
+            // shared cache to charge them to. Without this, they live outside every budget and grow
+            // with the database (the node keeps up to `fd_budget / 2` SSTs open per consensus DB).
+            block_opts.set_cache_index_and_filter_blocks(true);
+            block_opts.set_pin_l0_filter_and_index_blocks_in_cache(true);
+            block_opts.set_block_cache(&resources.block_cache);
+        }
+        opts.set_block_based_table_factory(&block_opts);
+
+        // Key-value separation: see `BLOB_MIN_VALUE_BYTES`.
+        opts.set_enable_blob_files(true);
+        opts.set_min_blob_size(BLOB_MIN_VALUE_BYTES);
+        opts.set_blob_file_size(64 * 1024 * 1024);
+        opts.set_blob_compression_type(rocksdb::DBCompressionType::Lz4);
+        opts.set_enable_blob_gc(true);
+        opts.set_blob_gc_age_cutoff(0.9);
+        opts.set_blob_gc_force_threshold(0.2);
+
+        if let Some(resources) = resources {
+            opts.set_blob_cache(&resources.blob_cache);
+            opts.set_write_buffer_manager(&resources.write_buffer_manager);
+        }
     }
 
     /// Apply HDD preset configuration (HDD-optimized settings)
-    fn apply_hdd(&self, opts: &mut Options, parallelism: usize, cache_budget: Option<usize>) {
+    fn apply_hdd(&self, opts: &mut Options, parallelism: usize, resources: Option<&RocksDbResources>) {
         if parallelism > 1 {
             opts.increase_parallelism(parallelism as i32);
         }
@@ -89,6 +203,11 @@ impl RocksDbPreset {
         // because optimize_level_style_compaction() internally overrides it to size/4
         opts.set_write_buffer_size(write_buffer_size);
 
+        // ...and cap how many of those 256MB buffers may exist at once. The value left behind by
+        // `optimize_level_style_compaction` is 6, i.e. up to 1.5 GB of memtables *per database* —
+        // multiplied by every DB the node opens. 3 keeps room for a flush to overlap writes.
+        opts.set_max_write_buffer_number(3);
+
         // LSM Tree Structure - Optimized for large (4TB+) archives
         // 256 MB SST files reduce file count dramatically (500K → 16K files for 4TB)
         opts.set_target_file_size_base(256 * 1024 * 1024); // 256 MB SST files
@@ -97,8 +216,11 @@ impl RocksDbPreset {
         opts.set_level_compaction_dynamic_level_bytes(true); // Minimize space amplification
 
         // Compaction settings
-        // Trigger compaction when L0 has just 1 file (minimize write amplification)
-        opts.set_level_zero_file_num_compaction_trigger(1);
+        // Compacting L0 at every single file minimizes read amplification but forces a compaction
+        // per flush — the opposite of what a spinning disk wants, since each pass rewrites data
+        // that the next flush would have let it batch. 4 trades a little read amplification for
+        // meaningfully less write amplification.
+        opts.set_level_zero_file_num_compaction_trigger(4);
 
         // Prioritize compacting older/smaller files first
         use rocksdb::CompactionPri;
@@ -113,23 +235,24 @@ impl RocksDbPreset {
         // Set default compression to LZ4 (fast)
         opts.set_compression_type(DBCompressionType::Lz4);
 
-        // Enable bottommost level compression with maximum ZSTD level
+        // Enable bottommost level compression with ZSTD
         opts.set_bottommost_compression_type(DBCompressionType::Zstd);
 
-        // ZSTD compression options for bottommost level
-        // Larger dictionaries (64 KB) improve compression on large archives
-        opts.set_compression_options(
-            -1,        // window_bits (let ZSTD choose optimal)
-            22,        // level (maximum compression)
-            0,         // strategy (default)
-            64 * 1024, // dict_bytes (64 KB dictionary)
+        // ZSTD options for the bottommost level only, so the level choice cannot leak into the LZ4
+        // levels. Larger dictionaries (64 KB) improve compression on large archives.
+        opts.set_bottommost_compression_options(
+            -1,                        // window_bits (let ZSTD choose optimal)
+            HDD_BOTTOMMOST_ZSTD_LEVEL, // level
+            0,                         // strategy (default)
+            64 * 1024,                 // dict_bytes (64 KB dictionary)
+            true,                      // enabled
         );
 
         // Train ZSTD dictionaries on 8 MB of sample data (~125x dictionary size)
-        opts.set_zstd_max_train_bytes(8 * 1024 * 1024);
+        opts.set_bottommost_zstd_max_train_bytes(8 * 1024 * 1024, true);
 
         // Block-based table options for better caching
-        use rocksdb::{BlockBasedOptions, Cache};
+        use rocksdb::BlockBasedOptions;
         let mut block_opts = BlockBasedOptions::default();
 
         // Partitioned Bloom filters (18 bits per key for better false-positive rate)
@@ -140,40 +263,80 @@ impl RocksDbPreset {
 
         // Cache index and filter blocks in block cache for faster queries
         block_opts.set_cache_index_and_filter_blocks(true);
+        block_opts.set_pin_l0_filter_and_index_blocks_in_cache(true);
 
-        // Block cache: Default 256MB (safe for low-RAM systems)
-        // Can be scaled via ram-scale or overridden via --rocksdb-cache-size
-        let default_cache_size = 256 * 1024 * 1024; // 256MB
-        let cache_size = cache_budget.unwrap_or(default_cache_size);
-        let cache = Cache::new_lru_cache(cache_size);
-        block_opts.set_block_cache(&cache);
+        // Block cache: the process-wide shared cache when one was provided, otherwise a local
+        // 256MB one (safe for low-RAM systems). Sized via --ram-scale / --rocksdb-cache-size.
+        match resources {
+            Some(resources) => block_opts.set_block_cache(&resources.block_cache),
+            None => block_opts.set_block_cache(&Cache::new_lru_cache(256 * 1024 * 1024)),
+        }
 
         // Set block size (256KB - better for sequential HDD reads)
         block_opts.set_block_size(256 * 1024);
 
         opts.set_block_based_table_factory(&block_opts);
 
-        // Rate limiting: prevent I/O spikes on HDD
-        // 12 MB/s rate limit for background writes
-        opts.set_ratelimiter(12 * 1024 * 1024, 100_000, 10);
+        // Rate limiting: prevent I/O spikes on HDD. Autotuned adapts when the disk is shared vs
+        // dedicated, while still honouring the configured ceiling (`--rocksdb-rate-limit-mb`).
+        let rate_limit =
+            resources.and_then(|resources| resources.rate_limit_bytes_per_sec).unwrap_or(DEFAULT_HDD_RATE_LIMIT_BYTES_PER_SEC);
+        opts.set_auto_tuned_ratelimiter(rate_limit as i64, 100_000, 10);
 
         // Enable BlobDB for large values (reduces write amplification)
         opts.set_enable_blob_files(true);
-        opts.set_min_blob_size(512); // Only values >512 bytes go to blob files
+        opts.set_min_blob_size(BLOB_MIN_VALUE_BYTES);
         opts.set_blob_file_size(256 * 1024 * 1024); // 256MB blob files
         opts.set_blob_compression_type(DBCompressionType::Zstd); // Compress blobs
         opts.set_enable_blob_gc(true); // Enable garbage collection
         opts.set_blob_gc_age_cutoff(0.9); // GC blobs when 90% old
         opts.set_blob_gc_force_threshold(0.1); // Force GC at 10% garbage
         opts.set_blob_compaction_readahead_size(8 * 1024 * 1024); // 8 MB blob readahead
+
+        if let Some(resources) = resources {
+            opts.set_blob_cache(&resources.blob_cache);
+            opts.set_write_buffer_manager(&resources.write_buffer_manager);
+        }
+    }
+
+    /// HDD + queue-depth-1 constraints (USB BOT / no NCQ). See `docs/storage-performance.md`.
+    fn apply_hdd_qd1(&self, opts: &mut Options, resources: Option<&RocksDbResources>) {
+        // Start from the HDD preset (single background parallelism), then constrain concurrency.
+        self.apply_hdd(opts, 1, resources);
+
+        // One flush + one compaction. `increase_parallelism(num_cpus)` would queue N background jobs
+        // against a device that can serve one command at a time, starving foreground reads.
+        opts.set_max_background_jobs(2);
+        opts.set_max_subcompactions(1);
+
+        // Fewer, larger reads: at ~8 ms per seek, a 16 MB sequential read costs about what two random
+        // 4 KiB reads do.
+        opts.set_compaction_readahead_size(16 * 1024 * 1024);
+        opts.set_blob_compaction_readahead_size(16 * 1024 * 1024);
+        opts.set_blob_file_size(512 * 1024 * 1024);
+
+        // Keep every SST open: each reopen is another command round-trip. Index/filter memory stays
+        // bounded because the preset charges it to the shared block cache.
+        opts.set_max_open_files(-1);
+
+        opts.set_optimize_filters_for_hits(true);
+        opts.set_avoid_unnecessary_blocking_io(true);
+
+        // Sync incrementally instead of letting dirty pages accumulate into one burst that would hold
+        // the single command slot for hundreds of milliseconds.
+        opts.set_bytes_per_sync(1024 * 1024);
+        opts.set_wal_bytes_per_sync(1024 * 1024);
     }
 
     /// Get a human-readable description of the preset
     pub fn description(&self) -> &'static str {
         match self {
-            Self::Default => "Default preset - balanced for SSD/NVMe (64MB write buffer, standard compression)",
+            Self::Default => "Default preset - balanced for SSD/NVMe (64MB write buffer, BlobDB for large values)",
             Self::Hdd => {
-                "HDD preset - optimized for hard disk drives (256MB write buffer, BlobDB, aggressive compression, rate limiting)"
+                "HDD preset - optimized for hard disk drives (256MB write buffer, BlobDB, aggressive compression, autotuned rate limiting)"
+            }
+            Self::HddQd1 => {
+                "HDD queue-depth-1 preset - for USB BOT / no-NCQ disks (single compaction thread, large readahead, all files open)"
             }
         }
     }
@@ -183,6 +346,7 @@ impl RocksDbPreset {
         match self {
             Self::Default => "General purpose nodes on SSD/NVMe storage",
             Self::Hdd => "Archival nodes on HDD storage (--archival flag recommended)",
+            Self::HddQd1 => "Nodes whose datadir sits behind USB Bulk-Only Transport or another QD1 link",
         }
     }
 
@@ -190,7 +354,9 @@ impl RocksDbPreset {
     pub fn memory_requirements(&self) -> &'static str {
         match self {
             Self::Default => "~4GB minimum, scales with --ram-scale",
-            Self::Hdd => "~4GB minimum (256MB write buffer + 256MB cache + overhead), 8GB+ recommended for public RPC",
+            Self::Hdd | Self::HddQd1 => {
+                "~4GB minimum (256MB write buffer + 256MB cache + overhead), 8GB+ recommended for public RPC"
+            }
         }
     }
 }
@@ -205,6 +371,20 @@ mod tests {
         assert_eq!(RocksDbPreset::from_str("Default").unwrap(), RocksDbPreset::Default);
         assert_eq!(RocksDbPreset::from_str("hdd").unwrap(), RocksDbPreset::Hdd);
         assert_eq!(RocksDbPreset::from_str("HDD").unwrap(), RocksDbPreset::Hdd);
+        assert_eq!(RocksDbPreset::from_str("hdd-qd1").unwrap(), RocksDbPreset::HddQd1);
         assert!(RocksDbPreset::from_str("unknown").is_err());
+    }
+
+    /// Both presets must be applicable with and without shared resources (tests and tooling open
+    /// connections without them).
+    #[test]
+    fn test_presets_apply_with_and_without_resources() {
+        let resources = RocksDbResources::new(16 * 1024 * 1024, 16 * 1024 * 1024, Some(1024 * 1024));
+        for preset in [RocksDbPreset::Default, RocksDbPreset::Hdd, RocksDbPreset::HddQd1] {
+            let mut opts = Options::default();
+            preset.apply_to_options(&mut opts, 2, 64 * 1024 * 1024, None);
+            let mut opts = Options::default();
+            preset.apply_to_options(&mut opts, 2, 64 * 1024 * 1024, Some(&resources));
+        }
     }
 }

--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -19,6 +19,6 @@ pub mod prelude {
     pub use super::key::DbKey;
     pub use super::set_access::{CachedDbSetAccess, DbSetAccess, ReadLock};
     pub use super::writer::{BatchDbWriter, DbWriter, DirectDbWriter, DirectWriter, MemoryWriter};
-    pub use db::{ConnBuilder, DB, RocksDbPreset, delete_db};
+    pub use db::{ConnBuilder, DB, DEFAULT_HDD_RATE_LIMIT_BYTES_PER_SEC, RocksDbPreset, RocksDbResources, delete_db};
     pub use errors::{StoreError, StoreErrorPredicates, StoreResult, StoreResultExt, StoreResultUnitExt};
 }

--- a/docs/storage-performance.md
+++ b/docs/storage-performance.md
@@ -1,0 +1,221 @@
+# Storage and Memory Performance
+
+This document records where a Keryx node's disk, RAM and CPU actually go, what was changed to reduce
+that footprint, and the measurements behind both. It exists so the next person tuning this does not
+have to re-derive the analysis — and so the numbers can be challenged with a reproducible benchmark
+rather than argued from intuition.
+
+Everything described here is **node-local policy**. None of it touches consensus, the wire format,
+or any DAA-gated constant: a patched and an unpatched node accept exactly the same blocks. The one
+change that would require network coordination is called out explicitly at the end.
+
+## 1. Where the resources go
+
+### Disk: the PoM proof dominates everything else
+
+Each post-H4 block carries a `PomProof` recording the full `K = 256`-step possession walk, every step
+with its Merkle path under the tier root — about **228 KB per block** (see the rationale on
+`POM_PROOF_RETENTION_DEPTH` in `consensus/core/src/config/params.rs`).
+
+At 10 BPS that is:
+
+| | |
+|---|---|
+| Logical proof writes | ~2.3 MB/s → **~197 GB/day** |
+| Live proof set (retention 25 000) | ~6 GB, in continuous churn (written and deleted at the same rate) |
+
+Before the change every one of those 228 KB values lived **inline in the LSM**, so each was rewritten
+by every compaction that touched its SST. Two consequences, both measured in §3:
+
+- write amplification multiplied the 2.3 MB/s into tens of MB/s of physical disk traffic;
+- the hot, small consensus records (ghostdag, reachability, headers, UTXO entries) shared their SSTs
+  and their block cache with proof bytes, so ordinary lookups paid for the churn.
+
+### RAM: three budgets that were not budgets
+
+1. **The PoM proof cache was sized by item count.** `pom_proof_store` used the shared header-data
+   policy — `Count(10_000)`. At ~228 KB per proof that reaches **~2.3 GB**, and because item counts
+   are not scaled by `--ram-scale`, the cache ignored that flag entirely.
+2. **Cache and memtable budgets were per-connection.** The node opens at least four RocksDB instances
+   (meta, active consensus, staging consensus, utxoindex) and each `build()` allocated its own cache.
+   `--rocksdb-cache-size=2048` therefore allocated **8 GB**, and the HDD preset's 256 MB write buffer
+   with `max_write_buffer_number` left at 6 could reach **1.5 GB of memtables per database**.
+3. **Index and filter blocks lived outside every budget.** The default preset configured no block
+   cache and no `cache_index_and_filter_blocks`, so the index/filter memory of up to `fd_budget / 2`
+   open SSTs per consensus DB grew with the database and was accounted nowhere.
+
+### CPU: the threads exist, the work is serial
+
+The rayon pools already default to one thread per core (`block_processors_num_threads: 0` means
+"rayon default"). Low CPU utilisation is not a pool-sizing problem; it is a lack of parallel width
+plus cores parked on I/O:
+
+- the virtual processor is single-consumer by construction — one virtual state at a time, with
+  `par_iter` only *within* a block, over transactions;
+- `commit_header` serialises reachability staging and holds relations/statuses write locks across the
+  `db.write(batch)` call, so on a slow disk every core waits on one commit;
+- `apply_balance_diff`, `apply_age_diff` and `windowed_production_prefix` do random point reads inside
+  the virtual-commit critical path (see §5 — these are **not** fixed).
+
+## 2. What changed
+
+| Area | Change | File |
+|---|---|---|
+| Disk | BlobDB key-value separation in the `default` preset, `min_blob_size = 4 KiB` — proofs leave the LSM, hot records stay inline | `database/src/db/rocksdb_preset.rs` |
+| RAM | `RocksDbResources`: one block cache + one `WriteBufferManager` shared by every DB the process opens | `database/src/db/rocksdb_preset.rs`, `keryxd/src/daemon.rs` |
+| RAM | `pom_proof_store` switched from `Count(10_000)` to a byte-tracked 64 MB budget that honours `--ram-scale` | `consensus/src/consensus/storage.rs` |
+| RAM | `cache_index_and_filter_blocks` + `pin_l0_filter_and_index_blocks_in_cache` when a shared cache exists | `database/src/db/rocksdb_preset.rs` |
+| RAM | Explicit `max_write_buffer_number` (4 default / 3 HDD) instead of the 6 left by `optimize_level_style_compaction` | `database/src/db/rocksdb_preset.rs` |
+| CPU | HDD bottommost ZSTD level 22 → 6, applied via `set_bottommost_compression_options` so it cannot leak into the LZ4 levels | `database/src/db/rocksdb_preset.rs` |
+| I/O | HDD `level_zero_file_num_compaction_trigger` 1 → 4 | `database/src/db/rocksdb_preset.rs` |
+| I/O | HDD background write rate limit 12 → 48 MB/s (autotuned), tunable via `--rocksdb-rate-limit-mb` | `database/src/db/rocksdb_preset.rs`, `keryxd/src/args.rs` |
+| I/O | Dedicated blob cache (¼ block cache) so proofs do not evict hot SST blocks | `database/src/db/rocksdb_preset.rs` |
+| I/O | Optional `--rocksdb-preset=hdd-qd1` for USB BOT / no-NCQ | `database/src/db/rocksdb_preset.rs` |
+| RAM | `address_balance` / `age_buckets` byte-budget caches (128 MB × `--ram-scale`) + MultiGet RMW | `consensus/src/consensus/storage.rs`, `database/src/access.rs` |
+| RAM | SeekForPrev result cache on `windowed_production_prefix` (64 MB × `--ram-scale`) | `consensus/src/model/stores/windowed_production_prefix.rs` |
+| CPU | Parallel Merkle path checks in `verify_pom_proof` / `verify_pom_proof_v2` (rayon, native) | `consensus/core/src/pom.rs` |
+
+The rate limiter deserves a note: at 12 MB/s it sat *below* the sustained physical write rate of a
+10-BPS node, so compaction debt accumulated until RocksDB stalled writes. §3 shows this directly —
+`legacy-hdd` produced identical numbers over USB and over SATA, because the limiter, not the disk,
+was the bottleneck in both.
+
+## 3. Benchmark
+
+`database/examples/rocksdb_workload_bench.rs` replays the node's dominant write pattern: one 228 KB
+proof per block, the small hot consensus records alongside it, point reads of recent hot keys, and
+the proof-GC delete of the block leaving the retention window — all in a single `WriteBatch`, as
+`commit_header` and the virtual processor do.
+
+```bash
+cargo run --release -p keryx-database --example rocksdb_workload_bench -- \
+    <legacy-default|opt-default|legacy-hdd|opt-hdd|hdd-qd1|opt-hdd-periodic> <db_dir> [blocks] [retention]
+```
+
+The `legacy-*` variants carry the pre-change option sets copied verbatim from the v1.4.0 source; the
+`opt-*` variants call the real production code path (`RocksDbPreset::apply_to_options`), so the
+comparison is against shipped behaviour, not a reconstruction.
+
+The bench forces a full compaction at the end and reports the footprint both as the run left it and
+after that compaction. This matters: a configuration that defers compaction shows a flattering
+amplification and an inflated footprint, and the two are not comparable until the deferred work is
+paid.
+
+### Results — HDD (WD Red WD30EFZX, SATA), 12 000 blocks, 2.7 GB logical
+
+| variant | write amplification | physical written | time to steady state | final on disk |
+|---|---:|---:|---:|---:|
+| `legacy-default` | 3.31x | 8 949 MiB | 197 s | 894 MiB |
+| `opt-default` | 2.85x | 7 712 MiB | 169 s | 1 000 MiB |
+| `legacy-hdd` | 1.59x | 4 291 MiB | 415 s | 893 MiB |
+| **`opt-hdd`** | **1.54x** | 4 155 MiB | **124 s** | 893 MiB |
+| `hdd-qd1` | 1.35x | **3 643 MiB** | 147 s | 892 MiB |
+
+**3.4x faster to the same steady state, at the same final footprint.** The mechanism is visible in
+the file breakdown: the LSM shrank from 894 MiB of SST to 1.7 MiB, with 891 MiB in blob files. That
+is the set compaction sweeps repeatedly and that competes with hot keys for cache.
+
+Two results worth keeping:
+
+- **`opt-hdd` peaks at ~2x the live set before compaction reclaims it** (1 751 MiB as-left → 893 MiB
+  after a forced compaction). This is deferred blob garbage, not a footprint regression: with ~99.8%
+  of bytes in blobs the LSM holds almost no SST, RocksDB's compaction triggers are SST-size based, and
+  blob GC only runs inside an SST compaction. The effect is **exaggerated by the synthetic workload** —
+  a real node holds gigabytes of small-value SST (UTXO set, headers, ghostdag, reachability) whose
+  ordinary churn keeps compactions firing. `opt-hdd-periodic` confirms periodic compaction eliminates
+  the peak, at **+48% physical writes**; that trade was judged not worth making by default.
+- **The worse the transport, the more the optimisation pays.** Over a USB Bulk-Only-Transport bridge
+  `legacy-default` reached 6.86x amplification and the optimisation cut 48% of wall time; over SATA the
+  same optimisation cuts 14%. `legacy-hdd` scored identically on both, because its 12 MB/s limiter
+  bounded it below either transport.
+
+### Results — SSD (NVMe), same workload
+
+| variant | write amplification | physical written | SST | blob |
+|---|---:|---:|---:|---:|
+| `legacy-default` | 3.81x | 10 291 MiB | 1 021 MiB | 0 |
+| `opt-default` | 2.84x | 7 673 MiB | 33 MiB | 967 MiB |
+
+Compaction read traffic dropped 47% (9 272 → 4 958 MiB).
+
+## 4. Hardware reference points
+
+Measured with an unbuffered tester (`FILE_FLAG_NO_BUFFERING | FILE_FLAG_WRITE_THROUGH`, 4096-aligned,
+single-threaded — i.e. queue depth 1), 2 GB file:
+
+| | WD Red WD30EFZX (SATA) | WD Red (USB BOT) | Seagate ST2000DM008 (USB BOT) |
+|---|---:|---:|---:|
+| Sequential read | 112.9 MB/s | 115.1 MB/s | 85.1 MB/s |
+| Sequential write | 96.0 MB/s | 113.4 MB/s | 62.9 MB/s |
+| Random 4K read | 112 IOPS / 8.9 ms | 131 IOPS / 7.6 ms | 72 IOPS / 13.9 ms |
+| Random 4K write | 553 IOPS / 1.8 ms † | 493 IOPS / 2.0 ms † | 75 IOPS / 13.4 ms (p95 76 ms) |
+
+† Not mechanical. Sub-2 ms on a 5400-rpm drive is impossible; these writes are absorbed by the drive's
+DRAM cache because the write-through flag is not honoured end to end. Do not plan against them.
+
+Conclusions that generalise:
+
+- **~110 random IOPS is the budget on a spinning disk**, and it is a mechanical limit (seek +
+  rotational latency), not a transport one. At queue depth 1, USB BOT measured *the same* as native
+  SATA — BOT only costs when I/O is concurrent, which is exactly what RocksDB background compaction
+  plus foreground reads produce.
+- Numbers above are short-stroked over a 2 GB file; a real multi-hundred-GB datadir seeks farther and
+  will be slower.
+- **SMR drives are disqualified.** The ST2000DM008 is shingled; its 76 ms p95 random write is the
+  signature of the persistent cache zone filling. RocksDB compaction is precisely the sustained
+  random-write workload SMR handles worst.
+- **USB enclosures are a reliability risk, not just a performance one.** During sustained write load
+  the drive dropped off the bus entirely (`disk` event 51 ×7, `Ntfs` event 140 — *"failed to flush data
+  to the transaction log. Corruption may occur"*) and did not return without a physical power cycle. A
+  node whose datadir vanishes mid-write is a corruption scenario no tuning addresses. Prefer direct
+  SATA; if USB is unavoidable, use a single-bay enclosure with its own supply and no hub.
+
+## 5. Operator guidance
+
+For a spinning disk, the preset choice matters more than anything else — `legacy-default` on HDD wrote
+**18.5 GB for 2.7 GB of data** over USB. Always set the preset:
+
+```
+keryxd --rocksdb-preset=hdd \
+       --rocksdb-cache-size=8192 \
+       --ram-scale=2.0 \
+       --rocksdb-wal-dir=/path/on/ssd
+```
+
+- `--rocksdb-cache-size` is now a **process-wide** budget. Before the change it was allocated per
+  database, so this flag delivered roughly 4x what was asked for; the value can now be trusted.
+  With ~110 IOPS on the disk, every cache hit saves ~9 ms — this is the single largest lever on
+  spinning storage, and RAM is the cheapest way to buy it.
+- `--rocksdb-wal-dir` on an SSD removes all log writes from the spinning disk's queue.
+- `--rocksdb-rate-limit-mb` (default 48) throttles background writes. Lower it if the disk is shared;
+  raise it if compaction cannot keep up and writes stall.
+
+## 6. Remaining / follow-ups
+
+**Read path in the virtual-commit critical section — mitigated (not eliminated).**
+`address_balance` / `age_buckets` now use a 128 MB byte-budget cache (scaled by `--ram-scale`)
+instead of `Count(10_000)`, and RMW batches go through RocksDB `MultiGet`. The production-prefix
+store caches `SeekForPrev` results within a block and invalidates on `extend`/collapse/`clear`.
+Hit/miss rates are logged every 10s by the consensus monitor
+(`Virtual-index cache: balance …; age …; production-prefix …`). Measure on a real HDD IBD before
+claiming the ~22 BPS ceiling is gone — cold-start and large UTXO churn can still miss.
+
+**Parallel PoM Merkle verification — done.** `verify_pom_proof` / `verify_pom_proof_v2` run path
+checks via rayon on native targets (walk transitions stay sequential). IBD still skips PoM verify.
+
+**Queue-depth-1 tuning — shipped as `--rocksdb-preset=hdd-qd1`.** Prefer plain `hdd` on SATA/NCQ;
+use `hdd-qd1` only for USB BOT / no-NCQ.
+
+**Blob cache + autotuned rate limiter — done** in both Default and HDD presets (blob cache = ¼ of
+the process-wide block cache, min 64 MB).
+
+**Lowering `POM_PROOF_RETENTION_DEPTH`.** Dropping it from 25 000 to ~5 000 would cut the live proof
+store from ~6 GB to ~1.2 GB and the churn proportionally. This is **not** a consensus rule, but it
+**cannot be changed unilaterally**: a peer decides whether to skip proof verification using its own
+copy of the constant (`protocol/flows/src/ibd/flow.rs`, `protocol/flows/src/v8/request_block_bodies.rs`),
+so a node that GCs earlier and serves a proofless block inside the window its peer still expects gets
+rejected with *"PoM possession proof missing"*. It requires a coordinated network release.
+
+**Reducing `POM_WALK_STEPS` / `POM_OPENINGS`.** These are the root cause of the 228 KB proof size, but
+changing them is a consensus fork requiring miner lockstep. Recorded as a candidate for a future
+H-fork, not a tuning option.

--- a/keryxd/src/args.rs
+++ b/keryxd/src/args.rs
@@ -97,6 +97,7 @@ pub struct Args {
     pub rocksdb_preset: Option<String>,
     pub rocksdb_wal_dir: Option<String>,
     pub rocksdb_cache_size: Option<usize>,
+    pub rocksdb_rate_limit_mb: Option<usize>,
 }
 
 impl Default for Args {
@@ -152,6 +153,7 @@ impl Default for Args {
             rocksdb_preset: None,
             rocksdb_wal_dir: None,
             rocksdb_cache_size: None,
+            rocksdb_rate_limit_mb: None,
         }
     }
 }
@@ -424,8 +426,9 @@ a large RAM (~64GB) can set this value to ~3.0-4.0 and gain superior performance
                 .env("KERYXD_ROCKSDB_PRESET")
                 .require_equals(true)
                 .value_parser(clap::value_parser!(String))
-                .help("RocksDB configuration preset: 'default' (SSD/NVMe) or 'hdd' (optimized for hard disk drives with BlobDB, compression, rate limiting). \
-                       HDD preset recommended for archival nodes on HDD storage (see docs/archival.md).")
+                .help("RocksDB configuration preset: 'default' (SSD/NVMe), 'hdd' (spinning disk with BlobDB, compression, autotuned rate limiting), \
+                       or 'hdd-qd1' (USB BOT / no-NCQ — single compaction thread). HDD presets recommended for archival nodes on HDD storage \
+                       (see docs/storage-performance.md).")
         )
         .arg(
             Arg::new("rocksdb-wal-dir")
@@ -442,8 +445,19 @@ a large RAM (~64GB) can set this value to ~3.0-4.0 and gain superior performance
                 .env("KERYXD_ROCKSDB_CACHE_SIZE")
                 .require_equals(true)
                 .value_parser(clap::value_parser!(usize))
-                .help("RocksDB block cache size in MB. Default: 256MB for HDD preset (scales with --ram-scale). \
-                       Increase for public RPC nodes with heavy query loads. Example: --rocksdb-cache-size=2048 for 2GB cache.")
+                .help("RocksDB block cache size in MB, shared by all databases the node opens. Default: 256MB \
+                       (scales with --ram-scale). Increase for public RPC nodes with heavy query loads. \
+                       Example: --rocksdb-cache-size=2048 for 2GB cache.")
+        )
+        .arg(
+            Arg::new("rocksdb-rate-limit-mb")
+                .long("rocksdb-rate-limit-mb")
+                .env("KERYXD_ROCKSDB_RATE_LIMIT_MB")
+                .require_equals(true)
+                .value_parser(clap::value_parser!(usize))
+                .help("RocksDB background write rate limit in MB/s (HDD / hdd-qd1 presets only). Default: 48. Lower it if the \
+                       disk is shared with other workloads; raise it if compaction cannot keep up (write stalls). \
+                       See docs/storage-performance.md.")
         )
         ;
 
@@ -536,6 +550,7 @@ impl Args {
             rocksdb_preset: m.get_one::<String>("rocksdb-preset").cloned().or(defaults.rocksdb_preset),
             rocksdb_wal_dir: m.get_one::<String>("rocksdb-wal-dir").cloned().or(defaults.rocksdb_wal_dir),
             rocksdb_cache_size: m.get_one::<usize>("rocksdb-cache-size").cloned().or(defaults.rocksdb_cache_size),
+            rocksdb_rate_limit_mb: m.get_one::<usize>("rocksdb-rate-limit-mb").cloned().or(defaults.rocksdb_rate_limit_mb),
         };
 
         if arg_match_unwrap_or::<bool>(&m, "enable-mainnet-mining", false) {

--- a/keryxd/src/daemon.rs
+++ b/keryxd/src/daemon.rs
@@ -11,7 +11,7 @@ use keryx_consensus_notify::{root::ConsensusNotificationRoot, service::NotifySer
 use keryx_core::{core::Core, debug, info, warn};
 use keryx_core::{kaspad_env::version, task::tick::TickService};
 use keryx_database::{
-    prelude::{CachePolicy, DbWriter, DirectDbWriter, RocksDbPreset},
+    prelude::{CachePolicy, DbWriter, DirectDbWriter, RocksDbPreset, RocksDbResources},
     registry::DatabaseStorePrefixes,
 };
 use keryx_grpc_server::service::GrpcService;
@@ -213,10 +213,23 @@ pub fn create_core(args: Args, fd_total_budget: i32) -> (Arc<Core>, Arc<RpcCoreS
     create_core_with_runtime(&rt, &args, fd_total_budget)
 }
 
+/// Baseline process-wide RocksDB block cache, before `--ram-scale`.
+const BASE_ROCKSDB_CACHE_BYTES: usize = 256 * 1024 * 1024;
+/// Floor for the process-wide block cache, however low `--ram-scale` is set.
+const MIN_ROCKSDB_CACHE_BYTES: usize = 64 * 1024 * 1024;
+/// Baseline process-wide memtable budget, before `--ram-scale`. Sized per preset: the HDD preset
+/// uses a 256 MB write buffer per database, so it needs headroom the default preset does not.
+const BASE_MEMTABLE_BYTES_DEFAULT: usize = 256 * 1024 * 1024;
+const BASE_MEMTABLE_BYTES_HDD: usize = 768 * 1024 * 1024;
+/// Floors for the memtable budget. Must stay at/above one write buffer per preset or flushes
+/// would trigger on every write.
+const MIN_MEMTABLE_BYTES_DEFAULT: usize = 64 * 1024 * 1024;
+const MIN_MEMTABLE_BYTES_HDD: usize = 512 * 1024 * 1024;
+
 /// Configure RocksDB parameters from CLI arguments.
 ///
-/// Returns: (preset, cache_budget, wal_directory)
-fn configure_rocksdb(args: &Args) -> (RocksDbPreset, Option<usize>, Option<PathBuf>) {
+/// Returns: (preset, shared resources, wal_directory)
+fn configure_rocksdb(args: &Args) -> (RocksDbPreset, Option<RocksDbResources>, Option<PathBuf>) {
     // Parse preset
     let preset = if let Some(preset_str) = &args.rocksdb_preset {
         match preset_str.parse::<RocksDbPreset>() {
@@ -235,23 +248,40 @@ fn configure_rocksdb(args: &Args) -> (RocksDbPreset, Option<usize>, Option<PathB
         RocksDbPreset::Default
     };
 
-    // Calculate cache budget for HDD preset
-    let cache_budget = if matches!(preset, RocksDbPreset::Hdd) {
-        if let Some(cache_mb) = args.rocksdb_cache_size {
-            let cache_bytes = cache_mb * 1024 * 1024;
-            info!("Custom RocksDB cache size: {} MB", cache_mb);
-            Some(cache_bytes)
-        } else {
-            let base_cache = 256 * 1024 * 1024;
-            let scaled_cache = (base_cache as f64 * args.ram_scale) as usize;
-            let min_cache = 64 * 1024 * 1024;
-            let final_cache = scaled_cache.max(min_cache);
-            info!("RocksDB cache size: {} MB (scaled by ram-scale)", final_cache / 1024 / 1024);
-            Some(final_cache)
+    // Process-wide memory budgets. Both are shared by every database the node opens (meta, active
+    // consensus, staging consensus, utxoindex) — building them per-connection multiplied whatever
+    // the operator asked for by the number of open databases.
+    let cache_bytes = match args.rocksdb_cache_size {
+        Some(cache_mb) => {
+            info!("Custom RocksDB cache size: {} MB (shared by all databases)", cache_mb);
+            cache_mb * 1024 * 1024
         }
-    } else {
-        None
+        None => {
+            let scaled = (BASE_ROCKSDB_CACHE_BYTES as f64 * args.ram_scale) as usize;
+            let final_cache = scaled.max(MIN_ROCKSDB_CACHE_BYTES);
+            info!("RocksDB cache size: {} MB (shared by all databases, scaled by ram-scale)", final_cache / 1024 / 1024);
+            final_cache
+        }
     };
+
+    let (base_memtable, min_memtable) = match preset {
+        RocksDbPreset::Hdd | RocksDbPreset::HddQd1 => (BASE_MEMTABLE_BYTES_HDD, MIN_MEMTABLE_BYTES_HDD),
+        RocksDbPreset::Default => (BASE_MEMTABLE_BYTES_DEFAULT, MIN_MEMTABLE_BYTES_DEFAULT),
+    };
+    let memtable_bytes = ((base_memtable as f64 * args.ram_scale) as usize).max(min_memtable);
+    info!("RocksDB memtable budget: {} MB (shared by all databases)", memtable_bytes / 1024 / 1024);
+
+    // Background-write rate limiting applies to the HDD presets only.
+    let rate_limit = matches!(preset, RocksDbPreset::Hdd | RocksDbPreset::HddQd1).then(|| {
+        let limit = args
+            .rocksdb_rate_limit_mb
+            .map(|mb| (mb * 1024 * 1024) as u64)
+            .unwrap_or(keryx_database::prelude::DEFAULT_HDD_RATE_LIMIT_BYTES_PER_SEC);
+        info!("RocksDB background write rate limit: {} MB/s", limit / 1024 / 1024);
+        limit
+    });
+
+    let resources = Some(RocksDbResources::new(cache_bytes, memtable_bytes, rate_limit));
 
     // Setup WAL directory if specified
     let wal_dir = args.rocksdb_wal_dir.as_ref().map(|custom_wal_dir| {
@@ -260,7 +290,7 @@ fn configure_rocksdb(args: &Args) -> (RocksDbPreset, Option<usize>, Option<PathB
         wal_path
     });
 
-    (preset, cache_budget, wal_dir)
+    (preset, resources, wal_dir)
 }
 
 /// Create [`Core`] instance with supplied [`Args`] and [`Runtime`].
@@ -286,7 +316,7 @@ pub fn create_core_with_runtime(runtime: &Runtime, args: &Args, fd_total_budget:
     };
 
     // Configure RocksDB parameters
-    let (rocksdb_preset, cache_budget, wal_dir) = configure_rocksdb(args);
+    let (rocksdb_preset, resources, wal_dir) = configure_rocksdb(args);
 
     // Make sure args forms a valid set of properties
     if let Err(err) = validate_args(args) {
@@ -391,7 +421,7 @@ do you confirm? (answer y/n or pass --yes to the Keryxd command line to confirm 
         .with_files_limit(META_DB_FILE_LIMIT)
         .with_preset(rocksdb_preset)
         .with_wal_dir(wal_dir.clone())
-        .with_cache_budget(cache_budget)
+        .with_resources(resources.clone())
         .build()
         .unwrap();
 
@@ -409,7 +439,7 @@ do you confirm? (answer y/n or pass --yes to the Keryxd command line to confirm 
                     .with_files_limit(1)
                     .with_preset(rocksdb_preset)
                     .with_wal_dir(wal_dir.clone())
-                    .with_cache_budget(cache_budget)
+                    .with_resources(resources.clone())
                     .build()
                     .unwrap();
 
@@ -464,7 +494,7 @@ Do you confirm? (y/n)";
                         .with_files_limit(10)
                         .with_preset(rocksdb_preset)
                         .with_wal_dir(wal_dir.clone())
-                        .with_cache_budget(cache_budget)
+                        .with_resources(resources.clone())
                         .build()
                         .unwrap();
 
@@ -528,7 +558,7 @@ Do you confirm? (y/n)";
             .with_files_limit(META_DB_FILE_LIMIT)
             .with_preset(rocksdb_preset)
             .with_wal_dir(wal_dir.clone())
-            .with_cache_budget(cache_budget)
+            .with_resources(resources.clone())
             .build()
             .unwrap();
     }
@@ -588,7 +618,7 @@ Do you confirm? (y/n)";
         mining_rules.clone(),
         rocksdb_preset,
         wal_dir.clone(),
-        cache_budget,
+        resources.clone(),
     ));
     let consensus_manager = Arc::new(ConsensusManager::new(consensus_factory));
     let consensus_monitor = Arc::new(ConsensusMonitor::new(processing_counters.clone(), tick_service.clone()));
@@ -618,7 +648,7 @@ Do you confirm? (y/n)";
             .with_files_limit(utxo_files_limit)
             .with_preset(rocksdb_preset)
             .with_wal_dir(wal_dir.clone())
-            .with_cache_budget(cache_budget)
+            .with_resources(resources.clone())
             .build()
             .unwrap();
         let utxoindex = UtxoIndexProxy::new(UtxoIndex::new(consensus_manager.clone(), utxoindex_db).unwrap());


### PR DESCRIPTION
## Summary

Node-local **storage / RAM / CPU** optimizations for sustaining 10 BPS with ~228 KB/block PoM proofs. **No consensus rule changes**, no wire-format changes, no DAA gates. Patched and unpatched nodes accept the same blocks.

This PR does **not** include the Electron launcher or unrelated gRPC log-level tweaks.

Primary reference: `docs/storage-performance.md` (workload model, measured results, operator flags, known remaining bottlenecks).

---

## Context for automated reviewers / coding agents

### Problem model

At 10 BPS each block carries a `PomProof` (~**228 KB**, `K=256` Merkle openings). That alone is ~2.3 MB/s logical proof writes (~197 GB/day) with a live retention set ~6 GB in continuous churn.

Before this PR:

1. **Proofs lived inline in the LSM** → every compaction rewrote them (high write amplification) and polluted SST block cache with cold proof bytes.
2. **Cache / memtable budgets were per RocksDB connection** (meta + active consensus + staging + utxoindex) → `--rocksdb-cache-size=2048` could allocate ~8 GB; HDD write buffers could reach ~1.5 GB memtables *per DB*.
3. **`pom_proof_store` was `Count(10_000)`** (~2.3 GB) and ignored `--ram-scale`.
4. **Index/filter blocks were outside every budget** (no `cache_index_and_filter_blocks`).
5. **HDD rate limit 12 MB/s** sat below sustained physical write need → compaction debt / write stalls.
6. **Virtual-commit hot path** did serial random point reads (`address_balance`, `age_buckets`, `windowed_production_prefix` SeekForPrev) on HDD-hostile I/O.
7. **PoM Merkle path checks** in `verify_pom_proof*` were serial despite rayon pools already existing.

### What this PR changes (by layer)

#### A. RocksDB presets (`database/src/db/rocksdb_preset.rs`)

| Knob | Behavior |
|---|---|
| BlobDB | `min_blob_size = 4 KiB` on `default` **and** HDD presets — proofs/bodies → blob files; hot consensus records stay inline |
| `RocksDbResources` | One shared **block cache**, **blob cache** (¼ block cache, min 64 MB), and **WriteBufferManager** for all DBs in the process |
| Index/filter | `cache_index_and_filter_blocks` + pin L0 filter/index when shared cache is present |
| Memtables | Cap `max_write_buffer_number` (4 default / 3 HDD) instead of leaving RocksDB’s `optimize_level_style_compaction` default of 6 |
| HDD compression | Bottommost ZSTD **22 → 6** via `set_bottommost_compression_options` (must not leak into LZ4 upper levels) |
| HDD L0 | `level_zero_file_num_compaction_trigger` 1 → 4 |
| HDD rate limit | Background writes **12 → 48 MB/s** (autotuned), override with `--rocksdb-rate-limit-mb` |
| `hdd-qd1` | New preset: single flush/compaction thread, larger readaheads, keep files open — for USB BOT / no-NCQ only |

#### B. Daemon wiring (`keryxd/src/daemon.rs`, `keryxd/src/args.rs`)

- Builds one `RocksDbResources` from `--rocksdb-cache-size` / `--ram-scale` and passes it into every DB open.
- Separate shared memtable floors for default vs HDD/hdd-qd1.
- New flag: `--rocksdb-rate-limit-mb` (`KERYXD_ROCKSDB_RATE_LIMIT_MB`).
- Help text points at `docs/storage-performance.md`.

#### C. Consensus store caches (`consensus/src/consensus/storage.rs` + stores)

- `pom_proof_store`: **byte-tracked ~64 MB × ram-scale** (was count-based 10k).
- `address_balance` / `age_buckets`: **128 MB × ram-scale** byte budgets.
- `windowed_production_prefix`: **SeekForPrev result cache** (~64 MB × ram-scale), invalidated on extend/collapse/clear (path-independent consensus preserved).
- Header/ghostdag cache policy tweaks where measured useful.

#### D. Read-path batching (`database/src/access.rs`, virtual processor)

- MultiGet-style RMW helpers so virtual-commit balance/age updates issue batched RocksDB reads instead of N serial `get`s when possible.
- Instrumentation counters in `consensus/core/src/api/counters.rs` + monitor logging for cache hit/miss on the virtual-index path (diagnosis only; not consensus).

#### E. CPU width on PoM verify (`consensus/core/src/pom.rs`)

- Parallel Merkle path verification via rayon in `verify_pom_proof` / `verify_pom_proof_v2` (native). Verification semantics unchanged.

#### F. Repro / docs

- `database/examples/rocksdb_workload_bench.rs` — comparative workload (legacy vs opt presets) measuring write amp, footprint, throughput, hot-read latency.
- `docs/storage-performance.md` — full analysis, measured tables (generic HDD/SSD models), operator guidance, **explicit list of remaining bottlenecks** (virtual-commit random reads still dominate on spinning disks after write-path wins).

---

## Explicit non-goals / invariants (agents: do not “fix” these)

- **No** fork activation / DAA constant edits.
- **No** PoM proof format, retention depth, or consensus validity changes.
- **No** path-dependent consensus state: prefix caches must remain re-derivable; invalidation on mutate is mandatory.
- Presets are **policy**, not consensus — peers do not negotiate them.
- Do **not** reintroduce per-connection caches/memtables; that regresses RAM by ×(open DBs).
- Do **not** put bottommost ZSTD options on upper LZ4 levels.
- Do **not** lower HDD rate limit below sustained ~10 BPS physical write need without documenting stall risk.

---

## Operator flags (quick)

```text
# SSD/NVMe (default preset now also uses BlobDB + shared budgets)
keryxd --rocksdb-preset=default --rocksdb-cache-size=2048 --ram-scale=2

# Spinning disk / archival
keryxd --rocksdb-preset=hdd --rocksdb-cache-size=8192 --ram-scale=2 --rocksdb-rate-limit-mb=48

# USB BOT / no NCQ only
keryxd --rocksdb-preset=hdd-qd1 ...
```

---

## Test plan

- [ ] `cargo check -p keryx-database -p keryx-consensus -p keryxd`
- [ ] `cargo nextest run -p keryx-consensus-core -- pom`
- [ ] `cargo nextest run -p keryx-consensus -- windowed_production`
- [ ] `cargo nextest run -p keryx-database`
- [ ] Optional: `cargo run --release -p keryx-database --example rocksdb_workload_bench -- opt-hdd <tmp_dir> 1000 250`
- [ ] Smoke: start node with `--rocksdb-preset=hdd` and confirm logs show shared cache/memtable/rate-limit lines; sync/relay still advances
- [ ] Confirm two nodes (patched vs unpatched) still accept the same tips on a shared peer set (policy-only change)


Made with [Cursor](https://cursor.com)