### PR TITLE
perf(p2p): compact multiproof wire encoding for PoM v4 proofs (protocol v11)

### DIFF
--- a/consensus/core/Cargo.toml
+++ b/consensus/core/Cargo.toml
@@ -52,6 +52,9 @@ workflow-wasm.workspace = true
 [dev-dependencies]
 criterion.workspace = true
 bincode.workspace = true
+# `pom_v4_size` example: measures what the tonic gzip already applied to every p2p channel
+# actually buys on a PoM v4 proof. Same codec as the wire, so the number is comparable.
+flate2.workspace = true
 wasm-bindgen-test.workspace = true
 web-sys.workspace = true
 

--- a/consensus/core/examples/pom_v4_size.rs
+++ b/consensus/core/examples/pom_v4_size.rs
@@ -1,0 +1,445 @@
+//! What a PoM v4 proof actually costs on the wire, and what is recoverable.
+//!
+//! The measurement harness behind `pom_v4_wire`: it answers, with numbers rather than arithmetic,
+//! three questions, in order of how much they change the plan:
+//!
+//!   1. How big is a v4 proof per tier, exactly? (`POM_V4_K` tiles + one Merkle range proof each)
+//!   2. What does the gzip we ALREADY run on every p2p channel actually buy on it?
+//!      (`protocol/p2p/src/core/connection_handler.rs` enables tonic gzip both directions, so any
+//!      further generic compression layer would stack on top of this, not add to it.)
+//!   3. How many Merkle siblings are redundant? All `POM_V4_K` paths climb to the SAME per-tier
+//!      root `R_T`, so their upper levels are shared, yet each tile ships its own full path today.
+//!
+//! Run: `cargo run --release -p keryx-consensus-core --example pom_v4_size`
+//!
+//! CAVEAT on the compression numbers: real tiles are quantized GGUF weight bytes. This example
+//! fills them from a CSPRNG, which is the incompressible worst case. Q4_K/Q8_0 data is close to
+//! that but not identical, so treat the gzip column as a lower bound on the ratio and re-run
+//! against real tier bytes (via the tier-root builder) before making a final call on any codec
+//! question. What the example does NOT approximate is the sibling redundancy — it is exact, being
+//! purely structural (it depends only on the tile offsets, not on the byte values).
+
+use flate2::{Compression, write::GzEncoder};
+use keryx_consensus_core::config::params::POM_TIERS_H6;
+use keryx_consensus_core::pom::PomProof;
+use keryx_consensus_core::pom_v4::{
+    POM_V4_CHUNK_BYTES, POM_V4_K, POM_V4_TILE_BYTES, POM_V4_TILE_CHUNKS, PomProofV4, PomV4RangeProof, v4_offset_chain,
+    v4_tile_subtree_root,
+};
+use keryx_consensus_core::pom_v4_wire::{decode_v4_deduped, encode_v4_deduped};
+use rand::{Rng, SeedableRng, rngs::StdRng};
+use std::collections::{BTreeMap, BTreeSet};
+use std::io::Write;
+
+/// Local mirror of `pom::hash_pair` (which is `pub(crate)`). Must stay byte-identical to it, or the
+/// tree built here stops matching the one the verifier folds.
+fn hash_pair(left: &[u8; 32], right: &[u8; 32]) -> [u8; 32] {
+    let mut buf = [0u8; 64];
+    buf[..32].copy_from_slice(left);
+    buf[32..].copy_from_slice(right);
+    *blake3::hash(&buf).as_bytes()
+}
+
+/// Number of independent offset draws averaged for the dedup figures. The count varies by a few
+/// nodes between nonces; one draw would read as false precision.
+const TRIALS: usize = 200;
+
+/// Size of the tile-root level: the level whose leaves are whole tiles. `fold_level` ceil-halves,
+/// and repeated ceil-halving is a single ceil, so this is `ceil(n_chunks / POM_V4_TILE_CHUNKS)`.
+///
+/// Deliberately NOT `v4_n_tiles`, which FLOORS: when `n_chunks` is not a multiple of 32 the tile
+/// level carries one extra partial node that no offset ever addresses. Tier 4
+/// (`chunks = 927_994_064`) is exactly that case — 28_999_814 addressable tiles under a level of
+/// 28_999_815 nodes. Conflating the two shifts the tree shape by one and silently breaks path
+/// reconstruction, so the two quantities are kept apart here on purpose.
+fn tile_level_len(n_chunks: u64) -> u64 {
+    n_chunks.div_ceil(POM_V4_TILE_CHUNKS)
+}
+
+/// Addressable tile count — the range the walk's offsets are reduced modulo.
+fn n_tiles(n_chunks: u64) -> u64 {
+    n_chunks / POM_V4_TILE_CHUNKS
+}
+
+/// Merkle path length from a tile-subtree root up to `R_T`: the number of `fold_level` steps that
+/// take the tile level down to a single root. Mirrors the `while level.len() > 1` loop in
+/// `pom_v4::v4_tile_path`.
+fn path_len(mut level_len: u64) -> usize {
+    let mut n = 0;
+    while level_len > 1 {
+        level_len = level_len.div_ceil(2);
+        n += 1;
+    }
+    n
+}
+
+/// Exact number of distinct Merkle siblings needed to prove ALL `offsets` at once.
+///
+/// Walks the tree bottom-up exactly as `fold_level` builds it. At each level a known node needs its
+/// sibling supplied unless the sibling is itself known (shared with another tile) or does not exist
+/// (the odd-tail node that `fold_level` pairs with itself — `hash_pair(p0, p0)`, which is why
+/// `v4_tile_path` falls back to `level[idx]` when `idx ^ 1` is out of range).
+///
+/// This is the multiproof node count; the difference against `offsets.len() * path_len` is the
+/// redundancy currently on the wire.
+fn multiproof_node_count(offsets: &[u64], level0_len: u64) -> usize {
+    let mut cur: BTreeSet<u64> = offsets.iter().copied().collect();
+    let mut level_len = level0_len;
+    let mut supplied = 0usize;
+    while level_len > 1 {
+        for &idx in cur.iter() {
+            let sib = idx ^ 1;
+            // Out of range => the self-paired odd tail, derivable. Already known => shared.
+            if sib < level_len && !cur.contains(&sib) {
+                supplied += 1;
+            }
+        }
+        cur = cur.iter().map(|&i| i >> 1).collect();
+        level_len = level_len.div_ceil(2);
+    }
+    supplied
+}
+
+/// gzip at the default level — what tonic's `CompressionEncoding::Gzip` applies today.
+fn gzip_len(bytes: &[u8]) -> usize {
+    let mut enc = GzEncoder::new(Vec::new(), Compression::default());
+    enc.write_all(bytes).unwrap();
+    enc.finish().unwrap().len()
+}
+
+/// Number of 32-byte blocks in `paths_bytes` that are exact repeats of an earlier one, and how many
+/// of those repeats fall within gzip's 32 KiB window (and so are reachable by it) versus beyond it.
+///
+/// This is the measurement that explains the gzip column: the redundancy is a set of duplicated
+/// siblings, and deflate can only turn one into a back-reference if its previous occurrence is still
+/// inside the window. It also bounds what a large-window codec (zstd, whose window spans the whole
+/// payload) could add without any format change.
+fn duplicate_reach(paths_bytes: &[u8]) -> (usize, usize, usize) {
+    use std::collections::HashMap;
+    const W: usize = 32 * 1024;
+    let mut last_seen: HashMap<&[u8], usize> = HashMap::new();
+    let (mut dups, mut in_window, mut out_of_window) = (0, 0, 0);
+    for (i, block) in paths_bytes.chunks_exact(32).enumerate() {
+        let pos = i * 32;
+        if let Some(&prev) = last_seen.get(block) {
+            dups += 1;
+            if pos - prev <= W { in_window += 1 } else { out_of_window += 1 }
+        }
+        last_seen.insert(block, pos);
+    }
+    (dups, in_window, out_of_window)
+}
+
+/// Stand-in for a tree node the prover would have but we are not materialising: a deterministic
+/// function of its position, so that any two tiles that share this node see the SAME bytes.
+fn prf(level: usize, idx: u64) -> [u8; 32] {
+    let mut buf = [0u8; 16];
+    buf[..8].copy_from_slice(&(level as u64).to_le_bytes());
+    buf[8..].copy_from_slice(&idx.to_le_bytes());
+    *blake3::hash(&buf).as_bytes()
+}
+
+/// Build the `POM_V4_K` per-tile Merkle paths so they are MUTUALLY CONSISTENT, and return the
+/// multiproof node list alongside them.
+///
+/// Consistency is the whole point: two tiles sharing an ancestor must carry byte-identical
+/// siblings above the meet point, because that shared redundancy is exactly what gzip may or may
+/// not find and what the multiproof removes outright. Random per-path bytes would understate
+/// gzip and so overstate the dedup win.
+///
+/// Only the ~9 k nodes actually touched are materialised — supplied siblings from `prf`, internal
+/// nodes folded from their children with `hash_pair`, matching `fold_level` including its
+/// self-paired odd tail.
+fn build_consistent_paths(offsets: &[u64], tiles: &[Vec<u8>], level0_len: u64, plen: usize) -> (Vec<PomV4RangeProof>, Vec<[u8; 32]>) {
+    let mut paths: Vec<Vec<[u8; 32]>> = vec![Vec::with_capacity(plen); offsets.len()];
+    let mut nodes: Vec<[u8; 32]> = Vec::new();
+
+    // Level 0: the REAL tile-subtree roots, folded from the tile bytes exactly as the verifier
+    // does. Rooting the tree anywhere else (a positional stand-in, say) would make the paths
+    // internally consistent yet unrelated to the tiles, and the production encoder would rightly
+    // fail to round-trip them. Keyed by tile index, so duplicate offsets collapse — which is what
+    // really happens, since both tiles carry the same bytes.
+    let mut cur: BTreeMap<u64, [u8; 32]> = BTreeMap::new();
+    for (i, &o) in offsets.iter().enumerate() {
+        cur.entry(o).or_insert_with(|| v4_tile_subtree_root(&tiles[i]));
+    }
+    let mut level_len = level0_len;
+
+    for level in 0..plen {
+        // Complete the level: supply every sibling that is neither known nor self-paired. Iterate
+        // ascending (BTreeMap order) — this is the canonical node order the real encoder/decoder
+        // must agree on.
+        let mut full = cur.clone();
+        for (&idx, _) in cur.iter() {
+            let sib = idx ^ 1;
+            if sib < level_len && !cur.contains_key(&sib) {
+                let v = prf(level, sib);
+                nodes.push(v);
+                full.insert(sib, v);
+            }
+        }
+
+        // Each tile's path entry at this level: its ancestor's sibling, self on the odd tail
+        // (mirrors `v4_tile_path`'s `if (idx ^ 1) < level.len() { .. } else { level[idx] }`).
+        for (i, &off) in offsets.iter().enumerate() {
+            let anc = off >> level;
+            let sib = anc ^ 1;
+            let key = if sib < level_len { sib } else { anc };
+            paths[i].push(*full.get(&key).expect("sibling materialised above"));
+        }
+
+        // Fold to the next level.
+        let mut next: BTreeMap<u64, [u8; 32]> = BTreeMap::new();
+        for (&idx, _) in cur.iter() {
+            let p = idx >> 1;
+            if next.contains_key(&p) {
+                continue;
+            }
+            let l = *full.get(&(p * 2)).expect("left child known");
+            let r = if p * 2 + 1 < level_len { *full.get(&(p * 2 + 1)).expect("right child known") } else { l };
+            next.insert(p, hash_pair(&l, &r));
+        }
+        cur = next;
+        level_len = level_len.div_ceil(2);
+    }
+
+    (paths.into_iter().map(|path| PomV4RangeProof { path }).collect(), nodes)
+}
+
+/// A canonical v4 container: every legacy/v3 field empty, as `verify_pom_proof_v4_container`
+/// requires (`NonCanonicalLegacyFields` otherwise).
+fn v4_proof(tier: u8, tiles: Vec<Vec<u8>>, merkle: Vec<PomV4RangeProof>) -> PomProof {
+    PomProof {
+        tier,
+        trace_root: [0u8; 32],
+        pow_value: [0xab; 32],
+        final_state: 0x1234_5678_9abc_def0,
+        initial_trace_path: vec![],
+        final_trace_path: vec![],
+        openings: vec![],
+        steps_v2: None,
+        v3: None,
+        v4: Some(PomProofV4 { tier, tiles, merkle }),
+    }
+}
+
+fn main() {
+    println!("PoM v4 proof size analysis  (POM_V4_K = {POM_V4_K}, tile = {POM_V4_TILE_BYTES} B = {POM_V4_TILE_CHUNKS} chunks)\n");
+
+    // ---- 1 + 3: exact sizes and the exact structural redundancy, per H6 tier ----
+    println!("Per-tier wire size and multiproof saving (structural, exact):\n");
+    println!(
+        "{:>4}  {:>13}  {:>11}  {:>4}  {:>9}  {:>9}  {:>10}  {:>10}  {:>7}",
+        "tier", "chunks", "tile level", "path", "sibs now", "sibs ded", "wire now", "wire ded", "saving"
+    );
+
+    for (tier, t) in POM_TIERS_H6.iter().enumerate() {
+        let level0 = tile_level_len(t.chunks);
+        let tiles = n_tiles(t.chunks);
+        let plen = path_len(level0);
+
+        // Average the dedup count over independent offset draws.
+        let mut total = 0usize;
+        for trial in 0..TRIALS {
+            let mut rng = StdRng::seed_from_u64(0xC0FFEE ^ (tier as u64) << 32 ^ trial as u64);
+            let offsets: Vec<u64> = (0..POM_V4_K).map(|_| rng.gen_range(0..tiles)).collect();
+            total += multiproof_node_count(&offsets, level0);
+        }
+        let deduped_sibs = total / TRIALS;
+        let legacy_sibs = POM_V4_K * plen;
+
+        // Legacy borsh: container + tiles (4 B Vec prefix each) + one path per tile (4 B prefix each).
+        let container = 1 + 32 + 32 + 8 + 4 + 4 + 4 + 1 + 1 + 1;
+        let tiles_field = 4 + POM_V4_K * (4 + POM_V4_TILE_BYTES);
+        let merkle_field = 4 + POM_V4_K * (4 + plen * 32);
+        let wire_now = container + 1 + tiles_field + merkle_field;
+
+        // Deduped: fixed-size tiles (no per-tile prefix), explicit offsets, one node list.
+        // tier + pow_value + final_state + level0_len + offsets + tiles + nodes
+        let wire_ded = 1 + 32 + 8 + 8 + (4 + POM_V4_K * 4) + (4 + POM_V4_K * POM_V4_TILE_BYTES) + (4 + deduped_sibs * 32);
+
+        println!(
+            "{:>4}  {:>13}  {:>11}  {:>4}  {:>9}  {:>9}  {:>10}  {:>10}  {:>6.1}%",
+            tier,
+            t.chunks,
+            level0,
+            plen,
+            legacy_sibs,
+            deduped_sibs,
+            wire_now,
+            wire_ded,
+            100.0 * (wire_now - wire_ded) as f64 / wire_now as f64
+        );
+    }
+
+    // ---- 2: what gzip buys, on the tier-0 shape ----
+    let t0 = &POM_TIERS_H6[0];
+    let level0 = tile_level_len(t0.chunks);
+    let tiles_n = n_tiles(t0.chunks);
+    let plen = path_len(level0);
+
+    println!("\n\nCompression, tier 0 shape (path = {plen}):\n");
+
+    let mut rng = StdRng::seed_from_u64(0xDEADBEEF);
+
+    // Tiles: incompressible stand-in for quantized weight bytes (see the CAVEAT above).
+    let tiles: Vec<Vec<u8>> = (0..POM_V4_K)
+        .map(|_| {
+            let mut t = vec![0u8; POM_V4_TILE_BYTES];
+            rng.fill(&mut t[..]);
+            t
+        })
+        .collect();
+
+    // Offsets come from the real walk derivation rather than a draw, so the proof built below is
+    // one the production encoder accepts — which is what makes the end-to-end check at the bottom
+    // meaningful at mainnet scale without materialising a 4.8 GB blob.
+    let walk_seed = 0xC0DE_1234_5678_9ABCu64;
+    let offsets: Vec<u64> = v4_offset_chain(walk_seed, &tiles, tiles_n).to_vec();
+
+    // Paths, built mutually consistent so the real shared-sibling redundancy is present in the
+    // bytes — that is what decides whether gzip already captures part of the dedup win.
+    let (merkle, nodes) = build_consistent_paths(&offsets, &tiles, level0, plen);
+
+    let proof = v4_proof(0, tiles.clone(), merkle.clone());
+    let wire = proof.to_wire_bytes();
+
+    // Component-wise, to see which half of the proof gzip can and cannot touch.
+    let tiles_bytes: Vec<u8> = tiles.concat();
+    let paths_bytes: Vec<u8> = merkle.iter().flat_map(|m| m.path.iter().flatten().copied()).collect();
+
+    // The deduped encoding, byte-for-byte as it would go on the wire:
+    // tier | pow_value | final_state | level0_len | offsets (u32 each) | tiles (fixed) | nodes
+    let mut deduped = Vec::with_capacity(400_000);
+    deduped.push(0u8);
+    deduped.extend_from_slice(&[0xab; 32]);
+    deduped.extend_from_slice(&0x1234_5678_9abc_def0u64.to_le_bytes());
+    deduped.extend_from_slice(&level0.to_le_bytes());
+    deduped.extend_from_slice(&(POM_V4_K as u32).to_le_bytes());
+    for &o in &offsets {
+        deduped.extend_from_slice(&(o as u32).to_le_bytes());
+    }
+    for t in &tiles {
+        deduped.extend_from_slice(t);
+    }
+    deduped.extend_from_slice(&(nodes.len() as u32).to_le_bytes());
+    for n in &nodes {
+        deduped.extend_from_slice(n);
+    }
+
+    // Same siblings, level-major instead of tile-major: all 256 siblings for level 0, then level 1,
+    // and so on. Duplicated siblings live within a level, and one level is only 8 KB, so this
+    // ordering brings every duplicate inside gzip's 32 KB window. Measuring it isolates how much of
+    // the gap is purely window reach — i.e. what a large-window codec like zstd could recover with
+    // no format change at all.
+    let paths_level_major: Vec<u8> = (0..plen).flat_map(|l| merkle.iter().flat_map(move |m| m.path[l]).collect::<Vec<u8>>()).collect();
+
+    println!("{:>30}  {:>9}  {:>9}  {:>8}", "payload", "raw", "gzip", "gzip saves");
+    for (name, buf) in [
+        ("full proof today (borsh)", &wire),
+        ("  tiles only (weight bytes)", &tiles_bytes),
+        ("  merkle paths, tile-major", &paths_bytes),
+        ("  merkle paths, level-major", &paths_level_major),
+        ("full proof deduped", &deduped),
+    ] {
+        let g = gzip_len(buf);
+        println!("{:>30}  {:>9}  {:>9}  {:>7.2}%", name, buf.len(), g, 100.0 * (buf.len() as f64 - g as f64) / buf.len() as f64);
+    }
+
+    let (dups, in_win, out_win) = duplicate_reach(&paths_bytes);
+    println!("\nWhy gzip gets what it gets (duplicate 32 B siblings in the path field, tile-major):");
+    println!("  exact repeats of an earlier sibling : {dups}");
+    println!("  within gzip's 32 KiB window         : {in_win}  <- deflate can back-reference these");
+    println!("  beyond it                           : {out_win}  <- only a large-window codec reaches these");
+
+    let legacy_sibs = POM_V4_K * plen;
+    let saved = (legacy_sibs - nodes.len()) * 32;
+
+    println!("\nStructural redundancy in the merkle field (tier 0, this offset draw):");
+    println!("  siblings on the wire today : {legacy_sibs} ({} B)", legacy_sibs * 32);
+    println!("  distinct siblings needed   : {} ({} B)", nodes.len(), nodes.len() * 32);
+    println!(
+        "  redundant                  : {} ({saved} B, {:.1}% of the path field)",
+        legacy_sibs - nodes.len(),
+        100.0 * saved as f64 / (legacy_sibs * 32) as f64
+    );
+
+    // The comparison that actually matters: bytes a peer receives now vs after the change, both
+    // measured AFTER the gzip that is already on the channel.
+    let now_raw = wire.len();
+    let now_gz = gzip_len(&wire);
+    let ded_raw = deduped.len();
+    let ded_gz = gzip_len(&deduped);
+
+    println!("\nWhat a peer actually receives (the metric CountBytesBody reports):");
+    let baseline = now_gz;
+    let rel = |b: usize| 100.0 * (b as f64 - baseline as f64) / baseline as f64;
+
+    // Same information as today, only the merkle field transposed to level-major, so gzip can reach
+    // every duplicate. Reversing a transposition needs no tree math, which makes this the cheapest
+    // conceivable format change and a MEASURED lower bound on what a large-window codec would buy.
+    let mut reordered = Vec::with_capacity(wire.len());
+    reordered.push(0u8);
+    reordered.extend_from_slice(&[0xab; 32]);
+    reordered.extend_from_slice(&0x1234_5678_9abc_def0u64.to_le_bytes());
+    for t in &tiles {
+        reordered.extend_from_slice(t);
+    }
+    reordered.extend_from_slice(&paths_level_major);
+    let reordered_gz = gzip_len(&reordered);
+
+    println!("  today: legacy + gzip          : {now_gz} B  (raw {now_raw})   <- baseline");
+    println!("  level-major + gzip            : {reordered_gz} B  ({:+.1}%)", rel(reordered_gz));
+    println!("  multiproof, uncompressed      : {ded_raw} B  ({:+.1}%)", rel(ded_raw));
+    println!("  multiproof + gzip (pointless) : {ded_gz} B  ({:+.1}%)", rel(ded_gz));
+    println!(
+        "\n  Best case for any pure-codec change (large window, no format change) is bounded below by\n  \
+         the redundancy-free size {ded_raw} B plus a match token per duplicate: about {} B ({:+.1}%).\n  \
+         So swapping gzip for zstd can recover at most ~{:.0}% of what the multiproof recovers.",
+        ded_raw + dups * 4,
+        rel(ded_raw + dups * 4),
+        100.0 * (baseline - (ded_raw + dups * 4)) as f64 / (baseline - ded_raw) as f64
+    );
+
+    println!(
+        "\nRatio check: tiles are {:.1}% of the raw proof, paths {:.1}%.",
+        100.0 * (POM_V4_K * POM_V4_TILE_BYTES) as f64 / wire.len() as f64,
+        100.0 * (legacy_sibs * 32) as f64 / wire.len() as f64
+    );
+    // End-to-end through the production encoder, at real tier-0 dimensions.
+    let real_compact = encode_v4_deduped(&proof, walk_seed, t0.chunks).expect("encode");
+    let decoded = decode_v4_deduped(&real_compact, walk_seed, t0.chunks).expect("decode");
+    assert_eq!(proof.to_wire_bytes(), decoded.to_wire_bytes(), "round-trip must be byte-exact");
+
+    // Best of N, after a warm-up: the first call also pays for spinning up the rayon pool, and a
+    // single shot reads as noise rather than cost.
+    let best_us = |mut f: Box<dyn FnMut()>| {
+        for _ in 0..3 {
+            f();
+        }
+        (0..20)
+            .map(|_| {
+                let t = std::time::Instant::now();
+                f();
+                t.elapsed().as_secs_f64() * 1e6
+            })
+            .fold(f64::INFINITY, f64::min)
+    };
+    let enc_us = best_us(Box::new(|| {
+        let _ = encode_v4_deduped(&proof, walk_seed, t0.chunks).unwrap();
+    }));
+    let dec_us = best_us(Box::new(|| {
+        let _ = decode_v4_deduped(&real_compact, walk_seed, t0.chunks).unwrap();
+    }));
+
+    println!("\nProduction encoder at tier-0 dimensions (round-trip verified byte-exact):");
+    println!("  compact encoding : {} B ({:+.1}% vs the {now_gz} B a peer gets today)", real_compact.len(), rel(real_compact.len()));
+    println!("  encode {enc_us:.0} us | decode {dec_us:.0} us");
+    println!(
+        "  At 10 BPS x 8 peers, encoding per peer costs {:.1}% of a core; once per block, {:.2}%.",
+        100.0 * (enc_us * 1e-6) * 10.0 * 8.0,
+        100.0 * (enc_us * 1e-6) * 10.0
+    );
+
+    println!("Chunk size is {POM_V4_CHUNK_BYTES} B; a tile is {POM_V4_TILE_CHUNKS} chunks.");
+}

--- a/consensus/core/src/lib.rs
+++ b/consensus/core/src/lib.rs
@@ -36,6 +36,7 @@ pub mod network;
 pub mod pom;
 pub mod pom_v3;
 pub mod pom_v4;
+pub mod pom_v4_wire;
 pub mod pruning;
 pub mod sign;
 pub mod subnets;

--- a/consensus/core/src/pom_v4.rs
+++ b/consensus/core/src/pom_v4.rs
@@ -70,7 +70,11 @@ impl PomProofV4 {
     pub fn approx_bytes(&self) -> usize {
         let tiles: usize = self.tiles.iter().map(|t| t.len()).sum();
         let paths: usize = self.merkle.iter().map(|m| m.path.len() * 32).sum();
-        1 + tiles + paths
+        // Include the length prefixes: one per `Vec` plus one per element of the two outer vectors.
+        // At K = 256 that is ~2 KB, and leaving it out biased the byte-tracked cache policy in
+        // `pom_proof_budget` low on every entry.
+        let prefixes = 4 + self.tiles.len() * 4 + 4 + self.merkle.len() * 4;
+        1 + tiles + paths + prefixes
     }
 }
 
@@ -330,6 +334,55 @@ pub fn v4_n_tiles(n_chunks: u64) -> u64 {
     n_chunks / POM_V4_TILE_CHUNKS
 }
 
+/// Size of the tile-root level: the level of the `R_T` tree whose nodes are whole-tile subtree
+/// roots. `fold_level` ceil-halves and repeated ceil-halving is a single ceil, so this is
+/// `ceil(n_chunks / POM_V4_TILE_CHUNKS)`.
+///
+/// Deliberately NOT [`v4_n_tiles`], which FLOORS. When `n_chunks` is not a multiple of
+/// `POM_V4_TILE_CHUNKS` the tile level carries one extra partial node that no walk offset ever
+/// addresses — tier 4 (`chunks = 927_994_064`) is exactly that case, 28_999_814 addressable tiles
+/// under a level of 28_999_815 nodes. The two must not be conflated: the tree SHAPE follows this
+/// function, the offset RANGE follows `v4_n_tiles`.
+#[inline]
+pub fn v4_tile_level_len(n_chunks: u64) -> u64 {
+    n_chunks.div_ceil(POM_V4_TILE_CHUNKS)
+}
+
+/// Merkle path length from a tile-subtree root up to `R_T`: the number of `fold_level` steps taking
+/// the tile level down to a single root. Mirrors the `while level.len() > 1` loop in `v4_tile_path`.
+#[inline]
+pub fn v4_tile_path_len(mut level_len: u64) -> usize {
+    let mut n = 0;
+    while level_len > 1 {
+        level_len = level_len.div_ceil(2);
+        n += 1;
+    }
+    n
+}
+
+/// The walk's tile-offset chain, derived from the seed and the tiles' leading snippets alone.
+///
+/// This is the hinge the compact p2p encoding turns on: a receiver can recover every tile's leaf
+/// index without being told, so tile positions never need to go on the wire. Extracted from
+/// [`verify_pom_proof_v4`] so the wire encoder and the verifier cannot drift apart — if they ever
+/// derived different offsets, the reconstructed Merkle paths would be silently wrong and blocks
+/// would be rejected with no obvious cause.
+///
+/// `tiles` must already be shape-checked (`POM_V4_K` entries of `POM_V4_TILE_BYTES`) and `n_tiles`
+/// must be non-zero; both are the caller's responsibility.
+pub fn v4_offset_chain(seed: u64, tiles: &[Vec<u8>], n_tiles: u64) -> [u64; POM_V4_K] {
+    debug_assert_eq!(tiles.len(), POM_V4_K);
+    debug_assert!(n_tiles > 0);
+    let mut offs = [0u64; POM_V4_K];
+    offs[0] = v4_first_offset(seed, n_tiles);
+    for step in 1..POM_V4_K {
+        let tile = &tiles[step - 1];
+        let snippet: [u8; POM_V4_SNIPPET_BYTES] = tile[..POM_V4_SNIPPET_BYTES].try_into().unwrap();
+        offs[step] = v4_next_offset(seed, step as u64, &snippet, n_tiles);
+    }
+    offs
+}
+
 /// Fold a full leaf level up one level (duplicate-last on an odd count — matches `pom-rt-builder`).
 fn fold_level(level: &[[u8; 32]]) -> Vec<[u8; 32]> {
     level.chunks(2).map(|p| if p.len() == 2 { hash_pair(&p[0], &p[1]) } else { hash_pair(&p[0], &p[0]) }).collect()
@@ -380,13 +433,7 @@ pub fn verify_pom_proof_v4(
 
     // Offset chain depends only on seed + snippets (tile[0..32]), not on the matrix walk.
     // Precompute it so Merkle checks can run in parallel.
-    let mut offs = [0u64; POM_V4_K];
-    offs[0] = v4_first_offset(seed, n_tiles);
-    for step in 1..POM_V4_K {
-        let tile = &proof.tiles[step - 1];
-        let snippet: [u8; POM_V4_SNIPPET_BYTES] = tile[..POM_V4_SNIPPET_BYTES].try_into().unwrap();
-        offs[step] = v4_next_offset(seed, step as u64, &snippet, n_tiles);
-    }
+    let offs = v4_offset_chain(seed, &proof.tiles, n_tiles);
 
     if !verify_tile_merkle_parallel(proof, &offs, r_t) {
         return Err(PomV4VerifyError::BadTilePath);

--- a/consensus/core/src/pom_v4_wire.rs
+++ b/consensus/core/src/pom_v4_wire.rs
@@ -1,0 +1,468 @@
+//! Compact p2p encoding of a v4 PoM proof: one Merkle multiproof instead of `POM_V4_K` independent
+//! paths.
+//!
+//! All `POM_V4_K` tile paths climb to the SAME per-tier root `R_T`, so their upper levels are
+//! shared, yet the canonical (borsh) form ships every path in full. Measured on the tier-0 shape
+//! (`consensus/core/examples/pom_v4_size.rs`): 5 888 siblings on the wire against 3 505 distinct
+//! ones actually needed — 40.5 % of the path field is redundant.
+//!
+//! Two kinds of redundancy are removed, and it is worth knowing which is which, because the gzip
+//! already running on every p2p channel reaches only the first:
+//!
+//!   * a sibling that literally repeats one carried by another tile (deflate can back-reference it,
+//!     but only within its 32 KiB window — about two thirds of them in practice);
+//!   * a sibling that is itself an *ancestor* of some other tile, so the receiver can fold it from
+//!     that tile's own subtree. These appear exactly once in the byte stream, so no compressor of
+//!     any window size can ever remove them.
+//!
+//! **Nothing positional goes on the wire.** Tile offsets are re-derived from the block seed and the
+//! tiles' leading snippets via [`v4_offset_chain`], and the tree shape from the tier's chunk count,
+//! so both sides independently reach the same node ordering. That is what keeps the encoding at
+//! pure payload.
+//!
+//! This is a transport encoding only: [`decode_v4_deduped`] reconstructs a byte-identical
+//! [`PomProof`], which is what then gets verified, stored and re-served to peers that speak the
+//! older format. Consensus never sees this module.
+
+use crate::hashing::header::hash_override_nonce_time;
+use crate::header::Header;
+use crate::pom::{PomProof, hash_pair, pom_block_seed_v4};
+use crate::pom_v4::{
+    POM_V4_K, POM_V4_TILE_BYTES, PomProofV4, PomV4RangeProof, v4_n_tiles, v4_offset_chain, v4_tile_level_len, v4_tile_path_len,
+    v4_tile_subtree_root,
+};
+use std::collections::BTreeMap;
+
+/// Fixed part of the encoding: `tier | pow_value | final_state | node_count`.
+const HEADER_BYTES: usize = 1 + 32 + 8 + 4;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum PomWireError {
+    /// Not a v4 proof, or the legacy/v3 container fields are non-empty. Only canonical v4 proofs
+    /// have a compact form — everything the compact form omits is required to be empty.
+    NotCanonicalV4,
+    /// `tiles`/`merkle` length is not `POM_V4_K`, or a tile is not `POM_V4_TILE_BYTES`.
+    WrongShape,
+    /// A path length disagrees with the tree implied by the tier's chunk count.
+    WrongPathLen,
+    /// The blob is too small to hold a single tile.
+    BlobTooSmall,
+    /// Two tiles that meet at the same tree node disagree about the value above it — the proof is
+    /// internally inconsistent and has no well-defined compact form.
+    InconsistentPaths,
+    /// Truncated, over-long, or otherwise malformed byte stream.
+    Malformed,
+    /// Tier index is not present in the v4 tier table.
+    UnknownTier(u8),
+}
+
+/// Seed and canonical chunk count for a v4 block, from its header alone.
+///
+/// Both are what [`encode_v4_deduped`]/[`decode_v4_deduped`] need, and both are derivable by any
+/// peer holding the header — which is why the compact form can omit them.
+///
+/// The tier table is pinned to `POM_TIERS_H6`: `pom_v4_activation` is strictly later than
+/// `pom_v3_activation`, so every v4 block selects that table in `pom_tiers`. A tier outside it is
+/// rejected here rather than guessed, and the caller falls back to the legacy encoding.
+pub fn v4_wire_context(header: &Header, tier: u8) -> Result<(u64, u64), PomWireError> {
+    let tiers = crate::config::params::POM_TIERS_H6;
+    let t = tiers.get(tier as usize).ok_or(PomWireError::UnknownTier(tier))?;
+    let pre_pow_hash = hash_override_nonce_time(header, 0, 0).as_bytes();
+    Ok((pom_block_seed_v4(&pre_pow_hash, header.timestamp, header.nonce), t.chunks))
+}
+
+/// Tier byte of a compact encoding, read without decoding it.
+///
+/// The tier selects `n_chunks`, which the decode needs in order to know the tree shape — so it has
+/// to be readable first. It is the first byte by construction; `decode_v4_deduped` re-reads and
+/// range-checks it, so a bogus value here only costs a failed lookup.
+pub fn deduped_tier(bytes: &[u8]) -> Option<u8> {
+    bytes.first().copied()
+}
+
+/// True when every field the compact form does not carry is canonically empty, exactly as
+/// `verify_pom_proof_v4_container` demands.
+fn is_canonical_v4(proof: &PomProof) -> bool {
+    proof.v4.is_some()
+        && proof.trace_root == [0u8; 32]
+        && proof.initial_trace_path.is_empty()
+        && proof.final_trace_path.is_empty()
+        && proof.openings.is_empty()
+        && proof.steps_v2.is_none()
+        && proof.v3.is_none()
+}
+
+fn shape_check(v4: &PomProofV4) -> Result<(), PomWireError> {
+    if v4.tiles.len() != POM_V4_K || v4.merkle.len() != POM_V4_K {
+        return Err(PomWireError::WrongShape);
+    }
+    if v4.tiles.iter().any(|t| t.len() != POM_V4_TILE_BYTES) {
+        return Err(PomWireError::WrongShape);
+    }
+    Ok(())
+}
+
+/// Drive one bottom-up pass over the tree, calling `visit` once per level with the set of nodes
+/// known at that level and the level's width.
+///
+/// Encoder and decoder must agree on the node ordering down to the last detail, so both go through
+/// this one walker rather than reimplementing the traversal. The known-set is keyed by node index
+/// and iterated ascending (`BTreeMap`), which *is* the canonical order.
+///
+/// `visit` receives `(level, level_len, known)` and returns the completed level — `known` plus every
+/// sibling needed to fold it — from which the next level is derived.
+fn walk_levels<F>(level0: BTreeMap<u64, [u8; 32]>, level0_len: u64, plen: usize, mut visit: F) -> Result<(), PomWireError>
+where
+    F: FnMut(usize, u64, &BTreeMap<u64, [u8; 32]>) -> Result<BTreeMap<u64, [u8; 32]>, PomWireError>,
+{
+    let mut cur = level0;
+    let mut level_len = level0_len;
+    for level in 0..plen {
+        let full = visit(level, level_len, &cur)?;
+
+        // Fold to the next level. `fold_level` pairs the odd tail with itself, so a right child
+        // past the end reuses the left one.
+        let mut next: BTreeMap<u64, [u8; 32]> = BTreeMap::new();
+        for &idx in cur.keys() {
+            let p = idx >> 1;
+            if next.contains_key(&p) {
+                continue;
+            }
+            let l = *full.get(&(p * 2)).ok_or(PomWireError::Malformed)?;
+            let r = if p * 2 + 1 < level_len { *full.get(&(p * 2 + 1)).ok_or(PomWireError::Malformed)? } else { l };
+            next.insert(p, hash_pair(&l, &r));
+        }
+        cur = next;
+        level_len = level_len.div_ceil(2);
+    }
+    Ok(())
+}
+
+/// Level 0 of the walk: each tile's subtree root, keyed by tile index so repeated offsets collapse
+/// to one node (both tiles carry the same bytes, so both fold to the same root).
+///
+/// Folding 256 tiles is ~16 k blake3 compressions and dominates both directions, so it runs on
+/// rayon exactly as `verify_tile_merkle_parallel` does — sequential on wasm, which has no pool.
+fn tile_level(offsets: &[u64; POM_V4_K], tiles: &[Vec<u8>]) -> BTreeMap<u64, [u8; 32]> {
+    #[cfg(not(target_arch = "wasm32"))]
+    let roots: Vec<[u8; 32]> = {
+        use rayon::prelude::*;
+        tiles.par_iter().map(|t| v4_tile_subtree_root(t)).collect()
+    };
+    #[cfg(target_arch = "wasm32")]
+    let roots: Vec<[u8; 32]> = tiles.iter().map(|t| v4_tile_subtree_root(t)).collect();
+
+    let mut level0: BTreeMap<u64, [u8; 32]> = BTreeMap::new();
+    for (i, &off) in offsets.iter().enumerate() {
+        level0.entry(off).or_insert(roots[i]);
+    }
+    level0
+}
+
+/// Whether `idx`'s sibling has to be supplied at a level of width `level_len`: not when it is the
+/// self-paired odd tail (out of range), and not when another tile already carries it.
+#[inline]
+fn needs_sibling(idx: u64, level_len: u64, known: &BTreeMap<u64, [u8; 32]>) -> Option<u64> {
+    let sib = idx ^ 1;
+    if sib < level_len && !known.contains_key(&sib) { Some(sib) } else { None }
+}
+
+/// Encode a canonical v4 proof into the compact form.
+///
+/// `seed`/`n_chunks` come from [`v4_wire_context`]. Returns an error rather than a degraded encoding
+/// for anything unexpected, so the caller can fall back to the canonical bytes; a proof whose paths
+/// are structurally atypical (the verifier only checks that a path folds to `R_T`, not that it was
+/// built canonically) is refused here instead of being silently mangled.
+pub fn encode_v4_deduped(proof: &PomProof, seed: u64, n_chunks: u64) -> Result<Vec<u8>, PomWireError> {
+    if !is_canonical_v4(proof) {
+        return Err(PomWireError::NotCanonicalV4);
+    }
+    let v4 = proof.v4.as_ref().expect("checked by is_canonical_v4");
+    shape_check(v4)?;
+
+    let n_tiles = v4_n_tiles(n_chunks);
+    if n_tiles == 0 {
+        return Err(PomWireError::BlobTooSmall);
+    }
+    let level0_len = v4_tile_level_len(n_chunks);
+    let plen = v4_tile_path_len(level0_len);
+    if v4.merkle.iter().any(|m| m.path.len() != plen) {
+        return Err(PomWireError::WrongPathLen);
+    }
+
+    let offsets = v4_offset_chain(seed, &v4.tiles, n_tiles);
+
+    let level0 = tile_level(&offsets, &v4.tiles);
+
+    let mut nodes: Vec<[u8; 32]> = Vec::new();
+    walk_levels(level0, level0_len, plen, |level, level_len, known| {
+        // What each tile claims the sibling of its ancestor is, at this level.
+        let mut claimed: BTreeMap<u64, [u8; 32]> = BTreeMap::new();
+        for (i, &off) in offsets.iter().enumerate() {
+            let anc = off >> level;
+            let v = v4.merkle[i].path[level];
+            // Tiles meeting at the same ancestor must agree; otherwise the proof has no single
+            // well-defined compact form and we refuse it.
+            if let Some(prev) = claimed.insert(anc, v) {
+                if prev != v {
+                    return Err(PomWireError::InconsistentPaths);
+                }
+            }
+        }
+
+        let mut full = known.clone();
+        for &idx in known.keys() {
+            if let Some(sib) = needs_sibling(idx, level_len, known) {
+                let v = *claimed.get(&idx).ok_or(PomWireError::Malformed)?;
+                nodes.push(v);
+                full.insert(sib, v);
+            }
+        }
+        Ok(full)
+    })?;
+
+    let mut out = Vec::with_capacity(HEADER_BYTES + POM_V4_K * POM_V4_TILE_BYTES + nodes.len() * 32);
+    out.push(v4.tier);
+    out.extend_from_slice(&proof.pow_value);
+    out.extend_from_slice(&proof.final_state.to_le_bytes());
+    out.extend_from_slice(&(nodes.len() as u32).to_le_bytes());
+    for t in &v4.tiles {
+        out.extend_from_slice(t);
+    }
+    for n in &nodes {
+        out.extend_from_slice(n);
+    }
+    Ok(out)
+}
+
+/// Decode the compact form back into a byte-identical [`PomProof`].
+///
+/// The result is what gets verified, stored, and re-served to peers on the older format, so it must
+/// match the prover's proof exactly — [`encode_v4_deduped`] callers are expected to confirm that by
+/// round-tripping before they rely on it.
+pub fn decode_v4_deduped(bytes: &[u8], seed: u64, n_chunks: u64) -> Result<PomProof, PomWireError> {
+    if bytes.len() < HEADER_BYTES {
+        return Err(PomWireError::Malformed);
+    }
+    let tier = bytes[0];
+    let mut pow_value = [0u8; 32];
+    pow_value.copy_from_slice(&bytes[1..33]);
+    let final_state = u64::from_le_bytes(bytes[33..41].try_into().map_err(|_| PomWireError::Malformed)?);
+    let node_count = u32::from_le_bytes(bytes[41..45].try_into().map_err(|_| PomWireError::Malformed)?) as usize;
+
+    let tiles_bytes = POM_V4_K * POM_V4_TILE_BYTES;
+    // Exact-length check: a compact proof has a fully determined size, so anything else is
+    // malformed. This also bounds `node_count` before it is used to size anything.
+    //
+    // Checked throughout: `node_count` is attacker-controlled and `usize` is 32-bit on wasm, where
+    // `node_count * 32` would otherwise wrap and let a short buffer pass the length check.
+    let expected = node_count
+        .checked_mul(32)
+        .and_then(|n| n.checked_add(HEADER_BYTES))
+        .and_then(|n| n.checked_add(tiles_bytes))
+        .ok_or(PomWireError::Malformed)?;
+    if bytes.len() != expected {
+        return Err(PomWireError::Malformed);
+    }
+
+    let n_tiles = v4_n_tiles(n_chunks);
+    if n_tiles == 0 {
+        return Err(PomWireError::BlobTooSmall);
+    }
+    let level0_len = v4_tile_level_len(n_chunks);
+    let plen = v4_tile_path_len(level0_len);
+
+    let tiles: Vec<Vec<u8>> =
+        bytes[HEADER_BYTES..HEADER_BYTES + tiles_bytes].chunks_exact(POM_V4_TILE_BYTES).map(|t| t.to_vec()).collect();
+    let node_base = HEADER_BYTES + tiles_bytes;
+    let supplied: Vec<[u8; 32]> =
+        bytes[node_base..].chunks_exact(32).map(|c| c.try_into().expect("chunks_exact(32) yields 32 bytes")).collect();
+
+    let offsets = v4_offset_chain(seed, &tiles, n_tiles);
+
+    // Same level-0 construction as the encoder: first tile wins on a repeated offset. A proof whose
+    // duplicate tiles disagree is not rejected here — it simply fails Merkle verification later,
+    // which is the check that is authoritative anyway.
+    let level0 = tile_level(&offsets, &tiles);
+
+    let mut paths: Vec<Vec<[u8; 32]>> = vec![Vec::with_capacity(plen); POM_V4_K];
+    let mut cursor = 0usize;
+    walk_levels(level0, level0_len, plen, |level, level_len, known| {
+        let mut full = known.clone();
+        for &idx in known.keys() {
+            if let Some(sib) = needs_sibling(idx, level_len, known) {
+                let v = *supplied.get(cursor).ok_or(PomWireError::Malformed)?;
+                cursor += 1;
+                full.insert(sib, v);
+            }
+        }
+
+        // Each tile's path entry: its ancestor's sibling, or the ancestor itself on the odd tail —
+        // mirroring `v4_tile_path`'s `if (idx ^ 1) < level.len() { .. } else { level[idx] }`.
+        for (i, &off) in offsets.iter().enumerate() {
+            let anc = off >> level;
+            let sib = anc ^ 1;
+            let key = if sib < level_len { sib } else { anc };
+            paths[i].push(*full.get(&key).ok_or(PomWireError::Malformed)?);
+        }
+        Ok(full)
+    })?;
+
+    // Every supplied node must have been consumed; a trailing remainder means the sender and we
+    // disagree about the tree, which would make the reconstruction wrong in ways verification might
+    // not localise.
+    if cursor != supplied.len() {
+        return Err(PomWireError::Malformed);
+    }
+
+    Ok(PomProof {
+        tier,
+        trace_root: [0u8; 32],
+        pow_value,
+        final_state,
+        initial_trace_path: vec![],
+        final_trace_path: vec![],
+        openings: vec![],
+        steps_v2: None,
+        v3: None,
+        v4: Some(PomProofV4 { tier, tiles, merkle: paths.into_iter().map(|path| PomV4RangeProof { path }).collect() }),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pom_v4::{POM_V4_TILE_CHUNKS, v4_prove};
+    use rand::{Rng, SeedableRng, rngs::StdRng};
+
+    /// Build a real blob, prove against it, and return the proof plus its chunk count — so the
+    /// paths under test are ones the actual prover produced, not ones shaped by hand.
+    fn real_proof(seed: u64, n_tiles: u64, rng_seed: u64) -> (PomProof, u64) {
+        let mut rng = StdRng::seed_from_u64(rng_seed);
+        let mut blob = vec![0u8; (n_tiles as usize) * POM_V4_TILE_BYTES];
+        rng.fill(&mut blob[..]);
+
+        let n_chunks = n_tiles * POM_V4_TILE_CHUNKS;
+        let leaves: Vec<[u8; 32]> = blob.chunks_exact(32).map(crate::pom::blake).collect();
+        let v4 = v4_prove(seed, 0, &blob, &leaves).expect("prove");
+        let proof = PomProof {
+            tier: 0,
+            trace_root: [0u8; 32],
+            pow_value: [0xab; 32],
+            final_state: 0xdead_beef_cafe_f00d,
+            initial_trace_path: vec![],
+            final_trace_path: vec![],
+            openings: vec![],
+            steps_v2: None,
+            v3: None,
+            v4: Some(v4),
+        };
+        (proof, n_chunks)
+    }
+
+    fn assert_round_trip(seed: u64, n_tiles: u64, rng_seed: u64) {
+        let (proof, n_chunks) = real_proof(seed, n_tiles, rng_seed);
+        let enc = encode_v4_deduped(&proof, seed, n_chunks).expect("encode");
+        let dec = decode_v4_deduped(&enc, seed, n_chunks).expect("decode");
+
+        let a = proof.v4.as_ref().unwrap();
+        let b = dec.v4.as_ref().unwrap();
+        assert_eq!(a.tiles, b.tiles, "tiles differ (n_tiles={n_tiles})");
+        for i in 0..POM_V4_K {
+            assert_eq!(a.merkle[i].path, b.merkle[i].path, "path {i} differs (n_tiles={n_tiles})");
+        }
+        // The whole point: the canonical bytes must come back identical, because the reconstructed
+        // proof is stored and re-served to peers still on the legacy format.
+        assert_eq!(proof.to_wire_bytes(), dec.to_wire_bytes(), "canonical wire bytes differ (n_tiles={n_tiles})");
+        assert_eq!(proof.wire_digest(), dec.wire_digest(), "wire digest differs (n_tiles={n_tiles})");
+    }
+
+    #[test]
+    fn round_trip_power_of_two() {
+        assert_round_trip(0x1234_5678, 256, 1);
+    }
+
+    /// Odd level widths exercise `fold_level`'s self-paired tail at several heights — the case that
+    /// silently corrupts reconstruction if the encoder and decoder disagree about it.
+    ///
+    /// Sizes are kept small on purpose: the reference prover rebuilds the whole tree once per tile
+    /// (`v4_tile_path`), so cost grows as `K * n_chunks` and a realistic mainnet blob would take
+    /// minutes in a debug build. The tail behaviour under test is a property of the level widths,
+    /// which these reproduce at every height.
+    #[test]
+    fn round_trip_odd_level_widths() {
+        for n_tiles in [3, 5, 7, 9, 17, 33, 63, 65, 127, 129, 255, 257, 511, 513] {
+            assert_round_trip(0xABCD_EF01 ^ n_tiles, n_tiles, n_tiles);
+        }
+    }
+
+    /// With very few tiles the 256 walk steps collide constantly, so most paths are shared and the
+    /// level-0 map is far smaller than `POM_V4_K`.
+    #[test]
+    fn round_trip_heavy_offset_collisions() {
+        for n_tiles in [1, 2, 4, 8] {
+            assert_round_trip(0x5555 ^ n_tiles, n_tiles, n_tiles + 100);
+        }
+    }
+
+    #[test]
+    fn round_trip_varied_seeds() {
+        for s in 0..8u64 {
+            assert_round_trip(0xDEAD_0000 + s, 333, s);
+        }
+    }
+
+    /// The compact form must be materially smaller than the canonical one — that is its only
+    /// reason to exist.
+    #[test]
+    fn compact_form_is_smaller() {
+        let (proof, n_chunks) = real_proof(42, 512, 7);
+        let enc = encode_v4_deduped(&proof, 42, n_chunks).unwrap();
+        let canonical = proof.to_wire_bytes();
+        assert!(enc.len() < canonical.len(), "compact {} not smaller than canonical {}", enc.len(), canonical.len());
+    }
+
+    #[test]
+    fn rejects_non_canonical_container() {
+        let (mut proof, n_chunks) = real_proof(9, 512, 9);
+        proof.trace_root = [7u8; 32];
+        assert_eq!(encode_v4_deduped(&proof, 9, n_chunks), Err(PomWireError::NotCanonicalV4));
+    }
+
+    #[test]
+    fn rejects_truncated_and_overlong_input() {
+        let (proof, n_chunks) = real_proof(11, 512, 11);
+        let enc = encode_v4_deduped(&proof, 11, n_chunks).unwrap();
+
+        assert!(matches!(decode_v4_deduped(&enc[..enc.len() - 1], 11, n_chunks), Err(PomWireError::Malformed)));
+        assert!(matches!(decode_v4_deduped(&enc[..4], 11, n_chunks), Err(PomWireError::Malformed)));
+
+        let mut long = enc.clone();
+        long.extend_from_slice(&[0u8; 32]);
+        assert!(matches!(decode_v4_deduped(&long, 11, n_chunks), Err(PomWireError::Malformed)));
+    }
+
+    /// Decoding under a different seed derives a different offset chain, so the reconstruction must
+    /// not match — and must not panic either.
+    #[test]
+    fn wrong_seed_does_not_reconstruct() {
+        let (proof, n_chunks) = real_proof(21, 400, 21);
+        let enc = encode_v4_deduped(&proof, 21, n_chunks).unwrap();
+        match decode_v4_deduped(&enc, 22, n_chunks) {
+            Ok(dec) => assert_ne!(proof.to_wire_bytes(), dec.to_wire_bytes(), "different seed must not reconstruct"),
+            Err(_) => {} // refusing outright is equally fine
+        }
+    }
+
+    /// A blob smaller than one tile has no addressable tile; both directions must say so rather
+    /// than divide by zero deriving the offset chain.
+    #[test]
+    fn rejects_blob_too_small() {
+        let (proof, _) = real_proof(3, 64, 3);
+        assert_eq!(encode_v4_deduped(&proof, 3, 0), Err(PomWireError::BlobTooSmall));
+        assert!(matches!(
+            decode_v4_deduped(&[0u8; HEADER_BYTES + POM_V4_K * POM_V4_TILE_BYTES], 3, 0),
+            Err(PomWireError::BlobTooSmall)
+        ));
+    }
+}

--- a/consensus/core/src/pom_v4_wire.rs
+++ b/consensus/core/src/pom_v4_wire.rs
@@ -203,10 +203,10 @@ pub fn encode_v4_deduped(proof: &PomProof, seed: u64, n_chunks: u64) -> Result<V
             let v = v4.merkle[i].path[level];
             // Tiles meeting at the same ancestor must agree; otherwise the proof has no single
             // well-defined compact form and we refuse it.
-            if let Some(prev) = claimed.insert(anc, v) {
-                if prev != v {
-                    return Err(PomWireError::InconsistentPaths);
-                }
+            if let Some(prev) = claimed.insert(anc, v)
+                && prev != v
+            {
+                return Err(PomWireError::InconsistentPaths);
             }
         }
 
@@ -285,7 +285,7 @@ pub fn decode_v4_deduped(bytes: &[u8], seed: u64, n_chunks: u64) -> Result<PomPr
     // which is the check that is authoritative anyway.
     let level0 = tile_level(&offsets, &tiles);
 
-    let mut paths: Vec<Vec<[u8; 32]>> = vec![Vec::with_capacity(plen); POM_V4_K];
+    let mut paths: Vec<Vec<[u8; 32]>> = (0..POM_V4_K).map(|_| Vec::with_capacity(plen)).collect();
     let mut cursor = 0usize;
     walk_levels(level0, level0_len, plen, |level, level_len, known| {
         let mut full = known.clone();
@@ -448,9 +448,9 @@ mod tests {
     fn wrong_seed_does_not_reconstruct() {
         let (proof, n_chunks) = real_proof(21, 400, 21);
         let enc = encode_v4_deduped(&proof, 21, n_chunks).unwrap();
-        match decode_v4_deduped(&enc, 22, n_chunks) {
-            Ok(dec) => assert_ne!(proof.to_wire_bytes(), dec.to_wire_bytes(), "different seed must not reconstruct"),
-            Err(_) => {} // refusing outright is equally fine
+        // Refusing outright is equally fine; what must not happen is a matching reconstruction.
+        if let Ok(dec) = decode_v4_deduped(&enc, 22, n_chunks) {
+            assert_ne!(proof.to_wire_bytes(), dec.to_wire_bytes(), "different seed must not reconstruct");
         }
     }
 

--- a/consensus/src/consensus/storage.rs
+++ b/consensus/src/consensus/storage.rs
@@ -135,10 +135,12 @@ impl ConsensusStorage {
         let utxo_diffs_budget = scaled(80_000_000);
         let block_window_budget = scaled(200_000_000); // x 2 for difficulty and median time
         let acceptance_data_budget = scaled(40_000_000);
-        // PoM v4 proofs are ~296 KB each (K=256 tiles + range proofs). A count-based
+        // PoM v4 proofs are ~442 KiB each on tier 0 and ~458 KiB on tier 4 (K=256 tiles of 1 KB,
+        // 58%, plus one Merkle range proof per tile, 42%) — see
+        // `consensus/core/examples/pom_v4_size.rs`, which computes this per tier. A count-based
         // policy of 10_000 items — what this store used to share with the header-data caches —
-        // reaches ~3 GB and, since item counts are not scaled, ignores `--ram-scale` entirely.
-        // 192 MB holds ~650 hottest proofs of the 1500-DAA / 2000-chain-block window.
+        // reaches ~4.4 GB and, since item counts are not scaled, ignores `--ram-scale` entirely.
+        // 192 MB holds ~435 of the hottest proofs of the 1500-DAA / 2000-chain-block window.
         let pom_proof_budget = scaled(192_000_000);
         // Ratio-reward / coin-age indexes are SPK-keyed over a UTXO-scale keyspace. The old
         // Count(10_000) shared with the UTXO set cache had near-zero hit rate; every virtual-commit

--- a/database/src/db/rocksdb_preset.rs
+++ b/database/src/db/rocksdb_preset.rs
@@ -24,7 +24,8 @@ fn blob_files_disabled() -> bool {
 /// Values at/above this size are written to blob files instead of being carried inline in the LSM
 /// (RocksDB key-value separation, aka BlobDB).
 ///
-/// The node writes one ~296 KB v4 `PomProof` per block at 10 BPS. Inline, every one of those is
+/// The node writes one ~442 KiB v4 `PomProof` per block at 10 BPS (tier 0; ~458 KiB on tier 4).
+/// Inline, every one of those is
 /// rewritten by every compaction that touches its SST — an order-of-magnitude write amplification
 /// on a value that is written once, read rarely (relay re-serve only) and deleted wholesale by the
 /// proof GC. Separated, the LSM carries only a small pointer, so compaction moves metadata instead
@@ -39,14 +40,14 @@ const BLOB_MIN_VALUE_BYTES: u64 = 4 * 1024;
 /// spinning disk the bottleneck is compaction throughput, not the last few percent of space.
 const HDD_BOTTOMMOST_ZSTD_LEVEL: i32 = 6;
 
-/// Default blob-file size for the SSD preset. A v4 proof is ~296 KB; 128 MB files hold ~430
+/// Default blob-file size for the SSD preset. A v4 proof is ~442 KiB; 128 MB files hold ~290
 /// proofs each, matching the 1500-DAA serve window without creating a swarm of tiny blob files.
 const SSD_BLOB_FILE_BYTES: u64 = 128 * 1024 * 1024;
 
-/// Floor for the dedicated blob cache. ~296 KB × 1500 DAA serve-window proofs ≈ 450 MB if every
+/// Floor for the dedicated blob cache. ~442 KiB × 1500 DAA serve-window proofs ≈ 660 MB if every
 /// DAA carried one proof; at 10 BPS the selected-chain window of 2000 chain blocks is ~2000
-/// live proofs ≈ 600 MB. We cannot pin the whole window on a 4 GB box, but 256 MB keeps the
-/// hottest ~850 proofs off the SST LRU so header/UTXO reads stay in cache during catch-up.
+/// live proofs ≈ 880 MB. We cannot pin the whole window on a 4 GB box, but 256 MB keeps the
+/// hottest ~580 proofs off the SST LRU so header/UTXO reads stay in cache during catch-up.
 pub const DA_1500_BLOB_CACHE_MIN_BYTES: usize = 256 * 1024 * 1024;
 
 /// Default background-write rate limit for the HDD preset, in bytes/s.
@@ -69,7 +70,7 @@ pub const DEFAULT_HDD_RATE_LIMIT_BYTES_PER_SEC: u64 = 48 * 1024 * 1024;
 #[derive(Clone)]
 pub struct RocksDbResources {
     block_cache: Cache,
-    /// Dedicated blob cache so ~296 KB v4 PoM proofs do not evict hot SST blocks from `block_cache`.
+    /// Dedicated blob cache so ~442 KiB v4 PoM proofs do not evict hot SST blocks from `block_cache`.
     blob_cache: Cache,
     write_buffer_manager: WriteBufferManager,
     rate_limit_bytes_per_sec: Option<u64>,
@@ -216,7 +217,7 @@ impl RocksDbPreset {
             opts.set_write_buffer_manager(&resources.write_buffer_manager);
         }
 
-        // Smooth the 10 BPS × ~296 KB proof write stream so flushes do not stall the body processor.
+        // Smooth the 10 BPS × ~442 KiB proof write stream so flushes do not stall the body processor.
         opts.set_bytes_per_sync(2 * 1024 * 1024);
         opts.set_wal_bytes_per_sync(2 * 1024 * 1024);
         opts.set_avoid_unnecessary_blocking_io(true);

--- a/database/src/registry.rs
+++ b/database/src/registry.rs
@@ -129,9 +129,10 @@ pub enum DatabaseStorePrefixes {
     CirculatingSupply = 194,
 
     // ---- PoM possession proof ----
-    /// Full PoM possession proof per block: block_hash → borsh(PomProof). Persisted so a block can
-    /// be re-served (relay/IBD) with its proof; otherwise `get_block` returns `pom_proof: None` and
-    /// peers reject the served block (`PoM possession proof missing`).
+    /// Full PoM possession proof per block: block_hash → bincode(PomProof) — bincode, like every
+    /// other `CachedDbAccess` store; borsh is the WIRE encoding only (`PomProof::to_wire_bytes`).
+    /// Persisted so a block can be re-served (relay/IBD) with its proof; otherwise `get_block`
+    /// returns `pom_proof: None` and peers reject the served block (`PoM possession proof missing`).
     PomProof = 195,
     /// Service-bond burned escrow outpoints (finality-deep misses): outpoint → miss daa.
     ServiceBurn = 196,

--- a/protocol/flows/src/flow_context.rs
+++ b/protocol/flows/src/flow_context.rs
@@ -32,7 +32,10 @@ use keryx_notify::notifier::Notify;
 use keryx_p2p_lib::{
     ConnectionInitializer, Hub, KaspadHandshake, PeerKey, PeerProperties, Router,
     common::ProtocolError,
-    convert::model::version::Version,
+    convert::{
+        block::{EncodedPomProof, PomWireFormat, encode_pom_proof},
+        model::version::Version,
+    },
     make_message,
     pb::{InvRelayBlockMessage, kaspad_message::Payload},
 };
@@ -61,7 +64,12 @@ use tokio_stream::{StreamExt, wrappers::UnboundedReceiverStream};
 use uuid::Uuid;
 
 /// The P2P protocol version.
-const PROTOCOL_VERSION: u32 = 10;
+///
+/// 11 adds the compact multiproof encoding for v4 possession proofs
+/// (`BlockMessage.pom_proof_deduped`) and the requester-declared proof horizon
+/// (`RequestIBDBlocksMessage.pom_proof_min_daa`). Both are negotiated per peer, so a v11 node
+/// still serves the full-path encoding to everything older.
+const PROTOCOL_VERSION: u32 = 11;
 
 /// See `check_orphan_resolution_range`
 const BASELINE_ORPHAN_RESOLUTION_RANGE: u32 = 5;
@@ -240,6 +248,10 @@ pub struct FlowContextInner {
     // service window (FIFO + dedup, bounded). Drained by the relay flow, which re-fetches each
     // block from a peer and adopts the proof — the self-healing counterpart of the guard-rail.
     pom_reproof_queue: Mutex<(VecDeque<Hash>, HashSet<Hash>)>,
+    // Compact (multiproof) proof encodings, computed once per block and reused across peers.
+    // Building one costs ~1.3 ms of hashing — affordable once a block, but not once per peer per
+    // block, which at 10 BPS with 8 peers would be ~10% of a core. FIFO-bounded.
+    pom_wire_cache: Mutex<(HashMap<Hash, Arc<Vec<u8>>>, VecDeque<Hash>)>,
 }
 
 #[derive(Clone)]
@@ -344,6 +356,44 @@ impl FlowContext {
         naked
     }
 
+    /// A block's proof encoded for one peer, reusing the compact form when the same block goes out
+    /// to several peers — the common case on relay, where every peer asks for the block within
+    /// milliseconds of the same inv.
+    ///
+    /// Falls back to the legacy bytes whenever the compact form cannot be built, exactly as
+    /// [`encode_pom_proof`] does on its own; the cache only ever changes cost, never content.
+    pub fn encode_pom_proof_cached(&self, format: PomWireFormat, block: &Block) -> EncodedPomProof {
+        /// ~370 KB per entry, so this bounds the cache at roughly 12 MB.
+        const POM_WIRE_CACHE_CAP: usize = 32;
+
+        if format != PomWireFormat::Deduped || block.pom_proof.is_none() {
+            return encode_pom_proof(format, block.header.as_ref(), block.pom_proof.as_ref());
+        }
+        let hash = block.hash();
+        if let Some(hit) = self.pom_wire_cache.lock().0.get(&hash) {
+            return EncodedPomProof { legacy: None, deduped: Some(hit.as_ref().clone()) };
+        }
+        let encoded = encode_pom_proof(format, block.header.as_ref(), block.pom_proof.as_ref());
+        let Some(bytes) = encoded.deduped else {
+            // Compact encoding refused (non-v4 proof, unknown tier, ...). Nothing to cache.
+            return EncodedPomProof { legacy: encoded.legacy, deduped: None };
+        };
+        let shared = Arc::new(bytes);
+        {
+            let mut guard = self.pom_wire_cache.lock();
+            let (map, order) = &mut *guard;
+            if map.insert(hash, shared.clone()).is_none() {
+                if order.len() >= POM_WIRE_CACHE_CAP {
+                    if let Some(evicted) = order.pop_front() {
+                        map.remove(&evicted);
+                    }
+                }
+                order.push_back(hash);
+            }
+        }
+        EncodedPomProof { legacy: None, deduped: Some(shared.as_ref().clone()) }
+    }
+
     /// Queues a block whose possession proof is missing while still within the proof service
     /// window, for re-fetching by the relay flow. FIFO with dedup; bounded — under a mass naked
     /// band the oldest entries are dropped first, and the guard-rail re-queues any block that is
@@ -414,6 +464,7 @@ impl FlowContext {
                 config,
                 mining_rule_engine,
                 pom_reproof_queue: Mutex::new((VecDeque::new(), HashSet::new())),
+                pom_wire_cache: Mutex::new((HashMap::new(), VecDeque::new())),
             }),
         }
     }
@@ -904,6 +955,9 @@ impl ConnectionInitializer for FlowContext {
         // Register all flows according to version
         let (flows, applied_protocol_version) = match peer_version.protocol_version {
             v if v >= PROTOCOL_VERSION => (v8::register(self.clone(), router.clone(), PROTOCOL_VERSION), PROTOCOL_VERSION),
+            // Explicit arm for the previous version: with PROTOCOL_VERSION at 11 the catch-all
+            // above no longer covers v10, and without this every v10 peer gets VersionMismatch.
+            10 => (v8::register(self.clone(), router.clone(), 10), 10),
             9 => (v8::register(self.clone(), router.clone(), 9), 9),
             8 => (v8::register(self.clone(), router.clone(), 8), 8),
             7 => (v7::register(self.clone(), router.clone()), 7),

--- a/protocol/flows/src/ibd/flow.rs
+++ b/protocol/flows/src/ibd/flow.rs
@@ -11,7 +11,6 @@ use keryx_consensus_core::{
     block::Block,
     config::params::POM_PROOF_SERVE_DEPTH_DAA,
     header::Header,
-    pom::PomProof,
     pruning::{PruningPointProof, PruningPointsList, PruningProofMetadata},
     trusted::TrustedBlock,
     tx::Transaction,
@@ -24,6 +23,7 @@ use keryx_p2p_lib::{
     IncomingRoute, Router,
     common::ProtocolError,
     convert::{
+        block::decode_pom_proof,
         header::{HeaderFormat, Versioned},
         model::trusted::TrustedDataPackage,
     },
@@ -905,28 +905,33 @@ staging selected tip ({}) is too small or negative. Aborting IBD...",
             self.router
                 .enqueue(make_message!(
                     Payload::RequestBlockBodies,
-                    RequestBlockBodiesMessage { hashes: chunk.iter().map(|h| h.into()).collect() }
+                    RequestBlockBodiesMessage {
+                        hashes: chunk.iter().map(|h| h.into()).collect(),
+                        // This path discards proofs unconditionally (below), so ask for none:
+                        // a horizon above every possible daa_score means "tier only".
+                        pom_proof_min_daa: Some(u64::MAX),
+                    }
                 ))
                 .await?;
             let mut jobs = Vec::with_capacity(chunk.len());
 
             for &hash in chunk.iter() {
                 let msg = dequeue_with_timeout!(self.incoming_route, Payload::BlockBody)?;
-                let pom_tier = msg.pom_tier.map(|tier| tier as u8);
-                let pom_proof = msg
-                    .pom_proof
-                    .as_deref()
-                    .map(PomProof::from_wire_bytes)
-                    .transpose()
-                    .map_err(|_| ProtocolError::OtherOwned(format!("invalid pom_proof for trusted block {}", hash)))?
-                    .map(Arc::new);
-                let blk_body: BlockBody = msg.try_into()?;
+                // Header first: the compact proof encoding omits the walk seed and tree shape,
+                // which are re-derived from the header, so decoding needs it. Handling both
+                // encodings here keeps this path independent of the peer honouring the horizon
+                // we asked for above.
                 // TODO (relaxed): make header queries in a batch.
                 let blk_header = consensus.async_get_header(hash).await.map_err(|err| {
                     // Conceptually this indicates local inconsistency, since we received the expected hashes via a local
                     // get_missing_block_body_hashes call. However for now we fail gracefully and only disconnect from this peer.
                     ProtocolError::OtherOwned(format!("syncee inconsistency: missing block header for {}, err: {}", hash, err))
                 })?;
+                let pom_tier = msg.pom_tier.map(|tier| tier as u8);
+                let pom_proof = decode_pom_proof(&blk_header, msg.pom_proof.clone(), msg.pom_proof_deduped.clone())
+                    .map_err(|_| ProtocolError::OtherOwned(format!("invalid pom_proof for trusted block {}", hash)))?
+                    .map(Arc::new);
+                let blk_body: BlockBody = msg.try_into()?;
                 if blk_body.is_empty() {
                     return Err(ProtocolError::OtherOwned(format!("sent empty block body for block {}", hash)));
                 }
@@ -958,7 +963,12 @@ staging selected tip ({}) is too small or negative. Aborting IBD...",
             self.router
                 .enqueue(make_message!(
                     Payload::RequestIbdBlocks,
-                    RequestIbdBlocksMessage { hashes: chunk.iter().map(|h| h.into()).collect() }
+                    RequestIbdBlocksMessage {
+                        hashes: chunk.iter().map(|h| h.into()).collect(),
+                        // This path discards proofs unconditionally (below), so ask for none:
+                        // a horizon above every possible daa_score means "tier only".
+                        pom_proof_min_daa: Some(u64::MAX),
+                    }
                 ))
                 .await?;
             let mut jobs = Vec::with_capacity(chunk.len());
@@ -1070,7 +1080,13 @@ staging selected tip ({}) is too small or negative. Aborting IBD...",
         self.router
             .enqueue(make_message!(
                 Payload::RequestIbdBlocks,
-                RequestIbdBlocksMessage { hashes: chunk.iter().map(|h| h.into()).collect() }
+                RequestIbdBlocksMessage {
+                    hashes: chunk.iter().map(|h| h.into()).collect(),
+                    // Tell the server our own proof horizon so it stops shipping proofs we would
+                    // strip on arrival anyway (below). Stating it ourselves is sound where the
+                    // server guessing it is not: it is our policy, applied at the source.
+                    pom_proof_min_daa: Some(high_daa.saturating_sub(POM_PROOF_SERVE_DEPTH_DAA)),
+                }
             ))
             .await?;
         for &expected_hash in chunk {
@@ -1110,7 +1126,13 @@ staging selected tip ({}) is too small or negative. Aborting IBD...",
         self.router
             .enqueue(make_request!(
                 Payload::RequestBlockBodies,
-                RequestBlockBodiesMessage { hashes: chunk.iter().map(|h| h.into()).collect() },
+                RequestBlockBodiesMessage {
+                    hashes: chunk.iter().map(|h| h.into()).collect(),
+                    // Tell the server our own proof horizon so it stops shipping proofs we would
+                    // strip on arrival anyway (below). Stating it ourselves is sound where the
+                    // server guessing it is not: it is our policy, applied at the source.
+                    pom_proof_min_daa: Some(high_daa.saturating_sub(POM_PROOF_SERVE_DEPTH_DAA)),
+                },
                 self.incoming_route.id()
             ))
             .await?;
@@ -1121,19 +1143,17 @@ staging selected tip ({}) is too small or negative. Aborting IBD...",
             // block can later be relayed to proof-enforcing peers (otherwise it is served "naked"
             // and rejected with "PoM possession proof missing").
             let pom_tier = msg.pom_tier.map(|t| t as u8);
-            let pom_proof = msg
-                .pom_proof
-                .as_deref()
-                .map(PomProof::from_wire_bytes)
-                .transpose()
-                .map_err(|_| ProtocolError::OtherOwned(format!("invalid pom_proof for block {}", expected_hash)))?
-                .map(Arc::new);
+            // The header has to come first: the compact proof encoding omits the walk seed and the
+            // tree shape precisely because both are re-derivable from the header.
             // TODO (relaxed): make header queries in a batch.
             let blk_header = consensus.async_get_header(expected_hash).await.map_err(|err| {
                 // Conceptually this indicates local inconsistency, since we received the expected hashes via a local
                 // get_missing_block_body_hashes call. However for now we fail gracefully and only disconnect from this peer.
                 ProtocolError::OtherOwned(format!("syncee inconsistency: missing block header for {}, err: {}", expected_hash, err))
             })?;
+            let pom_proof = decode_pom_proof(&blk_header, msg.pom_proof.clone(), msg.pom_proof_deduped.clone())
+                .map_err(|_| ProtocolError::OtherOwned(format!("invalid pom_proof for block {}", expected_hash)))?
+                .map(Arc::new);
             let blk_body: BlockBody = msg.try_into()?;
             if blk_body.is_empty() {
                 return Err(ProtocolError::OtherOwned(format!("sent empty block body for block {}", expected_hash)));

--- a/protocol/flows/src/v7/blockrelay/handle_requests.rs
+++ b/protocol/flows/src/v7/blockrelay/handle_requests.rs
@@ -3,7 +3,7 @@ use keryx_core::debug;
 use keryx_p2p_lib::{
     IncomingRoute, Router,
     common::ProtocolError,
-    convert::header::HeaderFormat,
+    convert::{block::PomWireFormat, header::HeaderFormat},
     dequeue_with_request_id, make_message, make_response,
     pb::{InvRelayBlockMessage, kaspad_message::Payload},
 };
@@ -14,6 +14,7 @@ pub struct HandleRelayBlockRequests {
     router: Arc<Router>,
     incoming_route: IncomingRoute,
     header_format: HeaderFormat,
+    pom_format: PomWireFormat,
 }
 
 #[async_trait::async_trait]
@@ -28,8 +29,14 @@ impl Flow for HandleRelayBlockRequests {
 }
 
 impl HandleRelayBlockRequests {
-    pub fn new(ctx: FlowContext, router: Arc<Router>, incoming_route: IncomingRoute, header_format: HeaderFormat) -> Self {
-        Self { ctx, router, incoming_route, header_format }
+    pub fn new(
+        ctx: FlowContext,
+        router: Arc<Router>,
+        incoming_route: IncomingRoute,
+        header_format: HeaderFormat,
+        pom_format: PomWireFormat,
+    ) -> Self {
+        Self { ctx, router, incoming_route, header_format, pom_format }
     }
 
     async fn start_impl(&mut self) -> Result<(), ProtocolError> {
@@ -47,7 +54,13 @@ impl HandleRelayBlockRequests {
             for hash in hashes {
                 let block = session.async_get_block(hash).await?;
                 self.ctx.warn_if_serving_naked_pom_block(&block);
-                self.router.enqueue(make_response!(Payload::Block, (self.header_format, &block).into(), request_id)).await?;
+                self.router
+                    .enqueue(make_response!(
+                        Payload::Block,
+                        (self.header_format, self.ctx.encode_pom_proof_cached(self.pom_format, &block), &block).into(),
+                        request_id
+                    ))
+                    .await?;
                 debug!("relayed block with hash {} to peer {}", hash, self.router);
             }
         }

--- a/protocol/flows/src/v7/mod.rs
+++ b/protocol/flows/src/v7/mod.rs
@@ -15,7 +15,10 @@ use crate::v7::{
     txrelay::flow::{RelayTransactionsFlow, RequestTransactionsFlow},
 };
 use crate::{flow_context::FlowContext, flow_trait::Flow};
-use keryx_p2p_lib::{KaspadMessagePayloadType, Router, SharedIncomingRoute, convert::header::HeaderFormat};
+use keryx_p2p_lib::{
+    KaspadMessagePayloadType, Router, SharedIncomingRoute,
+    convert::{block::PomWireFormat, header::HeaderFormat},
+};
 use keryx_utils::channel;
 use std::sync::Arc;
 
@@ -40,6 +43,8 @@ pub fn register(ctx: FlowContext, router: Arc<Router>) -> Vec<Box<dyn Flow>> {
     let body_only_ibd_permitted = false;
     // P2P header format prior to v9 is not compressed (legacy)
     let header_format = HeaderFormat::Legacy;
+    // A v7 peer is pre-v11 by definition, so it only understands the full-path encoding.
+    let pom_format = PomWireFormat::Legacy;
     let mut flows: Vec<Box<dyn Flow>> = vec![
         Box::new(IbdFlow::new(
             ctx.clone(),
@@ -72,6 +77,7 @@ pub fn register(ctx: FlowContext, router: Arc<Router>) -> Vec<Box<dyn Flow>> {
             router.clone(),
             router.subscribe(vec![KaspadMessagePayloadType::RequestRelayBlocks]),
             header_format,
+            pom_format,
         )),
         Box::new(ReceivePingsFlow::new(ctx.clone(), router.clone(), router.subscribe(vec![KaspadMessagePayloadType::Ping]))),
         Box::new(SendPingsFlow::new(ctx.clone(), router.clone(), router.subscribe(vec![KaspadMessagePayloadType::Pong]))),
@@ -100,6 +106,7 @@ pub fn register(ctx: FlowContext, router: Arc<Router>) -> Vec<Box<dyn Flow>> {
                 KaspadMessagePayloadType::RequestNextPruningPointAndItsAnticoneBlocks,
             ]),
             header_format,
+            pom_format,
         )),
         Box::new(RequestPruningPointUtxoSetFlow::new(
             ctx.clone(),
@@ -119,6 +126,7 @@ pub fn register(ctx: FlowContext, router: Arc<Router>) -> Vec<Box<dyn Flow>> {
             router.clone(),
             router.subscribe(vec![KaspadMessagePayloadType::RequestIbdBlocks]),
             header_format,
+            pom_format,
         )),
         Box::new(HandleAntipastRequests::new(
             ctx.clone(),

--- a/protocol/flows/src/v7/request_ibd_blocks.rs
+++ b/protocol/flows/src/v7/request_ibd_blocks.rs
@@ -1,7 +1,10 @@
 use crate::{flow_context::FlowContext, flow_trait::Flow};
 use keryx_core::debug;
 use keryx_p2p_lib::{
-    IncomingRoute, Router, common::ProtocolError, convert::header::HeaderFormat, dequeue_with_request_id, make_response,
+    IncomingRoute, Router,
+    common::ProtocolError,
+    convert::{block::PomWireFormat, header::HeaderFormat},
+    dequeue_with_request_id, make_response,
     pb::kaspad_message::Payload,
 };
 use std::sync::Arc;
@@ -11,6 +14,7 @@ pub struct HandleIbdBlockRequests {
     router: Arc<Router>,
     incoming_route: IncomingRoute,
     header_format: HeaderFormat,
+    pom_format: PomWireFormat,
 }
 
 #[async_trait::async_trait]
@@ -25,27 +29,51 @@ impl Flow for HandleIbdBlockRequests {
 }
 
 impl HandleIbdBlockRequests {
-    pub fn new(ctx: FlowContext, router: Arc<Router>, incoming_route: IncomingRoute, header_format: HeaderFormat) -> Self {
-        Self { ctx, router, incoming_route, header_format }
+    pub fn new(
+        ctx: FlowContext,
+        router: Arc<Router>,
+        incoming_route: IncomingRoute,
+        header_format: HeaderFormat,
+        pom_format: PomWireFormat,
+    ) -> Self {
+        Self { ctx, router, incoming_route, header_format, pom_format }
     }
 
     async fn start_impl(&mut self) -> Result<(), ProtocolError> {
         loop {
             let (msg, request_id) = dequeue_with_request_id!(self.incoming_route, Payload::RequestIbdBlocks)?;
+            // The requester's own proof horizon (see the field doc in p2p.proto). Absent from
+            // pre-v11 peers, in which case nothing is stripped.
+            let pom_proof_min_daa = msg.pom_proof_min_daa;
             let hashes: Vec<_> = msg.try_into()?;
 
             debug!("got request for {} IBD blocks", hashes.len());
             let session = self.ctx.consensus().unguarded_session();
 
             for hash in hashes {
-                let block = session.async_get_block(hash).await?;
-                self.ctx.warn_if_serving_naked_pom_block(&block);
-                // Always ship the possession proof when we have it. Depth-stripping it against OUR
-                // virtual is unsound: the receiver's virtual lags behind ours during IBD, so a block
-                // that is "deep" for us can still be recent for the receiver — it would persist the
-                // block naked and later be rejected by proof-enforcing relay peers (the 2026-07-31
-                // naked-band wedge). Proofs we no longer have (GC'd) are absent anyway.
-                self.router.enqueue(make_response!(Payload::IbdBlock, (self.header_format, &block).into(), request_id)).await?;
+                let mut block = session.async_get_block(hash).await?;
+                // Never depth-strip against OUR virtual: the receiver's virtual lags behind ours
+                // during IBD, so a block that is "deep" for us can still be recent for the receiver
+                // — it would persist the block naked and later be rejected by proof-enforcing relay
+                // peers. Proofs we no longer have (GC'd) are absent anyway.
+                //
+                // We do strip when the REQUESTER states its own horizon: that is its policy applied
+                // at the source, so it can never drop a proof the receiver would have kept — and it
+                // saves shipping ~440 KB that the receiver was going to discard on arrival.
+                if pom_proof_min_daa.is_some_and(|min_daa| block.header.daa_score < min_daa) {
+                    // Keep the tier: it is consensus-critical for the coinbase tier-reward split.
+                    block.pom_tier = block.pom_tier.or_else(|| block.pom_proof.as_ref().map(|p| p.tier));
+                    block.pom_proof = None;
+                } else {
+                    self.ctx.warn_if_serving_naked_pom_block(&block);
+                }
+                self.router
+                    .enqueue(make_response!(
+                        Payload::IbdBlock,
+                        (self.header_format, self.ctx.encode_pom_proof_cached(self.pom_format, &block), &block).into(),
+                        request_id
+                    ))
+                    .await?;
             }
         }
     }

--- a/protocol/flows/src/v7/request_pruning_point_and_anticone.rs
+++ b/protocol/flows/src/v7/request_pruning_point_and_anticone.rs
@@ -7,7 +7,7 @@ use itertools::Itertools;
 use keryx_p2p_lib::{
     IncomingRoute, Router,
     common::ProtocolError,
-    convert::header::HeaderFormat,
+    convert::{block::PomWireFormat, header::HeaderFormat},
     dequeue, dequeue_with_request_id, make_response,
     pb::{
         BlockWithTrustedDataV4Message, DoneBlocksWithTrustedDataMessage, PruningPointsMessage, TrustedDataMessage,
@@ -24,6 +24,7 @@ pub struct PruningPointAndItsAnticoneRequestsFlow {
     router: Arc<Router>,
     incoming_route: IncomingRoute,
     header_format: HeaderFormat,
+    pom_format: PomWireFormat,
 }
 
 #[async_trait::async_trait]
@@ -38,8 +39,14 @@ impl Flow for PruningPointAndItsAnticoneRequestsFlow {
 }
 
 impl PruningPointAndItsAnticoneRequestsFlow {
-    pub fn new(ctx: FlowContext, router: Arc<Router>, incoming_route: IncomingRoute, header_format: HeaderFormat) -> Self {
-        Self { ctx, router, incoming_route, header_format }
+    pub fn new(
+        ctx: FlowContext,
+        router: Arc<Router>,
+        incoming_route: IncomingRoute,
+        header_format: HeaderFormat,
+        pom_format: PomWireFormat,
+    ) -> Self {
+        Self { ctx, router, incoming_route, header_format, pom_format }
     }
 
     async fn start_impl(&mut self) -> Result<(), ProtocolError> {
@@ -84,7 +91,12 @@ impl PruningPointAndItsAnticoneRequestsFlow {
                         .enqueue(make_response!(
                             Payload::BlockWithTrustedDataV4,
                             // No need to send window indices in v6
-                            BlockWithTrustedDataV4Message { block: Some((self.header_format, &block).into()), ..Default::default() },
+                            BlockWithTrustedDataV4Message {
+                                block: Some(
+                                    (self.header_format, self.ctx.encode_pom_proof_cached(self.pom_format, &block), &block).into()
+                                ),
+                                ..Default::default()
+                            },
                             request_id
                         ))
                         .await?;

--- a/protocol/flows/src/v8/mod.rs
+++ b/protocol/flows/src/v8/mod.rs
@@ -17,7 +17,10 @@ pub(crate) mod request_block_bodies;
 use crate::{flow_context::FlowContext, flow_trait::Flow};
 
 use crate::ibd::IbdFlow;
-use keryx_p2p_lib::{KaspadMessagePayloadType, Router, SharedIncomingRoute, convert::header::HeaderFormat};
+use keryx_p2p_lib::{
+    KaspadMessagePayloadType, Router, SharedIncomingRoute,
+    convert::{block::PomWireFormat, header::HeaderFormat},
+};
 use keryx_utils::channel;
 use request_block_bodies::HandleBlockBodyRequests;
 use std::sync::Arc;
@@ -28,6 +31,8 @@ pub fn register(ctx: FlowContext, router: Arc<Router>, protocol_version: u32) ->
     let (ibd_sender, relay_receiver) = channel::job();
     let body_only_ibd_permitted = true;
     let header_format = HeaderFormat::from(protocol_version);
+    // Compact multiproof proof encoding from v11 on; older peers keep the full-path form.
+    let pom_format = PomWireFormat::from(protocol_version);
     let mut flows: Vec<Box<dyn Flow>> = vec![
         Box::new(IbdFlow::new(
             ctx.clone(),
@@ -61,6 +66,7 @@ pub fn register(ctx: FlowContext, router: Arc<Router>, protocol_version: u32) ->
             router.clone(),
             router.subscribe(vec![KaspadMessagePayloadType::RequestRelayBlocks]),
             header_format,
+            pom_format,
         )),
         Box::new(ReceivePingsFlow::new(ctx.clone(), router.clone(), router.subscribe(vec![KaspadMessagePayloadType::Ping]))),
         Box::new(SendPingsFlow::new(ctx.clone(), router.clone(), router.subscribe(vec![KaspadMessagePayloadType::Pong]))),
@@ -89,6 +95,7 @@ pub fn register(ctx: FlowContext, router: Arc<Router>, protocol_version: u32) ->
                 KaspadMessagePayloadType::RequestNextPruningPointAndItsAnticoneBlocks,
             ]),
             header_format,
+            pom_format,
         )),
         Box::new(RequestPruningPointUtxoSetFlow::new(
             ctx.clone(),
@@ -108,11 +115,13 @@ pub fn register(ctx: FlowContext, router: Arc<Router>, protocol_version: u32) ->
             router.clone(),
             router.subscribe(vec![KaspadMessagePayloadType::RequestIbdBlocks]),
             header_format,
+            pom_format,
         )),
         Box::new(HandleBlockBodyRequests::new(
             ctx.clone(),
             router.clone(),
             router.subscribe(vec![KaspadMessagePayloadType::RequestBlockBodies]),
+            pom_format,
         )),
         Box::new(HandleAntipastRequests::new(
             ctx.clone(),

--- a/protocol/flows/src/v8/request_block_bodies.rs
+++ b/protocol/flows/src/v8/request_block_bodies.rs
@@ -1,7 +1,8 @@
 use crate::{flow_context::FlowContext, flow_trait::Flow};
 use keryx_core::debug;
 use keryx_p2p_lib::{
-    IncomingRoute, Router, common::ProtocolError, dequeue_with_request_id, make_response, pb::kaspad_message::Payload,
+    IncomingRoute, Router, common::ProtocolError, convert::block::PomWireFormat, dequeue_with_request_id, make_response,
+    pb::kaspad_message::Payload,
 };
 use std::sync::Arc;
 
@@ -9,6 +10,7 @@ pub struct HandleBlockBodyRequests {
     ctx: FlowContext,
     router: Arc<Router>,
     incoming_route: IncomingRoute,
+    pom_format: PomWireFormat,
 }
 
 #[async_trait::async_trait]
@@ -23,13 +25,16 @@ impl Flow for HandleBlockBodyRequests {
 }
 
 impl HandleBlockBodyRequests {
-    pub fn new(ctx: FlowContext, router: Arc<Router>, incoming_route: IncomingRoute) -> Self {
-        Self { ctx, router, incoming_route }
+    pub fn new(ctx: FlowContext, router: Arc<Router>, incoming_route: IncomingRoute, pom_format: PomWireFormat) -> Self {
+        Self { ctx, router, incoming_route, pom_format }
     }
 
     async fn start_impl(&mut self) -> Result<(), ProtocolError> {
         loop {
             let (msg, request_id) = dequeue_with_request_id!(self.incoming_route, Payload::RequestBlockBodies)?;
+            // The requester's own proof horizon (see the field doc in p2p.proto). Absent from
+            // pre-v11 peers, in which case nothing is stripped.
+            let pom_proof_min_daa = msg.pom_proof_min_daa;
             let hashes: Vec<_> = msg.try_into()?;
             debug!("got request for {} blocks bodies", hashes.len());
             let session = self.ctx.consensus().unguarded_session();
@@ -39,17 +44,27 @@ impl HandleBlockBodyRequests {
                 // possession proof travel with the body: a syncing peer needs the tier to validate
                 // the coinbase tier-reward split, and the proof so the block it persists can later
                 // be relayed to proof-enforcing peers (otherwise it is served "naked" and rejected
-                // with "PoM possession proof missing"). Always ship the proof when we have it:
-                // depth-stripping it against OUR virtual is unsound, since the receiver's virtual
-                // lags behind ours during IBD — a block "deep" for us can still be recent for the
-                // receiver, which would persist it naked and later be rejected by proof-enforcing
-                // relay peers (the 2026-07-31 naked-band wedge).
+                // with "PoM possession proof missing").
+                //
+                // Never depth-strip against OUR virtual: the receiver's virtual lags behind ours
+                // during IBD, so a block "deep" for us can still be recent for the receiver, which
+                // would persist it naked and later be rejected by proof-enforcing relay peers. We
+                // strip only when the REQUESTER told us its own horizon, which by construction
+                // cannot drop a proof it would have kept.
                 let block = session.async_get_block(hash).await?;
-                self.ctx.warn_if_serving_naked_pom_block(&block);
+                let below_horizon = pom_proof_min_daa.is_some_and(|min_daa| block.header.daa_score < min_daa);
+                if !below_horizon {
+                    self.ctx.warn_if_serving_naked_pom_block(&block);
+                }
                 let mut body_msg: keryx_p2p_lib::pb::BlockBodyMessage = block.transactions.as_ref().into();
-                body_msg.pom_tier =
-                    block.pom_tier.map(|t| t as u32).or_else(|| block.pom_proof.as_ref().map(|p| p.tier as u32));
-                body_msg.pom_proof = block.pom_proof.as_ref().map(|p| p.to_wire_bytes());
+                // The tier is kept even when the proof is dropped: it is consensus-critical for the
+                // coinbase tier-reward split.
+                body_msg.pom_tier = block.pom_tier.map(|t| t as u32).or_else(|| block.pom_proof.as_ref().map(|p| p.tier as u32));
+                if !below_horizon {
+                    let pom = self.ctx.encode_pom_proof_cached(self.pom_format, &block);
+                    body_msg.pom_proof = pom.legacy;
+                    body_msg.pom_proof_deduped = pom.deduped;
+                }
                 self.router.enqueue(make_response!(Payload::BlockBody, body_msg, request_id)).await?;
             }
         }

--- a/protocol/p2p/proto/p2p.proto
+++ b/protocol/p2p/proto/p2p.proto
@@ -68,6 +68,12 @@ message BlockMessage{
   // unavailable (legacy blocks have a stored tier but no proof). Consensus-critical: scales
   // the coinbase tier-reward split. Absent before pom_activation.
   optional uint32 pom_tier = 4;
+  // Same v4 proof as pom_proof, in the compact multiproof encoding (pom_v4_wire): the K tile
+  // Merkle paths share their upper levels, so ~40% of the sibling hashes in pom_proof are
+  // redundant. Sent INSTEAD of pom_proof to peers at protocol version >= 11; exactly one of the
+  // two is ever set. Decoding rebuilds a byte-identical PomProof, so what gets verified, stored
+  // and re-served to older peers is unchanged.
+  optional bytes pom_proof_deduped = 5;
 }
 
 message BlockBodyMessage{
@@ -79,6 +85,9 @@ message BlockBodyMessage{
   // can later be relayed to proof-enforcing peers (otherwise they are served "naked" and
   // rejected with "PoM possession proof missing"). Absent before pom_activation.
   optional bytes pom_proof = 3;
+  // Compact multiproof encoding of the same v4 proof — see BlockMessage.pom_proof_deduped.
+  // Sent instead of pom_proof to peers at protocol version >= 11.
+  optional bytes pom_proof_deduped = 4;
 }
 
 message BlockHeader{
@@ -212,10 +221,21 @@ message DonePruningPointUtxoSetChunksMessage {
 
 message RequestIBDBlocksMessage{
   repeated Hash hashes = 1;
+  // Lowest daa_score for which the REQUESTER still wants possession proofs; blocks below it are
+  // served with pom_tier only. The requester states its own horizon because the server cannot
+  // safely infer it: depth-stripping against the SERVER's virtual is unsound during IBD, since the
+  // receiver's virtual lags and a block that is deep for the server may still be recent for the
+  // receiver, leaving it with a band of proof-less blocks that wedges its own serving. Applied at
+  // the source it is just the receiver's own policy, so nothing is stripped that the receiver would
+  // have kept. Absent => send proofs for everything, i.e. the pre-v11 behaviour.
+  optional uint64 pom_proof_min_daa = 2;
 }
 
 message RequestBlockBodiesMessage{
   repeated Hash hashes = 1;
+  // Lowest daa_score for which the REQUESTER still wants possession proofs — see
+  // RequestIBDBlocksMessage.pom_proof_min_daa.
+  optional uint64 pom_proof_min_daa = 2;
 }
 
 message UnexpectedPruningPointMessage{

--- a/protocol/p2p/src/convert/block.rs
+++ b/protocol/p2p/src/convert/block.rs
@@ -1,21 +1,97 @@
 use super::error::ConversionError;
 use super::header::{HeaderFormat, Versioned};
 use crate::pb as protowire;
-use keryx_consensus_core::{block::Block, pom::PomProof, tx::Transaction};
+use keryx_consensus_core::{block::Block, header::Header, pom::PomProof, pom_v4_wire, tx::Transaction};
 type BlockBody = Vec<Transaction>;
+
+/// Which encoding a peer gets for a v4 possession proof.
+///
+/// Separate from [`HeaderFormat`] because it flips at a different protocol version (11, against 9),
+/// and derived from the negotiated version at flow registration so a single peer is always served
+/// one consistent format.
+///
+/// Only the SEND side needs this: the receive side is self-describing, since the compact form
+/// arrives in its own protobuf field.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum PomWireFormat {
+    /// Full borsh `PomProof` in `pom_proof` — every tile carries its whole Merkle path.
+    Legacy,
+    /// Multiproof encoding in `pom_proof_deduped`, dropping the ~40% of sibling hashes that the
+    /// receiver can derive. See `keryx_consensus_core::pom_v4_wire`.
+    Deduped,
+}
+
+impl From<u32> for PomWireFormat {
+    fn from(version: u32) -> Self {
+        if version >= 11 { Self::Deduped } else { Self::Legacy }
+    }
+}
+
+/// A proof already encoded for one peer. At most one field is `Some`, and which one depends on the
+/// peer's protocol version.
+///
+/// This is a parameter of the message conversions rather than something they compute, for two
+/// reasons: building the compact form costs ~1.3 ms of hashing and callers serving one block to
+/// many peers want to do it once (`FlowContext::encode_pom_proof_cached`), and making it explicit
+/// means a serving path cannot silently ship a block with no proof, which peers then reject with
+/// `PoM possession proof missing`.
+#[derive(Debug, Default, Clone)]
+pub struct EncodedPomProof {
+    /// Full borsh `PomProof`, for `pom_proof`.
+    pub legacy: Option<Vec<u8>>,
+    /// Compact multiproof form, for `pom_proof_deduped`.
+    pub deduped: Option<Vec<u8>>,
+}
+
+/// Encode a proof for one peer, preferring the compact form when the peer speaks it.
+///
+/// Any reason the compact form cannot be produced — a non-v4 proof, an unknown tier, paths that are
+/// not canonically shaped — falls back to the legacy bytes rather than failing the serve. The proof
+/// still reaches the peer; it is just bigger. That fallback is what makes this safe to deploy: the
+/// compact form is an optimisation, never a correctness dependency.
+pub fn encode_pom_proof(format: PomWireFormat, header: &Header, proof: Option<&std::sync::Arc<PomProof>>) -> EncodedPomProof {
+    let Some(proof) = proof else { return EncodedPomProof::default() };
+    if format == PomWireFormat::Deduped
+        && let Ok(compact) = pom_v4_wire::v4_wire_context(header, proof.tier)
+            .and_then(|(seed, n_chunks)| pom_v4_wire::encode_v4_deduped(proof, seed, n_chunks))
+    {
+        return EncodedPomProof { legacy: None, deduped: Some(compact) };
+    }
+    // `to_wire_bytes` keeps a pre-H4 proof (steps_v2 == None) byte-identical to the legacy
+    // layout, so not-yet-updated peers still decode re-served pre-H4 blocks.
+    EncodedPomProof { legacy: Some(proof.to_wire_bytes()), deduped: None }
+}
+
+/// Decode whichever proof encoding a peer sent. `header` is needed for the compact form only, to
+/// re-derive the walk seed and tree shape that the encoding deliberately omits.
+pub fn decode_pom_proof(
+    header: &Header,
+    pom_proof: Option<Vec<u8>>,
+    pom_proof_deduped: Option<Vec<u8>>,
+) -> Result<Option<PomProof>, ConversionError> {
+    if let Some(bytes) = pom_proof_deduped {
+        let tier = pom_v4_wire::deduped_tier(&bytes).ok_or(ConversionError::PomProofDecode)?;
+        let (seed, n_chunks) = pom_v4_wire::v4_wire_context(header, tier).map_err(|_| ConversionError::PomProofDecode)?;
+        let proof = pom_v4_wire::decode_v4_deduped(&bytes, seed, n_chunks).map_err(|_| ConversionError::PomProofDecode)?;
+        return Ok(Some(proof));
+    }
+    if let Some(bytes) = pom_proof {
+        return Ok(Some(PomProof::from_wire_bytes(&bytes).map_err(|_| ConversionError::PomProofDecode)?));
+    }
+    Ok(None)
+}
 // ----------------------------------------------------------------------------
 // consensus_core to protowire
 // ----------------------------------------------------------------------------
 
-impl From<(HeaderFormat, &Block)> for protowire::BlockMessage {
-    fn from(value: (HeaderFormat, &Block)) -> Self {
-        let (header_format, block) = value;
+impl From<(HeaderFormat, EncodedPomProof, &Block)> for protowire::BlockMessage {
+    fn from(value: (HeaderFormat, EncodedPomProof, &Block)) -> Self {
+        let (header_format, pom, block) = value;
         Self {
             header: Some((header_format, block.header.as_ref()).into()),
             transactions: block.transactions.iter().map(|tx| tx.into()).collect(),
-            // `to_wire_bytes` keeps a pre-H4 proof (steps_v2 == None) byte-identical to the legacy
-            // layout, so not-yet-updated peers still decode re-served pre-H4 blocks.
-            pom_proof: block.pom_proof.as_ref().map(|p| p.to_wire_bytes()),
+            pom_proof: pom.legacy,
+            pom_proof_deduped: pom.deduped,
             // Carry the tier explicitly (falls back to the proof's tier) so it survives IBD even
             // when the full proof is absent (legacy blocks).
             pom_tier: block.pom_tier.or_else(|| block.pom_proof.as_ref().map(|p| p.tier)).map(|t| t as u32),
@@ -24,9 +100,14 @@ impl From<(HeaderFormat, &Block)> for protowire::BlockMessage {
 }
 impl From<&BlockBody> for protowire::BlockBodyMessage {
     fn from(block_body: &BlockBody) -> Self {
-        // `pom_tier`/`pom_proof` are set by the IBD body serving flow (it has the block hash to
-        // look them up); this `BlockBody` (= just transactions) carries neither.
-        Self { transactions: block_body.iter().map(|tx| tx.into()).collect(), pom_tier: None, pom_proof: None }
+        // `pom_tier`/`pom_proof*` are set by the IBD body serving flow (it has the block hash to
+        // look them up); this `BlockBody` (= just transactions) carries none of them.
+        Self {
+            transactions: block_body.iter().map(|tx| tx.into()).collect(),
+            pom_tier: None,
+            pom_proof: None,
+            pom_proof_deduped: None,
+        }
     }
 }
 
@@ -41,9 +122,12 @@ impl TryFrom<Versioned<protowire::BlockMessage>> for Block {
         let Versioned(header_format, block) = value;
         let header = block.header.ok_or(ConversionError::NoneValue)?;
         let txs = block.transactions.into_iter().map(|i| i.try_into()).collect::<Result<Vec<Transaction>, Self::Error>>()?;
-        let mut blk = Block::new(Versioned(header_format, header).try_into()?, txs);
-        if let Some(bytes) = block.pom_proof {
-            let proof = PomProof::from_wire_bytes(&bytes).map_err(|_| ConversionError::PomProofDecode)?;
+        let hdr: Header = Versioned(header_format, header).try_into()?;
+        // Decode the proof against the header: the compact encoding omits the walk seed and tree
+        // shape precisely because both are derivable from it.
+        let proof = decode_pom_proof(&hdr, block.pom_proof, block.pom_proof_deduped)?;
+        let mut blk = Block::new(hdr, txs);
+        if let Some(proof) = proof {
             blk = blk.with_pom_proof(proof);
         }
         blk = blk.with_pom_tier(block.pom_tier.map(|t| t as u8));
@@ -106,10 +190,67 @@ mod tests {
         }
     }
 
+    /// A v11 peer must still receive pre-v4 proofs in the legacy field: only v4 proofs have a
+    /// compact form, and everything older has to keep flowing untouched.
+    #[test]
+    fn deduped_format_falls_back_for_non_v4_proofs() {
+        for proof in [dummy_proof(), dummy_proof_v2()] {
+            let block = Block::from_precomputed_hash(Hash::from_bytes([1u8; 32]), vec![]).with_pom_proof(proof);
+            let msg: protowire::BlockMessage = (
+                HeaderFormat::Legacy,
+                encode_pom_proof(PomWireFormat::Deduped, block.header.as_ref(), block.pom_proof.as_ref()),
+                &block,
+            )
+                .into();
+            assert!(msg.pom_proof.is_some(), "non-v4 proof must fall back to the legacy field");
+            assert!(msg.pom_proof_deduped.is_none());
+
+            // And it still decodes, which is the point of the fallback.
+            let back: Block = Versioned(HeaderFormat::Legacy, msg).try_into().unwrap();
+            assert!(back.pom_proof.is_some());
+        }
+    }
+
+    /// The two encodings are mutually exclusive: a peer never has to guess which one it got, and a
+    /// proof is never paid for twice.
+    #[test]
+    fn exactly_one_proof_encoding_is_set() {
+        for format in [PomWireFormat::Legacy, PomWireFormat::Deduped] {
+            let block = Block::from_precomputed_hash(Hash::from_bytes([2u8; 32]), vec![]).with_pom_proof(dummy_proof_v2());
+            let msg: protowire::BlockMessage =
+                (HeaderFormat::Legacy, encode_pom_proof(format, block.header.as_ref(), block.pom_proof.as_ref()), &block).into();
+            assert_eq!(msg.pom_proof.is_some() as u8 + msg.pom_proof_deduped.is_some() as u8, 1, "{format:?}");
+        }
+    }
+
+    /// A block with no proof stays with no proof, in either format.
+    #[test]
+    fn absent_proof_stays_absent() {
+        for format in [PomWireFormat::Legacy, PomWireFormat::Deduped] {
+            let block = Block::from_precomputed_hash(Hash::from_bytes([3u8; 32]), vec![]);
+            let msg: protowire::BlockMessage =
+                (HeaderFormat::Legacy, encode_pom_proof(format, block.header.as_ref(), block.pom_proof.as_ref()), &block).into();
+            assert!(msg.pom_proof.is_none() && msg.pom_proof_deduped.is_none(), "{format:?}");
+        }
+    }
+
+    /// The version threshold is what keeps a v11 node from sending a v10 peer bytes it cannot parse.
+    #[test]
+    fn wire_format_follows_protocol_version() {
+        for v in 0..11 {
+            assert_eq!(PomWireFormat::from(v), PomWireFormat::Legacy, "version {v}");
+        }
+        for v in [11, 12, 50] {
+            assert_eq!(PomWireFormat::from(v), PomWireFormat::Deduped, "version {v}");
+        }
+    }
+
     #[test]
     fn pom_proof_survives_p2p_roundtrip() {
         let block = Block::from_precomputed_hash(Hash::from_bytes([1u8; 32]), vec![]).with_pom_proof(dummy_proof());
-        let msg: protowire::BlockMessage = (HeaderFormat::Legacy, &block).into();
+        let msg: protowire::BlockMessage =
+            (HeaderFormat::Legacy, encode_pom_proof(PomWireFormat::Legacy, block.header.as_ref(), block.pom_proof.as_ref()), &block)
+                .into();
         assert!(msg.pom_proof.is_some());
         let back: Block = Versioned(HeaderFormat::Legacy, msg).try_into().unwrap();
         let p = back.pom_proof.expect("proof preserved over the wire");
@@ -150,7 +291,9 @@ mod tests {
     #[test]
     fn no_proof_roundtrips_as_none() {
         let block = Block::from_precomputed_hash(Hash::from_bytes([2u8; 32]), vec![]);
-        let msg: protowire::BlockMessage = (HeaderFormat::Legacy, &block).into();
+        let msg: protowire::BlockMessage =
+            (HeaderFormat::Legacy, encode_pom_proof(PomWireFormat::Legacy, block.header.as_ref(), block.pom_proof.as_ref()), &block)
+                .into();
         assert!(msg.pom_proof.is_none());
         let back: Block = Versioned(HeaderFormat::Legacy, msg).try_into().unwrap();
         assert!(back.pom_proof.is_none());
@@ -159,7 +302,9 @@ mod tests {
     #[test]
     fn proofless_forged_tier_survives_p2p_roundtrip() {
         let block = Block::from_precomputed_hash(Hash::from_bytes([4u8; 32]), vec![]).with_pom_tier(Some(4));
-        let msg: protowire::BlockMessage = (HeaderFormat::Legacy, &block).into();
+        let msg: protowire::BlockMessage =
+            (HeaderFormat::Legacy, encode_pom_proof(PomWireFormat::Legacy, block.header.as_ref(), block.pom_proof.as_ref()), &block)
+                .into();
 
         assert!(msg.pom_proof.is_none());
         assert_eq!(msg.pom_tier, Some(4));
@@ -172,7 +317,9 @@ mod tests {
     #[test]
     fn v2_proof_survives_p2p_roundtrip() {
         let block = Block::from_precomputed_hash(Hash::from_bytes([3u8; 32]), vec![]).with_pom_proof(dummy_proof_v2());
-        let msg: protowire::BlockMessage = (HeaderFormat::Legacy, &block).into();
+        let msg: protowire::BlockMessage =
+            (HeaderFormat::Legacy, encode_pom_proof(PomWireFormat::Legacy, block.header.as_ref(), block.pom_proof.as_ref()), &block)
+                .into();
         let back: Block = Versioned(HeaderFormat::Legacy, msg).try_into().unwrap();
         let p = back.pom_proof.expect("v2 proof preserved over the wire");
         assert_eq!(p.tier, 4);


### PR DESCRIPTION
## Summary

At 10 BPS every block carries a v4 `PomProof`: **442.1 KiB** on tier 0. Serving one block to 8 peers is ~3.5 MB of upload; sustained, ~35 MB/s just for possession proofs.

All `POM_V4_K` tile Merkle paths climb to the **same** per-tier root, so their upper levels are shared — yet the canonical borsh form ships every path in full. Measured: **5 888 siblings on the wire against 3 502 distinct ones needed**, i.e. 40.5 % of the path field is redundant.

This PR sends a Merkle **multiproof** instead, and adds a **requester-declared proof horizon** so IBD stops shipping proofs the receiver will discard on arrival.

**Transport only.** No consensus rule changes, no DAA gate, no `keryx-miner` lockstep. The proof that gets verified, stored and re-served is byte-identical to what the miner produced.

## Why not just compress it

Both compression layers a reader would reach for **are already enabled** — tonic gzip on every p2p channel (`connection_handler.rs`), and LZ4/ZSTD on the RocksDB blob files. Adding an application-level codec stacks on top of gzip and returns approximately nothing:

| payload | raw | gzip | gzip saves |
|---|---:|---:|---:|
| full proof (borsh) | 452 705 | 404 212 | **10.7 %** |
| tiles only (weight bytes) | 262 144 | 262 207 | **-0.02 %** |
| merkle paths, tile-major | 188 416 | 140 678 | 25.3 % |

The tiles — 58 % of the proof — are **incompressible**; gzip makes them larger. All of gzip's 10.7 % comes from the Merkle field, and it cannot reach all of it, because there are two kinds of redundancy:

1. **Literal duplicates** (~1 872) — deflate can back-reference these, *but only within its 32 KiB window*: ~1 533 are reachable, ~339 are not.
2. **Derivable ancestors** (~515) — a sibling that is itself an ancestor of another tile. Each appears **exactly once** in the byte stream, so **no compressor of any window size can ever remove them.**

That gap is why a codec swap cannot close it:

| what a peer actually receives | bytes | vs today |
|---|---:|---:|
| today: legacy + gzip | 404 212 | baseline |
| level-major reorder + gzip | 394 110 | -2.5 % |
| **compact multiproof** | **374 253** | **-7.4 %** |
| ceiling for any pure-codec change (e.g. zstd) | ~382 800 | ~-5.3 % |

Swapping gzip for zstd recovers at most ~74 % of what the multiproof recovers, and the two do **not** add up: once the multiproof removes the redundancy, there is nothing left for zstd to find.

> **Honest limit.** 7.4 % is an improvement, not a fix. The proof remains the dominant bandwidth item. A 2-4x reduction requires changing the proof itself (`POM_V4_K`, tile size, or a v3-style spot-check) — a DAA-gated fork with mandatory miner lockstep, deliberately out of scope here.

## Design

**The hinge: nothing positional goes on the wire.** `verify_pom_proof_v4` already derives the tile-offset chain from the block seed and the tiles' leading snippets, and the tree shape follows from the tier's chunk count. A receiver therefore knows every tile's leaf index **without being told**. So the compact form is a bare list of sibling hashes in canonical order — no bitmap, no indices, no offsets, no tree metadata.

```
tier          1 byte
pow_value    32 bytes
final_state   8 bytes  (LE)
node_count    4 bytes  (LE u32)
tiles        POM_V4_K * POM_V4_TILE_BYTES   (fixed size, no per-tile length prefix)
nodes        node_count * 32                (deduplicated siblings, canonical order)
```

Encoder and decoder share **one** traversal (`walk_levels`, a `BTreeMap` keyed by node index, iterated ascending) so they cannot drift apart on node ordering. `v4_offset_chain` was extracted from the verifier and is now used by both — if the two ever derived different offsets, the reconstructed paths would be silently wrong and blocks would be rejected with no obvious cause.

### Two correctness traps, for reviewers

1. **Odd-tail self-pairing.** The `R_T` tree is *not* padded to a power of two; `fold_level` pairs an odd level's last node with itself. Both directions replicate this exactly.
2. **`v4_tile_level_len` ceils, `v4_n_tiles` floors.** Tier 4 is exactly that case: 28 999 814 addressable tiles under a level of 28 999 815 nodes. The tree *shape* follows the ceil, the offset *range* the floor. Conflating them shifts the tree by one.

### Fallback, not dependency

`encode_pom_proof` returns the legacy bytes whenever the compact form cannot be produced — non-v4 proof, tier outside `POM_TIERS_H6`, path lengths that disagree with the tree. The proof still reaches the peer, just larger. **The compact form is an optimisation and never a correctness dependency.**

## Protocol changes

`PROTOCOL_VERSION` **10 -> 11**. New protobuf fields, all optional and therefore wire-compatible in both directions:

```proto
BlockMessage.pom_proof_deduped              = 5
BlockBodyMessage.pom_proof_deduped          = 4
RequestIBDBlocksMessage.pom_proof_min_daa   = 2
RequestBlockBodiesMessage.pom_proof_min_daa = 2
```

`PomWireFormat::from(version)` selects `Deduped` at `>= 11`, mirroring the existing `HeaderFormat` precedent (which flips at 9). Exactly one of `pom_proof` / `pom_proof_deduped` is ever set, so a receiver never has to guess: **the send side is version-gated, the receive side self-describing.** That is why only the four serving flows needed the format threaded through.

The explicit `10 =>` dispatch arm is **required, not cosmetic** — with `PROTOCOL_VERSION` at 11 the `v >= PROTOCOL_VERSION` catch-all no longer covers v10, and without the arm every v10 peer drops straight to `VersionMismatch`.

## Requester-declared proof horizon

The IBD serve path deliberately never depth-stripped proofs, and rightly so: stripping against the *server's* virtual is unsound, because the receiver's virtual lags during IBD — a block that is deep for the server can still be recent for the receiver, leaving a band of proof-less blocks that wedges its serving. The receiver then received the full proof, decoded it, and threw it away.

Inverting who decides makes stripping sound: **the requester states its own horizon**, which by construction cannot drop a proof the receiver would have kept. The two IBD paths that discard proofs unconditionally now request none at all (`Some(u64::MAX)`) — a **100 % saving** on those transfers rather than 7.4 %. `sync_missing_block_bodies` passes its real horizon.

`pom_tier` is always retained even when the proof is dropped: it is consensus-critical for the coinbase tier-reward split.

## Encode-once cache

Building the compact form costs **~1.29 ms** of hashing (folding 256 tile subtree roots, ~16k blake3 compressions — parallelised with rayon, as the verifier already does). Per peer that would be **10.3 % of a core** at 10 BPS x 8 peers, more than the 7.4 % of bandwidth is worth. `FlowContext::encode_pom_proof_cached` computes it once per block and shares it across peers: **1.29 %**. FIFO-bounded at 32 entries (~12 MB).

Decode costs ~1.25 ms per block (~1.3 % of a core at 10 BPS) and cannot be cached — each block is decoded once. This is a real regression against the legacy `from_wire_bytes` (~100 us), accepted as the price of the encoding.

The encoded proof is an **explicit parameter** of the message conversion (`EncodedPomProof`) rather than something the conversion computes, so a serving path cannot silently ship a block with no proof and have peers reject it with `PoM possession proof missing`.

## Byte-exact reconstruction is a hard requirement

The decoded `PomProof` is stored and later **re-served to peers on the older format**, and `PomProof::wire_digest()` feeds negative caching. So decode must reproduce the prover's proof *exactly* — not merely an equivalent one. The round-trip tests assert this.

## Stale accounting fixed (third commit, comments only)

The `~296 KB` figure for a v4 proof was wrong in two places, and everything derived from it was off by ~1.5x:

- `consensus/src/consensus/storage.rs` — the 192 MB budget was documented as holding ~650 proofs; it holds **~435** (a ~33 % mis-size).
- `database/src/db/rocksdb_preset.rs` — 128 MB blob files hold **~290**, not ~430.
- `PomProofV4::approx_bytes()` omitted the borsh length prefixes (~2 KB), biasing the byte-tracked cache policy low on **every** entry.
- `database/src/registry.rs` documented the proof store as borsh; on disk it is **bincode**, like every other `CachedDbAccess` store (borsh is the wire encoding only). Verified against `database/src/access.rs`.

## Testing

```
9  property tests   pom_v4_wire                            ok
4  compat tests     convert/block.rs                       ok
109 / 111 / 12      consensus-core / consensus / p2p-lib   0 failed
cargo check --workspace --tests --benches --examples       ok
```

The 9 property tests cover power-of-two and odd level widths (3...513), heavy offset collisions (1-8 tiles), varied seeds, non-canonical container rejection, truncated and over-long input, wrong seed, and a blob too small to hold one tile. Attacker-controlled lengths use **checked arithmetic** — `node_count * 32` overflows a 32-bit `usize`, and this crate builds for wasm32.

Round-trip verified **byte-exact at real tier-0 dimensions**, including `wire_digest()`.

Consensus tests pass **unmodified** — the check that the "wire-only" scope was not violated.

Reproduce every figure in this description:

```bash
cargo run --release -p keryx-consensus-core --example pom_v4_size
```

> Note: the example fills tiles from a CSPRNG — the incompressible worst case. Real Q4/Q8 GGUF bytes are close but not identical, so treat the tiles' gzip ratio as a lower bound. The sibling *count* is exact regardless: it is purely structural.

## Not yet done

**A live two-node test has not been run.** The remaining verification is to sync a v10 and a v11 node from the same peer and compare the `CountBytesBody` counters in `connection_handler.rs`, which measure **post-compression** bytes — the metric that matters. Everything verifiable without a second node has been verified.

## Deployment

- **No miner lockstep** — miners keep submitting proofs unchanged via `submit_block`; the node re-encodes for p2p only.
- **No consensus change, no DAA gate** — a v11 node and a v10 node accept exactly the same blocks.
- **Gains require both peers on v11** — against a v10 network the wire behaviour is unchanged, so this rolls out incrementally with no flag day.
- **Rollback is safe** — reverting to a v10 binary changes only which encoding is negotiated.
