### PR TITLE
fix(p2p): exempt official bootstrap peer from automatic bans

### DIFF
--- a/components/connectionmanager/src/lib.rs
+++ b/components/connectionmanager/src/lib.rs
@@ -27,6 +27,18 @@ use tokio::{
 const PING_TIMEOUT_BAN_THRESHOLD: u32 = 3;
 const PING_TIMEOUT_WINDOW: Duration = Duration::from_secs(600); // 10 minutes
 
+fn canonical_ip(ip: IpAddr) -> IpAddr {
+    match ip {
+        IpAddr::V6(ip) => ip.to_ipv4_mapped().map(IpAddr::V4).unwrap_or(IpAddr::V6(ip)),
+        ip => ip,
+    }
+}
+
+fn is_fixed_seed_ip(seeders: &[&str], ip: IpAddr) -> bool {
+    let ip = canonical_ip(ip);
+    seeders.iter().filter_map(|seeder| seeder.parse().ok()).any(|seeder| canonical_ip(seeder) == ip)
+}
+
 struct PingTimeoutRecord {
     count: u32,
     window_start: Instant,
@@ -37,6 +49,7 @@ pub struct ConnectionManager {
     outbound_target: usize,
     inbound_limit: usize,
     dns_seeders: &'static [&'static str],
+    ban_exempt_seeders: &'static [&'static str],
     default_port: u16,
     address_manager: Arc<ParkingLotMutex<AddressManager>>,
     connection_requests: TokioMutex<HashMap<SocketAddr, ConnectionRequest>>,
@@ -64,6 +77,7 @@ impl ConnectionManager {
         outbound_target: usize,
         inbound_limit: usize,
         dns_seeders: &'static [&'static str],
+        ban_exempt_seeders: &'static [&'static str],
         default_port: u16,
         address_manager: Arc<ParkingLotMutex<AddressManager>>,
     ) -> Arc<Self> {
@@ -77,6 +91,7 @@ impl ConnectionManager {
             force_next_iteration: tx,
             shutdown_signal: SingleTrigger::new(),
             dns_seeders,
+            ban_exempt_seeders,
             default_port,
             ping_timeout_tracker: Default::default(),
         });
@@ -319,23 +334,34 @@ impl ConnectionManager {
     /// Bans the given IP and disconnects from all the peers with that IP.
     ///
     /// _GO-KASPAD: BanByIP_
-    pub async fn ban(&self, ip: IpAddr) {
+    pub async fn ban(&self, ip: IpAddr) -> bool {
+        let ip = canonical_ip(ip);
         if self.ip_has_permanent_connection(ip).await {
-            return;
+            return false;
         }
+        self.address_manager.lock().ban(ip.into());
         for peer in self.p2p_adaptor.active_peers() {
-            if peer.net_address().ip() == ip {
+            if canonical_ip(peer.net_address().ip()) == ip {
                 self.p2p_adaptor.terminate(peer.key()).await;
             }
         }
-        self.address_manager.lock().ban(ip.into());
+        true
+    }
+
+    pub async fn ban_automatically(&self, ip: IpAddr) -> bool {
+        let ip = canonical_ip(ip);
+        if is_fixed_seed_ip(self.ban_exempt_seeders, ip) || self.ip_has_permanent_connection(ip).await {
+            return false;
+        }
+        self.ban(ip).await
     }
 
     /// Records a ping timeout for the given IP. Bans it after PING_TIMEOUT_BAN_THRESHOLD
     /// timeouts within PING_TIMEOUT_WINDOW — targets phantom nodes that flood inbound slots
     /// by connecting silently then immediately reconnecting after each timeout.
     pub async fn record_ping_timeout(&self, ip: IpAddr) {
-        if self.ip_has_permanent_connection(ip).await {
+        let ip = canonical_ip(ip);
+        if is_fixed_seed_ip(self.ban_exempt_seeders, ip) || self.ip_has_permanent_connection(ip).await {
             return;
         }
         let should_ban = {
@@ -354,9 +380,8 @@ impl ConnectionManager {
                 false
             }
         };
-        if should_ban {
+        if should_ban && self.ban_automatically(ip).await {
             warn!("Banning peer {} after {} ping timeouts within {:?}", ip, PING_TIMEOUT_BAN_THRESHOLD, PING_TIMEOUT_WINDOW);
-            self.ban(ip).await;
         }
     }
 
@@ -372,6 +397,21 @@ impl ConnectionManager {
 
     /// Returns whether the given IP has some permanent request.
     pub async fn ip_has_permanent_connection(&self, ip: IpAddr) -> bool {
-        self.connection_requests.lock().await.iter().any(|(address, request)| request.is_permanent && address.ip() == ip)
+        let ip = canonical_ip(ip);
+        self.connection_requests.lock().await.iter().any(|(address, request)| request.is_permanent && canonical_ip(address.ip()) == ip)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fixed_seed_ip_is_ban_exempt() {
+        let seeders = &["seed.example.net", "192.0.2.1"];
+
+        assert!(is_fixed_seed_ip(seeders, "192.0.2.1".parse().unwrap()));
+        assert!(is_fixed_seed_ip(seeders, "::ffff:192.0.2.1".parse().unwrap()));
+        assert!(!is_fixed_seed_ip(seeders, "127.0.0.1".parse().unwrap()));
     }
 }

--- a/consensus/core/src/config/params.rs
+++ b/consensus/core/src/config/params.rs
@@ -825,6 +825,7 @@ impl From<Params> for OverrideParams {
 #[derive(Clone, Debug)]
 pub struct Params {
     pub dns_seeders: &'static [&'static str],
+    pub automatic_ban_exemptions: &'static [&'static str],
     pub net: NetworkId,
     pub genesis: GenesisBlock,
 
@@ -1153,6 +1154,7 @@ impl Params {
     pub fn override_params(self, overrides: OverrideParams) -> Self {
         Self {
             dns_seeders: self.dns_seeders,
+            automatic_ban_exemptions: self.automatic_ban_exemptions,
             net: self.net,
             genesis: self.genesis.clone(),
 
@@ -1288,11 +1290,14 @@ impl From<NetworkId> for Params {
     }
 }
 
+const MAINNET_BOOTSTRAP_PEER: &str = "141.95.35.181";
+
 pub const MAINNET_PARAMS: Params = Params {
     // A literal IP is valid here: the seeder string is resolved through
     // `(seeder, default_port).to_socket_addrs()`, which parses an IP address before
     // falling back to a DNS lookup. It acts as a fixed bootstrap peer on port 22111.
-    dns_seeders: &["seed.keryx-labs.com", "141.95.35.181"],
+    dns_seeders: &["seed.keryx-labs.com", MAINNET_BOOTSTRAP_PEER],
+    automatic_ban_exemptions: &[MAINNET_BOOTSTRAP_PEER],
     net: NetworkId::new(NetworkType::Mainnet),
     genesis: GENESIS,
     timestamp_deviation_tolerance: TIMESTAMP_DEVIATION_TOLERANCE,
@@ -1430,6 +1435,7 @@ pub const MAINNET_PARAMS: Params = Params {
 
 pub const TESTNET_PARAMS: Params = Params {
     dns_seeders: &[],
+    automatic_ban_exemptions: &[],
     net: NetworkId::with_suffix(NetworkType::Testnet, 10),
     genesis: TESTNET_GENESIS,
     timestamp_deviation_tolerance: TIMESTAMP_DEVIATION_TOLERANCE,
@@ -1538,6 +1544,7 @@ pub const TESTNET_PARAMS: Params = Params {
 
 pub const SIMNET_PARAMS: Params = Params {
     dns_seeders: &[],
+    automatic_ban_exemptions: &[],
     net: NetworkId::new(NetworkType::Simnet),
     genesis: SIMNET_GENESIS,
     timestamp_deviation_tolerance: TIMESTAMP_DEVIATION_TOLERANCE,
@@ -1608,6 +1615,7 @@ pub const SIMNET_PARAMS: Params = Params {
 
 pub const DEVNET_PARAMS: Params = Params {
     dns_seeders: &[],
+    automatic_ban_exemptions: &[],
     net: NetworkId::new(NetworkType::Devnet),
     genesis: DEVNET_GENESIS,
     timestamp_deviation_tolerance: TIMESTAMP_DEVIATION_TOLERANCE,

--- a/keryxd/src/daemon.rs
+++ b/keryxd/src/daemon.rs
@@ -668,6 +668,7 @@ Do you confirm? (y/n)";
         outbound_target,
         inbound_limit,
         dns_seeders,
+        config.automatic_ban_exemptions,
         config.default_p2p_port(),
         p2p_tower_counters.clone(),
     ));

--- a/protocol/flows/src/flow_context.rs
+++ b/protocol/flows/src/flow_context.rs
@@ -41,6 +41,7 @@ use keryx_utils::iter::IterExtensions;
 use keryx_utils::networking::PeerId;
 use parking_lot::{Mutex, RwLock};
 use std::collections::HashMap;
+use std::net::IpAddr;
 use std::time::Instant;
 use std::{collections::hash_map::Entry, fmt::Display};
 use std::{
@@ -406,6 +407,13 @@ impl FlowContext {
 
     pub fn connection_manager(&self) -> Option<Arc<ConnectionManager>> {
         self.connection_manager.read().clone()
+    }
+
+    pub async fn ban_peer_automatically(&self, ip: IpAddr) -> bool {
+        match self.connection_manager() {
+            Some(connection_manager) => connection_manager.ban_automatically(ip).await,
+            None => false,
+        }
     }
 
     pub fn consensus(&self) -> ConsensusInstance {

--- a/protocol/flows/src/ibd/flow.rs
+++ b/protocol/flows/src/ibd/flow.rs
@@ -102,8 +102,9 @@ impl IbdFlow {
                         info!("IBD with peer {} completed with error: {}", self.router, e);
                         if e.is_ban_worthy() {
                             let peer_ip = self.router.net_address().ip();
-                            self.ctx.address_manager.lock().ban(peer_ip.into());
-                            warn!("Banned peer {} for ban-worthy protocol violation: {}", self.router, e);
+                            if self.ctx.ban_peer_automatically(peer_ip).await {
+                                warn!("Banned peer {} for ban-worthy protocol violation: {}", self.router, e);
+                            }
                         }
                         return Err(e);
                     }
@@ -302,8 +303,9 @@ impl IbdFlow {
             // `highest_known_syncer_chain_hash`). So it means there's a finality conflict.
             //
             let peer_ip = self.router.net_address().ip();
-            self.ctx.address_manager.lock().ban(peer_ip.into());
-            warn!("Banned peer {} for finality conflict with local pruning point", self.router);
+            if self.ctx.ban_peer_automatically(peer_ip).await {
+                warn!("Banned peer {} for finality conflict with local pruning point", self.router);
+            }
             return Err(ProtocolError::Other("peer is in a finality conflict with the local pruning point"));
         }
 
@@ -335,8 +337,12 @@ impl IbdFlow {
                     // consensus has matured for long enough (and not recently synced). This is mostly a spam-protector
                     // since subsequent checks identify these violations as well
                     let peer_ip = self.router.net_address().ip();
-                    self.ctx.address_manager.lock().ban(peer_ip.into());
-                    warn!("Banned peer {} for IBD spam (peer has no known block while local consensus is up to date)", self.router);
+                    if self.ctx.ban_peer_automatically(peer_ip).await {
+                        warn!(
+                            "Banned peer {} for IBD spam (peer has no known block while local consensus is up to date)",
+                            self.router
+                        );
+                    }
                     return Err(ProtocolError::Other(
                         "peer has no known block but local consensus appears to be up to date, this is most likely a spam attempt",
                     ));
@@ -447,8 +453,9 @@ impl IbdFlow {
         // Check if past pruning points violate finality of current consensus
         if self.ctx.consensus().session().await.async_are_pruning_points_violating_finality(pruning_points.clone()).await {
             let peer_ip = self.router.net_address().ip();
-            self.ctx.address_manager.lock().ban(peer_ip.into());
-            warn!("Banned peer {} for sending pruning points that violate finality", self.router);
+            if self.ctx.ban_peer_automatically(peer_ip).await {
+                warn!("Banned peer {} for sending pruning points that violate finality", self.router);
+            }
             return Err(ProtocolError::Other("pruning points are violating finality"));
         }
 

--- a/protocol/flows/src/service.rs
+++ b/protocol/flows/src/service.rs
@@ -22,6 +22,7 @@ pub struct P2pService {
     outbound_target: usize,
     inbound_limit: usize,
     dns_seeders: &'static [&'static str],
+    ban_exempt_seeders: &'static [&'static str],
     default_port: u16,
     shutdown: SingleTrigger,
     counters: Arc<TowerConnectionCounters>,
@@ -36,6 +37,7 @@ impl P2pService {
         outbound_target: usize,
         inbound_limit: usize,
         dns_seeders: &'static [&'static str],
+        ban_exempt_seeders: &'static [&'static str],
         default_port: u16,
         counters: Arc<TowerConnectionCounters>,
     ) -> Self {
@@ -48,6 +50,7 @@ impl P2pService {
             outbound_target,
             inbound_limit,
             dns_seeders,
+            ban_exempt_seeders,
             default_port,
             counters,
         }
@@ -76,6 +79,7 @@ impl AsyncService for P2pService {
             self.outbound_target,
             self.inbound_limit,
             self.dns_seeders,
+            self.ban_exempt_seeders,
             self.default_port,
             self.flow_context.address_manager.clone(),
         );

--- a/protocol/flows/src/v7/blockrelay/flow.rs
+++ b/protocol/flows/src/v7/blockrelay/flow.rs
@@ -87,8 +87,9 @@ impl Flow for HandleRelayInvsFlow {
         match self.start_impl().await {
             Err(e) if e.is_ban_worthy() => {
                 let peer_ip = self.router.net_address().ip();
-                self.ctx.address_manager.lock().ban(peer_ip.into());
-                warn!("Banned peer {} for ban-worthy protocol violation: {}", self.router, e);
+                if self.ctx.ban_peer_automatically(peer_ip).await {
+                    warn!("Banned peer {} for ban-worthy protocol violation: {}", self.router, e);
+                }
                 Err(e)
             }
             res => res,
@@ -165,15 +166,26 @@ impl HandleRelayInvsFlow {
                 self.rd_violation_count += 1;
                 if self.rd_violation_count >= RD_VIOLATION_BAN_THRESHOLD {
                     let peer_ip = self.router.net_address().ip();
-                    warn!(
-                        "Peer {} reached {} R&D violations (last: block {} — {}) — banning",
-                        peer_ip, self.rd_violation_count, block.hash(), reason
-                    );
-                    if let Some(cm) = self.ctx.connection_manager() {
-                        cm.ban(peer_ip).await;
+                    if self.ctx.ban_peer_automatically(peer_ip).await {
+                        warn!(
+                            "Peer {} reached {} R&D violations (last: block {} — {}) — banning",
+                            peer_ip,
+                            self.rd_violation_count,
+                            block.hash(),
+                            reason
+                        );
+                    } else {
+                        warn!(
+                            "Peer {} reached {} R&D violations (last: block {} — {}) — disconnecting without a ban",
+                            peer_ip,
+                            self.rd_violation_count,
+                            block.hash(),
+                            reason
+                        );
                     }
                     return Err(ProtocolError::OtherOwned(format!(
-                        "peer banned after {} blocks missing R&D allocation", self.rd_violation_count
+                        "peer disconnected after {} blocks missing R&D allocation",
+                        self.rd_violation_count
                     )));
                 }
                 warn!(

--- a/rpc/service/src/service.rs
+++ b/rpc/service/src/service.rs
@@ -1139,7 +1139,9 @@ NOTE: This error usually indicates an RPC conversion error between the node and 
             if connection_manager.ip_has_permanent_connection(ip).await {
                 return Err(RpcError::IpHasPermanentConnection(request.ip));
             }
-            connection_manager.ban(ip).await;
+            if !connection_manager.ban(ip).await {
+                return Err(RpcError::IpHasPermanentConnection(request.ip));
+            }
         } else {
             return Err(RpcError::NoConnectionManager);
         }


### PR DESCRIPTION
## Summary

- define the official mainnet bootstrap peer in one constant
- explicitly exempt that peer from automatic bans
- route IBD, block-relay, R&D, and ping-timeout bans through the centralized policy
- preserve manual RPC bans and permanent-peer behavior
- normalize IPv4-mapped IPv6 addresses before comparing peers
- persist bans before awaiting peer disconnection

## Problem

The official fixed bootstrap peer was stored as an ordinary address. Several protocol flows also wrote directly to the address-manager ban store, bypassing the connection manager's permanent-peer checks.

This could place the bootstrap peer on the 24-hour ban list during IBD or block relay, potentially preventing nodes from reconnecting to it.

## Behavior

The official bootstrap peer can still be disconnected when it sends invalid data, and the invalid data is still rejected. Automatic violations no longer persist a ban for its IP.

Manual RPC bans remain unrestricted. Disabling DNS discovery does not disable the exemption.

## Testing

- `cargo test --package keryx-connectionmanager --package keryx-p2p-flows --package keryx-rpc-service --package keryx-consensus-core --lib`
  - 59 passed
  - 2 ignored
  - 0 failed
- `cargo check --package keryxd`
- `cargo fmt --package keryx-connectionmanager -- --check`
- `git diff --check`

This PR was made by AI