### PR TITLE
fix(consensus): bound service ledger snapshots

### DIFF
--- a/consensus/core/src/collateral.rs
+++ b/consensus/core/src/collateral.rs
@@ -185,7 +185,7 @@ pub struct ServiceMiss {
     pub burned: Vec<EscrowClaim>,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 struct PendingRequest {
     tier: u8,
     max_tokens: u32,
@@ -195,14 +195,14 @@ struct PendingRequest {
 
 /// One cohort audit: every declared miner of the request's tier must respond before the window
 /// closes; the silent ones are struck when it does.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 struct Audit {
     cohort: Vec<Hash>,
     responded: Vec<Hash>,
     window_end_daa: u64,
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 struct StrikeEntry {
     count: u32,
     last_daa: u64,
@@ -212,7 +212,7 @@ struct StrikeEntry {
 /// is a pure function of the accepted requests/responses stream and the cohort function, with
 /// BTreeMap ordering; any node folding the last [`SERVICE_LEDGER_HORIZON_DAA`] of chain from an
 /// empty ledger reaches the identical state. Never persisted.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct ServiceLedger {
     pending: std::collections::BTreeMap<[u8; 32], PendingRequest>,
     strikes: std::collections::BTreeMap<Hash, StrikeEntry>,

--- a/consensus/src/pipeline/virtual_processor/service_bond.rs
+++ b/consensus/src/pipeline/virtual_processor/service_bond.rs
@@ -43,8 +43,13 @@ fn verified_responder(resp: &AiResponsePayload) -> Option<Hash> {
     Some(escrow_miner_key(&r.escrow_pubkey))
 }
 
-/// Retained per-chain-block ledger snapshots; reorgs deeper than this fall back to a horizon refold.
-const SERVICE_SNAPSHOT_CAP: usize = 4_096;
+/// Sparse checkpoints cover twice the service horizon. Reorgs replay from the nearest checkpoint;
+/// deeper restores fall back to the existing bounded refold.
+#[cfg(not(test))]
+const SERVICE_SNAPSHOT_INTERVAL: u64 = 4_096;
+#[cfg(test)]
+const SERVICE_SNAPSHOT_INTERVAL: u64 = 2;
+const SERVICE_SNAPSHOT_CAP: usize = (2 * SERVICE_LEDGER_HORIZON_DAA / SERVICE_SNAPSHOT_INTERVAL) as usize + 2;
 
 /// RAM-only service-ledger state folded along the committed selected chain.
 #[derive(Default)]
@@ -287,18 +292,28 @@ impl VirtualStateProcessor {
         // A reorg (or restore) drops queued misses above the common ancestor with the chain.
         sync.queue.retain(|(idx, _, _)| *idx <= common);
         if sync.tip != Some(common) {
-            let restored = sync.snapshots.get(&common).cloned();
-            sync.ledger = match restored {
-                Some(ledger) => ledger,
+            let checkpoint = sync.snapshots.range(..=common).next_back().map(|(&idx, ledger)| (idx, ledger.clone()));
+            match checkpoint {
+                Some((checkpoint_idx, ledger)) => {
+                    sync.ledger = ledger;
+                    sync.queue.retain(|(idx, _, _)| *idx <= checkpoint_idx);
+                    for idx in checkpoint_idx + 1..=common {
+                        let h = sc.get_by_index(idx).unwrap();
+                        let daa = self.headers_store.get_daa_score(h).unwrap();
+                        for miss in self.fold_service_chain_block(&mut sync.ledger, &*sc, h) {
+                            sync.queue.push_back((idx, daa, miss));
+                        }
+                    }
+                }
                 None => {
                     let cursor = sync.deep_cursor_daa;
                     let mut queue = std::mem::take(&mut sync.queue);
                     queue.clear();
                     let ledger = self.refold_service_ledger(&*sc, common, pruning_point, cursor, &mut queue);
                     sync.queue = queue;
-                    ledger
+                    sync.ledger = ledger;
                 }
-            };
+            }
         }
         sync.snapshots.split_off(&(common + 1));
         for (k, h) in chain_path.added.iter().enumerate() {
@@ -308,11 +323,13 @@ impl VirtualStateProcessor {
             for miss in misses {
                 sync.queue.push_back((idx, daa, miss));
             }
-            let snapshot = sync.ledger.clone();
-            sync.snapshots.insert(idx, snapshot);
-        }
-        while sync.snapshots.len() > SERVICE_SNAPSHOT_CAP {
-            sync.snapshots.pop_first();
+            if idx % SERVICE_SNAPSHOT_INTERVAL == 0 {
+                let snapshot = sync.ledger.clone();
+                sync.snapshots.insert(idx, snapshot);
+                while sync.snapshots.len() > SERVICE_SNAPSHOT_CAP {
+                    sync.snapshots.pop_first();
+                }
+            }
         }
         sync.tip = Some(tip_idx);
         // Misses now deeper than finality are reorg-immune on every acceptable POV: persist their
@@ -375,6 +392,18 @@ impl VirtualStateProcessor {
     /// lookup in the reorg-immune suspended set — cheap and identical on every H6 node.
     pub(super) fn is_producer_suspended(&self, producer: &Hash, daa_score: u64) -> bool {
         self.service_suspended.read().get(producer).is_some_and(|&until| daa_score < until)
+    }
+
+    #[cfg(test)]
+    pub(super) fn service_ledger_for_test(&self) -> ServiceLedger {
+        self.service_ledger.lock().ledger.clone()
+    }
+
+    #[cfg(test)]
+    pub(super) fn reset_service_ledger_for_checkpoint_test(&self) {
+        let mut sync = self.service_ledger.lock();
+        sync.ledger = ServiceLedger::default();
+        sync.tip = None;
     }
 }
 

--- a/consensus/src/pipeline/virtual_processor/tests.rs
+++ b/consensus/src/pipeline/virtual_processor/tests.rs
@@ -558,6 +558,11 @@ async fn service_cohort_from_recent_tier_producers() {
     assert_eq!(claims.len(), 2);
     assert!(claims.iter().all(|c| c.value > 0));
 
+    let expected = vp.service_ledger_for_test();
+    vp.reset_service_ledger_for_checkpoint_test();
+    vp.advance_service_ledger(&keryx_consensus_core::ChainPath::default(), genesis);
+    assert_eq!(vp.service_ledger_for_test(), expected, "checkpoint replay must reproduce the continuously folded ledger");
+
     tc.shutdown(handles);
 }
 


### PR DESCRIPTION
## Reason

During testnet IBD with `--utxoindex`, `keryxd` repeatedly exhausted a 14 GiB Ubuntu mini PC and was OOM-killed at about 14.4 GiB anonymous RSS. A fully synced 64 GiB node independently reached about 25.4 GiB anonymous RSS. The growth came from cloning and retaining the complete `ServiceLedger` after every selected-chain block, outside all `ram-scale` budgets. This fix bounds that amplification while preserving deterministic reorg restoration.

## Summary

- replace 4,096 per-block `ServiceLedger` deep clones with sparse checkpoints every 4,096 selected-chain blocks
- retain about 37 checkpoints, covering twice the service horizon, and trim immediately after insertion
- restore the nearest checkpoint during reorgs and deterministically replay to the common ancestor
- add exact checkpoint-restore state comparison coverage

## Root cause

`advance_service_ledger` cloned the complete service ledger after every selected-chain block. The ledger contains pending requests, strikes/audits, and per-miner escrow claim queues. During fast IBD, retaining 4,096 independent copies amplified the live ledger into multi-gigabyte anonymous heap outside `ram-scale` budgets.

On a 14 GiB Ubuntu mini PC, the release binary reached about 14.4 GiB anonymous RSS and was OOM-killed twice.

## Verification

- `cargo test -p keryx-consensus service_ -- --test-threads=1`: 3 passed
- `cargo test -p keryx-consensus -- --test-threads=1`: 94 passed
- bounded mini-PC run completed 100% IBD at 311,195 blocks plus two subsequent catch-ups
- maximum sampled RSS: 2,085,704 KiB
- systemd memory peak: 5,765,877,760 bytes
- swap peak: 0
- panic, OOM, and application errors: 0
- restart-at-tip soak accepted 717 live block events and processed 3,353 blocks with zero swap

The candidate used the authoritative `h6-matrix-walk` source and the original `--testnet --utxoindex --ram-scale=0.3` operating configuration.

## Residual scope

Cold restart still uses the pre-existing bounded historical refold because checkpoints remain RAM-only. Follow-up coverage would be useful for non-empty miss-queue replay, checkpoint eviction, deep fallback refolding, and a forked-chain reorg. These are not introduced by this memory fix.
