### PR TITLE
p2p: stop the node evicting its own peers (discovery and retention)

### DIFF
--- a/components/addressmanager/src/lib.rs
+++ b/components/addressmanager/src/lib.rs
@@ -2,7 +2,13 @@ mod port_mapping_extender;
 mod stores;
 extern crate self as address_manager;
 
-use std::{collections::HashSet, iter, net::SocketAddr, sync::Arc, time::Duration};
+use std::{
+    collections::HashSet,
+    iter,
+    net::{IpAddr, Ipv6Addr, SocketAddr},
+    sync::Arc,
+    time::Duration,
+};
 
 use address_manager::port_mapping_extender::Extender;
 use igd_next::{
@@ -32,6 +38,15 @@ const UPNP_EXTEND_PERIOD: u64 = UPNP_DEADLINE_SEC / 2;
 
 /// The name used as description when registering the UPnP service
 pub(crate) const UPNP_REGISTRATION_NAME: &str = "keryx-labs";
+
+/// Normalizes an address to the v6-mapped form the address store keys on, so that a ban recorded
+/// against `1.2.3.4` also matches an entry stored as `::ffff:1.2.3.4`.
+fn mapped_v6(ip: IpAddress) -> Ipv6Addr {
+    match ip.0 {
+        IpAddr::V4(ip) => ip.to_ipv6_mapped(),
+        IpAddr::V6(ip) => ip,
+    }
+}
 
 struct ExtendHelper {
     gateway: Gateway,
@@ -78,7 +93,10 @@ impl AddressManager {
         let extender = if self.local_net_addresses.is_empty() && !self.config.disable_upnp {
             let (net_address, ExtendHelper { gateway, local_addr, external_port }) = match self.upnp() {
                 Err(err) => {
-                    info!("[UPnP] Port mapping unavailable ({}). Use --disable-upnp to silence or --externalip to set your public IP manually.", err);
+                    info!(
+                        "[UPnP] Port mapping unavailable ({}). Use --disable-upnp to silence or --externalip to set your public IP manually.",
+                        err
+                    );
                     return None;
                 }
                 Ok(None) => return None,
@@ -106,6 +124,19 @@ impl AddressManager {
             None
         };
 
+        if self.local_net_addresses.is_empty() {
+            // Without a local address there is nothing to put in our handshake `Version` message,
+            // so no peer ever learns how to reach us and this node can only make outbound
+            // connections. That is a silent, permanent halving of its connectivity, so say it out
+            // loud rather than leaving it to an `info!` line lost in the boot log.
+            warn!(
+                "This node has no publicly routable address{} — it will advertise NO address to peers, \
+                 no other node can learn how to reach it, and it will receive ZERO inbound connections. \
+                 Set --externalip=<public-ip>[:<port>] and forward TCP {} to fix this.",
+                if self.config.disable_upnp { " and UPnP is disabled" } else { " and UPnP port mapping did not succeed" },
+                self.config.default_p2p_port()
+            );
+        }
         self.local_net_addresses.iter().for_each(|net_addr| {
             info!("Publicly routable local address {} added to store", net_addr);
         });
@@ -258,36 +289,58 @@ impl AddressManager {
         }
     }
 
-    pub fn add_address(&mut self, address: NetAddress) {
+    /// Adds `address` to the store. Returns whether it was newly learned, which callers use to
+    /// decide whether a discovery round actually made progress.
+    pub fn add_address(&mut self, address: NetAddress) -> bool {
         if address.ip.is_loopback() || address.ip.is_unspecified() {
             debug!("[Address manager] skipping local address {}", address.ip);
-            return;
+            return false;
         }
 
         // Do not re-add banned IPs — they would be re-selected for outbound connections
         if self.is_banned(address.ip) {
-            return;
+            return false;
         }
 
         if self.address_store.has(address) {
-            return;
+            return false;
         }
 
         // We mark `connection_failed_count` as 0 only after first success
         self.address_store.set(address, 1);
+        true
     }
 
+    /// Records a failed dial for `address`.
+    ///
+    /// The failure count *saturates* at [`MAX_CONNECTION_FAILED_COUNT`] instead of evicting the
+    /// entry. Deleting on the 4th failure used to make the store starve itself: a fresh gossiped
+    /// address enters with count 1, so three unlucky dials (a single lost SYN is enough at the p2p
+    /// connect timeout) erased an honest peer permanently, and the only way back in was a new
+    /// gossip or DNS result — which on a two-seeder network means never. A saturated entry keeps a
+    /// weight 64^3 below a proven peer (see `iterate_prioritized_random_addresses`), so it
+    /// is almost never selected, and one success resets it to 0. Capacity pressure is handled by
+    /// `keep_limit`, which already evicts the highest-failure entries first.
     pub fn mark_connection_failure(&mut self, address: NetAddress) {
         if !self.address_store.has(address) {
             return;
         }
 
-        let new_count = self.address_store.get(address).connection_failed_count + 1;
-        if new_count > MAX_CONNECTION_FAILED_COUNT {
-            self.address_store.remove(address);
-        } else {
-            self.address_store.set(address, new_count);
-        }
+        let new_count = (self.address_store.get(address).connection_failed_count + 1).min(MAX_CONNECTION_FAILED_COUNT);
+        self.address_store.set(address, new_count);
+    }
+
+    /// Decrements every non-zero failure count by one. Called when the selection iterator is
+    /// exhausted while the store is non-empty, i.e. when every known address has been written off:
+    /// without this, a node that was offline long enough to saturate all of its entries would keep
+    /// treating them as hopeless forever.
+    pub fn decay_connection_failures(&mut self) {
+        self.address_store.decay_connection_failures();
+    }
+
+    /// Number of addresses currently known (banned entries included).
+    pub fn address_count(&self) -> usize {
+        self.address_store.len()
     }
 
     pub fn mark_connection_success(&mut self, address: NetAddress) {
@@ -302,16 +355,33 @@ impl AddressManager {
         self.address_store.iterate_addresses()
     }
 
+    /// Outbound selection iterator, excluding `exceptions` and every address whose IP is currently
+    /// banned. The ban filter lives here (rather than in `ban`, which used to delete the entries)
+    /// and honors the ban expiry: an expired ban is lifted in passing and its addresses become
+    /// selectable again.
     pub fn iterate_prioritized_random_addresses(
-        &self,
-        exceptions: HashSet<NetAddress>,
+        &mut self,
+        mut exceptions: HashSet<NetAddress>,
     ) -> impl ExactSizeIterator<Item = NetAddress> + 'static {
+        let banned: HashSet<Ipv6Addr> =
+            self.get_all_banned_addresses().into_iter().filter(|&ip| self.is_banned(ip)).map(mapped_v6).collect();
+        if !banned.is_empty() {
+            exceptions
+                .extend(self.address_store.iterate_addresses().filter(|addr| banned.contains(&mapped_v6(addr.ip))).collect_vec());
+        }
         self.address_store.iterate_prioritized_random_addresses(exceptions)
     }
 
+    /// Bans `ip` for `MAX_BANNED_TIME` (24h).
+    ///
+    /// The addresses of that IP are deliberately *kept* in the store: a ban is local policy that
+    /// expires after 24h, and dropping the entries turned every ban into a permanent forget — after
+    /// the ban lifted, the peer could only come back through a seeder or fresh gossip. They are
+    /// filtered out of outbound selection while the ban holds (see
+    /// [`AddressManager::iterate_prioritized_random_addresses`]) and re-admitted automatically once
+    /// it expires.
     pub fn ban(&mut self, ip: IpAddress) {
         self.banned_address_store.set(ip.into(), ConnectionBanTimestamp(unix_now())).unwrap();
-        self.address_store.remove_by_ip(ip.into());
     }
 
     pub fn unban(&mut self, ip: IpAddress) {
@@ -347,7 +417,6 @@ mod address_store_with_cache {
     // We don't expect it to be expensive since we limit the number of saved addresses.
     use std::{
         collections::{HashMap, HashSet},
-        net::IpAddr,
         sync::Arc,
     };
 
@@ -410,10 +479,6 @@ mod address_store_with_cache {
             *self.addresses.get(&address.into()).unwrap()
         }
 
-        pub fn remove(&mut self, address: NetAddress) {
-            self.remove_by_key(address.into())
-        }
-
         fn remove_by_key(&mut self, key: AddressKey) {
             self.addresses.remove(&key);
             self.db_store.remove(key).unwrap()
@@ -421,6 +486,27 @@ mod address_store_with_cache {
 
         pub fn iterate_addresses(&self) -> impl Iterator<Item = NetAddress> + '_ {
             self.addresses.values().map(|entry| entry.address)
+        }
+
+        pub fn len(&self) -> usize {
+            self.addresses.len()
+        }
+
+        /// Decrements every non-zero `connection_failed_count`. Counts only ever shrink here, so
+        /// there is no need to re-run `keep_limit`.
+        pub fn decay_connection_failures(&mut self) {
+            let decayed = self
+                .addresses
+                .iter()
+                .filter(|(_, entry)| entry.connection_failed_count > 0)
+                .map(|(key, entry)| {
+                    (*key, Entry { connection_failed_count: entry.connection_failed_count - 1, address: entry.address })
+                })
+                .collect_vec();
+            for (key, entry) in decayed {
+                self.db_store.set(key, entry).unwrap();
+                self.addresses.insert(key, entry);
+            }
         }
 
         /// This iterator functions as the node's ip routing selection algo.
@@ -463,12 +549,6 @@ mod address_store_with_cache {
             }
 
             RandomWeightedIterator::new(weights, filtered_addresses)
-        }
-
-        pub fn remove_by_ip(&mut self, ip: IpAddr) {
-            for key in self.addresses.keys().filter(|key| key.is_ip(ip)).copied().collect_vec() {
-                self.remove_by_key(key);
-            }
         }
     }
 
@@ -537,6 +617,76 @@ mod address_store_with_cache {
         use keryx_utils::networking::IpAddress;
         use rv::{dist::Uniform, misc::ks_test as one_way_ks_test, traits::Cdf};
         use std::net::{IpAddr, Ipv6Addr};
+
+        fn test_address_manager() -> Arc<parking_lot::Mutex<AddressManager>> {
+            let db = create_temp_db!(ConnBuilder::default().with_files_limit(10));
+            // The temp db is dropped with its handle, so leak it for the lifetime of the test
+            std::mem::forget(db.0);
+            AddressManager::new(Arc::new(Config::new(SIMNET_PARAMS)), db.1, Arc::new(TickService::default())).0
+        }
+
+        fn addr(s: &str) -> NetAddress {
+            NetAddress::new(IpAddress::from_str(s).unwrap(), 22111)
+        }
+
+        #[test]
+        fn failed_dials_saturate_instead_of_evicting() {
+            let am = test_address_manager();
+            let mut am = am.lock();
+            let peer = addr("1.2.3.4");
+
+            assert!(am.add_address(peer), "a fresh address is newly learned");
+            assert!(!am.add_address(peer), "a known address is not learned again");
+
+            for _ in 0..(MAX_CONNECTION_FAILED_COUNT + 5) {
+                am.mark_connection_failure(peer);
+            }
+            assert_eq!(am.address_count(), 1, "a written-off address must stay in the store");
+            assert_eq!(am.iterate_prioritized_random_addresses(HashSet::new()).count(), 1, "and stay selectable, at low weight");
+
+            am.mark_connection_success(peer);
+            assert_eq!(am.address_count(), 1);
+        }
+
+        #[test]
+        fn decay_lets_a_written_off_store_recover() {
+            let am = test_address_manager();
+            let mut am = am.lock();
+            let peer = addr("1.2.3.4");
+            am.add_address(peer);
+            for _ in 0..(MAX_CONNECTION_FAILED_COUNT + 5) {
+                am.mark_connection_failure(peer);
+            }
+            for _ in 0..MAX_CONNECTION_FAILED_COUNT {
+                am.decay_connection_failures();
+            }
+            assert_eq!(am.address_count(), 1);
+        }
+
+        #[test]
+        fn ban_hides_the_address_without_forgetting_it() {
+            let am = test_address_manager();
+            let mut am = am.lock();
+            let peer = addr("1.2.3.4");
+            am.add_address(peer);
+
+            am.ban(peer.ip);
+            assert_eq!(am.address_count(), 1, "a ban expires after 24h, so it must not delete the entry");
+            assert_eq!(am.iterate_prioritized_random_addresses(HashSet::new()).count(), 0, "but it must not be dialed meanwhile");
+
+            am.unban(peer.ip);
+            assert_eq!(am.iterate_prioritized_random_addresses(HashSet::new()).count(), 1, "and comes back once the ban lifts");
+        }
+
+        #[test]
+        fn ban_matches_v4_mapped_entries() {
+            let am = test_address_manager();
+            let mut am = am.lock();
+            am.add_address(addr("::ffff:1.2.3.4"));
+
+            am.ban(IpAddress::from_str("1.2.3.4").unwrap());
+            assert_eq!(am.iterate_prioritized_random_addresses(HashSet::new()).count(), 0);
+        }
 
         #[test]
         fn test_weighted_iterator() {

--- a/components/addressmanager/src/stores/mod.rs
+++ b/components/addressmanager/src/stores/mod.rs
@@ -12,13 +12,6 @@ impl AddressKey {
     pub fn new(ip: Ipv6Addr, port: u16) -> Self {
         Self(ip, port)
     }
-
-    pub fn is_ip(&self, ip: IpAddr) -> bool {
-        match ip {
-            IpAddr::V4(ip) => ip.to_ipv6_mapped() == self.0,
-            IpAddr::V6(ip) => ip == self.0,
-        }
-    }
 }
 
 impl From<NetAddress> for AddressKey {

--- a/components/connectionmanager/src/lib.rs
+++ b/components/connectionmanager/src/lib.rs
@@ -27,6 +27,18 @@ use tokio::{
 const PING_TIMEOUT_BAN_THRESHOLD: u32 = 3;
 const PING_TIMEOUT_WINDOW: Duration = Duration::from_secs(600); // 10 minutes
 
+/// How long a protocol version learned from a handshake is trusted for outbound preference.
+/// A peer that upgrades must be able to stop looking old, so the observation expires.
+const KNOWN_PROTOCOL_TTL: Duration = Duration::from_secs(86400); // 24 hours
+/// Hard ceiling on the version map, mirroring `MAX_ADDRESSES` in the address store. The map is keyed
+/// by remote-supplied IPs, so it needs a bound.
+const MAX_KNOWN_PROTOCOL_ENTRIES: usize = 4096;
+/// The first protocol version that encodes a v4 PoM proof as a compact multiproof. Older peers
+/// serve the same proof in the legacy encoding — correct, just several times heavier on the wire.
+const COMPACT_POM_PROTOCOL_VERSION: u32 = 11;
+/// How many candidates to draw per free outbound slot before ranking them by protocol preference.
+const CANDIDATE_POOL_FACTOR: usize = 3;
+
 fn canonical_ip(ip: IpAddr) -> IpAddr {
     match ip {
         IpAddr::V6(ip) => ip.to_ipv4_mapped().map(IpAddr::V4).unwrap_or(IpAddr::V6(ip)),
@@ -56,6 +68,9 @@ pub struct ConnectionManager {
     force_next_iteration: UnboundedSender<()>,
     shutdown_signal: SingleTrigger,
     ping_timeout_tracker: ParkingLotMutex<HashMap<IpAddr, PingTimeoutRecord>>,
+    /// Last protocol version negotiated with each IP, plus the instant it was learned. Used to
+    /// prefer peers that serve the compact proof encoding while keeping older ones dialable.
+    known_protocols: ParkingLotMutex<HashMap<IpAddr, (u32, Instant)>>,
 }
 
 #[derive(Clone, Debug)]
@@ -94,10 +109,54 @@ impl ConnectionManager {
             ban_exempt_seeders,
             default_port,
             ping_timeout_tracker: Default::default(),
+            known_protocols: Default::default(),
         });
         manager.clone().start_event_loop(rx);
         manager.force_next_iteration.send(()).unwrap();
         manager
+    }
+
+    /// Records the protocol version actually negotiated with `ip`. Called from the handshake path;
+    /// best-effort and never blocks the flow.
+    pub fn record_peer_protocol_version(&self, ip: IpAddr, version: u32) {
+        let ip = canonical_ip(ip);
+        let now = Instant::now();
+        let mut known = self.known_protocols.lock();
+        if known.len() >= MAX_KNOWN_PROTOCOL_ENTRIES && !known.contains_key(&ip) {
+            // Full, and this is a new IP: drop what already expired, and if that frees nothing, drop
+            // the oldest observation. Either way a peer cycling through addresses cannot grow the map.
+            known.retain(|_, (_, learned_at)| now.duration_since(*learned_at) <= KNOWN_PROTOCOL_TTL);
+            if known.len() >= MAX_KNOWN_PROTOCOL_ENTRIES
+                && let Some(oldest) = known.iter().min_by_key(|(_, (_, learned_at))| *learned_at).map(|(ip, _)| *ip)
+            {
+                known.remove(&oldest);
+            }
+        }
+        known.insert(ip, (version, now));
+    }
+
+    /// Dial preference, lowest first. Every version here serves a valid v4 PoM proof; v11 differs
+    /// only in encoding it as a compact multiproof, so this ranks peers by what a block costs on the
+    /// wire, not by what they are capable of. It is therefore a preference over a candidate pool and
+    /// **not** a filter: an older peer is still dialed when nothing better is on offer, which is what
+    /// keeps the network from partitioning along the version line while v11 adoption is partial.
+    fn peer_protocol_preference(ip: IpAddr, known: &HashMap<IpAddr, (u32, Instant)>, now: Instant) -> u8 {
+        let version = known
+            .get(&canonical_ip(ip))
+            .filter(|(_, learned_at)| now.duration_since(*learned_at) <= KNOWN_PROTOCOL_TTL)
+            .map(|(version, _)| *version);
+        match version {
+            Some(v) if v >= COMPACT_POM_PROTOCOL_VERSION => 0, // compact multiproof encoding
+            None => 1,                                         // never met, or the observation expired
+            Some(10) => 2,                                     // legacy encoding, deliberately still dialed
+            Some(_) => 3,                                      // older
+        }
+    }
+
+    /// Drops expired protocol observations. Without this the map grows over the process lifetime.
+    fn gc_known_protocols(&self) {
+        let now = Instant::now();
+        self.known_protocols.lock().retain(|_, (_, learned_at)| now.duration_since(*learned_at) <= KNOWN_PROTOCOL_TTL);
     }
 
     fn start_event_loop(self: Arc<Self>, mut rx: UnboundedReceiver<()>) {
@@ -126,6 +185,7 @@ impl ConnectionManager {
         self.handle_connection_requests(&peer_by_address).await;
         self.handle_outbound_connections(&peer_by_address).await;
         self.handle_inbound_connections(&peer_by_address).await;
+        self.gc_known_protocols();
     }
 
     pub async fn add_connection_request(&self, address: SocketAddr, is_permanent: bool) {
@@ -199,13 +259,27 @@ impl ConnectionManager {
             if self.shutdown_signal.trigger.is_triggered() {
                 return;
             }
-            let mut addrs_to_connect = Vec::with_capacity(missing_connections);
-            let mut jobs = Vec::with_capacity(missing_connections);
-            for _ in 0..missing_connections {
+            // Gather a pool larger than needed and rank it by proof encoding: a node whose outbound
+            // slots all went to pre-v11 peers still syncs, but pays the legacy proof encoding on every
+            // block — which is the bandwidth the v4 proof made expensive in the first place.
+            let mut candidates = Vec::with_capacity(missing_connections * CANDIDATE_POOL_FACTOR);
+            while candidates.len() < missing_connections * CANDIDATE_POOL_FACTOR {
                 let Some(net_addr) = addr_iter.next() else {
                     connecting = false;
                     break;
                 };
+                candidates.push(net_addr);
+            }
+            // `sort_by_key` is stable, so the failure-weighted random order the address store handed
+            // us survives inside each preference tier — the ranking re-orders tiers, it does not
+            // replace the selection policy.
+            let now = Instant::now();
+            let known = self.known_protocols.lock().clone();
+            candidates.sort_by_key(|net_addr| Self::peer_protocol_preference(net_addr.ip.into(), &known, now));
+
+            let mut addrs_to_connect = Vec::with_capacity(missing_connections);
+            let mut jobs = Vec::with_capacity(missing_connections);
+            for net_addr in candidates.into_iter().take(missing_connections) {
                 let socket_addr = SocketAddr::new(net_addr.ip.into(), net_addr.port).to_string();
                 debug!("Connecting to {}", &socket_addr);
                 addrs_to_connect.push(net_addr);
@@ -413,5 +487,58 @@ mod tests {
         assert!(is_fixed_seed_ip(seeders, "192.0.2.1".parse().unwrap()));
         assert!(is_fixed_seed_ip(seeders, "::ffff:192.0.2.1".parse().unwrap()));
         assert!(!is_fixed_seed_ip(seeders, "127.0.0.1".parse().unwrap()));
+    }
+
+    /// v10 serves a perfectly valid v4 PoM proof, just in the legacy encoding rather than the compact
+    /// multiproof v11 added — so this ranks by wire cost, and v10 must stay dialable. A peer we have
+    /// never met also ranks above one known to be old: it may well be v11.
+    #[test]
+    fn outbound_dialing_prefers_v11_but_keeps_v10() {
+        let now = Instant::now();
+        let ip = |s: &str| s.parse::<IpAddr>().unwrap();
+        let known: HashMap<IpAddr, (u32, Instant)> = [
+            (ip("1.1.1.1"), (11u32, now)),
+            (ip("2.2.2.2"), (10u32, now)),
+            (ip("3.3.3.3"), (9u32, now)),
+            (ip("4.4.4.4"), (12u32, now)),
+        ]
+        .into_iter()
+        .collect();
+
+        let pref = |s: &str| ConnectionManager::peer_protocol_preference(ip(s), &known, now);
+        assert!(pref("1.1.1.1") < pref("5.5.5.5"), "a known v11 peer is dialed before an unknown one");
+        assert!(pref("5.5.5.5") < pref("2.2.2.2"), "an unknown peer is dialed before a known v10 one");
+        assert!(pref("2.2.2.2") < pref("3.3.3.3"), "v10 is a fallback, still ahead of anything older");
+        assert_eq!(pref("4.4.4.4"), pref("1.1.1.1"), "anything at or above v11 ranks the same");
+    }
+
+    /// v4-mapped and plain forms must land on the same entry, or the preference silently misses.
+    #[test]
+    fn protocol_observations_match_v4_mapped_addresses() {
+        let now = Instant::now();
+        let known: HashMap<IpAddr, (u32, Instant)> = [("1.1.1.1".parse::<IpAddr>().unwrap(), (11u32, now))].into_iter().collect();
+
+        assert_eq!(
+            ConnectionManager::peer_protocol_preference("::ffff:1.1.1.1".parse().unwrap(), &known, now),
+            0,
+            "a v4-mapped address must resolve to the same observation"
+        );
+    }
+
+    /// A stale entry must not pin a peer to an old version forever: a peer that upgrades has to
+    /// become indistinguishable from one we have never met.
+    #[test]
+    fn a_stale_protocol_observation_is_ignored() {
+        let now = Instant::now();
+        let learned_at = now - KNOWN_PROTOCOL_TTL - Duration::from_secs(1);
+        let ip: IpAddr = "2.2.2.2".parse().unwrap();
+        let known: HashMap<IpAddr, (u32, Instant)> = [(ip, (10u32, learned_at))].into_iter().collect();
+        let unknown = HashMap::new();
+
+        assert_eq!(
+            ConnectionManager::peer_protocol_preference(ip, &known, now),
+            ConnectionManager::peer_protocol_preference(ip, &unknown, now),
+            "an expired observation must rank as unknown, not as known-old"
+        );
     }
 }

--- a/components/connectionmanager/src/lib.rs
+++ b/components/connectionmanager/src/lib.rs
@@ -1,5 +1,5 @@
 use std::{
-    cmp::min,
+    cmp::{Reverse, min},
     collections::{HashMap, HashSet},
     net::{IpAddr, SocketAddr, ToSocketAddrs},
     sync::Arc,
@@ -12,7 +12,7 @@ use itertools::Itertools;
 use keryx_addressmanager::{AddressManager, NetAddress};
 use keryx_core::{debug, info, warn};
 use keryx_p2p_lib::{ConnectionError, Peer, common::ProtocolError};
-use keryx_utils::triggers::SingleTrigger;
+use keryx_utils::{networking::PrefixBucket, triggers::SingleTrigger};
 use parking_lot::Mutex as ParkingLotMutex;
 use rand::{seq::SliceRandom, thread_rng};
 use tokio::{
@@ -21,20 +21,57 @@ use tokio::{
         Mutex as TokioMutex,
         mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel},
     },
-    time::{MissedTickBehavior, interval},
 };
 
-const PING_TIMEOUT_BAN_THRESHOLD: u32 = 3;
-const PING_TIMEOUT_WINDOW: Duration = Duration::from_secs(600); // 10 minutes
+/// Ping-timeout strikes tolerated within [`PING_TIMEOUT_WINDOW`] before an IP is banned.
+///
+/// Only peers that have *never* answered a pong on the connection reach this counter (see
+/// `SendPingsFlow`), which is the phantom-node signature the mechanism was written for. An honest
+/// peer that stalls under load is therefore structurally excluded.
+const PING_TIMEOUT_BAN_THRESHOLD: u32 = 5;
+const PING_TIMEOUT_WINDOW: Duration = Duration::from_secs(1800); // 30 minutes
+
+/// Cadence of the connection loop, by how far we are from the outbound target. A node in cold start
+/// or recovery cannot afford a 30s wait between rounds; a satisfied node should stay quiet. The
+/// per-address dial cooldown is what makes the fast cadence safe -- without it a 2s loop would just
+/// hammer the same dead addresses.
+const LOOP_INTERVAL_STARVED: Duration = Duration::from_secs(2);
+const LOOP_INTERVAL_BELOW_TARGET: Duration = Duration::from_secs(10);
+const LOOP_INTERVAL_SATISFIED: Duration = Duration::from_secs(30);
+
+/// Max dial rounds per loop iteration. Without a cap a single iteration could walk the whole
+/// address store (up to 4096 entries) in serialized rounds, blocking the event loop and -- worse --
+/// postponing the DNS seeding at the end of the iteration, which is the only recovery path when the
+/// store is full of dead addresses.
+const MAX_DIAL_ROUNDS_PER_ITERATION: usize = 4;
+
+/// Per-address dial backoff: `30s * 2^min(consecutive_failures - 1, 4)`, i.e. 30s .. 8min.
+const DIAL_COOLDOWN_BASE: Duration = Duration::from_secs(30);
+const MAX_ACCOUNTABLE_DIAL_FAILURES: u32 = 5;
+
+/// How often the peering health line is logged.
+const HEALTH_LOG_INTERVAL: Duration = Duration::from_secs(60);
+
+/// How long an inbound peer may stay connected without ever answering a pong before it is treated
+/// as a silent squatter for eviction purposes. Comfortably above two ping intervals.
+const INBOUND_SILENCE_GRACE: Duration = Duration::from_secs(300);
+
+/// How long an outbound connection must last before its dial history is forgiven.
+///
+/// A dial that completes is not yet evidence of a usable peer: the session can die seconds later on
+/// a flow error — a peer asking us for a block body we only have the header of, for instance, which
+/// tears down the whole router. Until a connection clears this bar it keeps its exponential dial
+/// backoff, so a flapping peer is retried at 30s, 1m, 2m, ... instead of on every loop iteration.
+const STABLE_CONNECTION_GRACE: Duration = Duration::from_secs(60);
 
 /// How long a protocol version learned from a handshake is trusted for outbound preference.
-/// A peer that upgrades must be able to stop looking old, so the observation expires.
+/// The map is keyed by remote-supplied IPs, so it needs a bound like the other per-IP trackers.
 const KNOWN_PROTOCOL_TTL: Duration = Duration::from_secs(86400); // 24 hours
-/// Hard ceiling on the version map, mirroring `MAX_ADDRESSES` in the address store. The map is keyed
-/// by remote-supplied IPs, so it needs a bound.
+/// Hard ceiling on the version map, mirroring `MAX_ADDRESSES` in the address store.
 const MAX_KNOWN_PROTOCOL_ENTRIES: usize = 4096;
-/// The first protocol version that encodes a v4 PoM proof as a compact multiproof. Older peers
-/// serve the same proof in the legacy encoding — correct, just several times heavier on the wire.
+
+/// The first protocol version that encodes a v4 PoM proof as a compact multiproof. Older peers serve
+/// the same proof in the legacy encoding — correct, just several times heavier on the wire.
 const COMPACT_POM_PROTOCOL_VERSION: u32 = 11;
 /// How many candidates to draw per free outbound slot before ranking them by protocol preference.
 const CANDIDATE_POOL_FACTOR: usize = 3;
@@ -49,6 +86,61 @@ fn canonical_ip(ip: IpAddr) -> IpAddr {
 fn is_fixed_seed_ip(seeders: &[&str], ip: IpAddr) -> bool {
     let ip = canonical_ip(ip);
     seeders.iter().filter_map(|seeder| seeder.parse().ok()).any(|seeder| canonical_ip(seeder) == ip)
+}
+
+/// Eviction rank for an inbound peer: higher is evicted first.
+///
+/// 1. A peer that has never answered a pong although it has been connected for longer than two ping
+///    intervals is a silent squatter — exactly the phantom-node shape — and goes first.
+/// 2. Then the newest connections, so a burst of arrivals cannot displace established peers.
+/// 3. Ties are broken by how represented the peer's /16 (or /64) prefix already is among our inbound
+///    peers, which keeps a single network from filling the slots.
+fn inbound_eviction_rank(time_connected_ms: u64, last_ping_duration: u64, prefix_redundancy: usize) -> (bool, Reverse<u64>, usize) {
+    let silent = last_ping_duration == 0 && time_connected_ms > INBOUND_SILENCE_GRACE.as_millis() as u64;
+    (silent, Reverse(time_connected_ms), prefix_redundancy)
+}
+
+/// Exponential dial backoff after `failures` consecutive failed dials: 30s, 1m, 2m, 4m, 8m.
+fn dial_backoff(failures: u32) -> Duration {
+    DIAL_COOLDOWN_BASE * 2u32.pow(min(failures.max(1), MAX_ACCOUNTABLE_DIAL_FAILURES) - 1)
+}
+
+/// Per-address dial backoff.
+///
+/// Its own type because the part that matters is counter-intuitive and regressed once: a
+/// *successful* dial also takes a hold, and only a connection that lasts clears it. Reaching that
+/// behaviour through a live [`ConnectionManager`] would need a running p2p adaptor, so it lives here
+/// where it can be tested directly.
+#[derive(Default)]
+struct DialCooldown {
+    entries: HashMap<NetAddress, (Instant, u32)>,
+}
+
+impl DialCooldown {
+    fn is_cooling_down(&self, address: NetAddress, now: Instant) -> bool {
+        self.entries.get(&address).is_some_and(|(until, _)| *until > now)
+    }
+
+    /// Escalates the backoff for `address`, one step per call.
+    fn back_off(&mut self, address: NetAddress, now: Instant) {
+        let failures = self.entries.get(&address).map_or(1, |(_, failures)| failures.saturating_add(1));
+        self.entries.insert(address, (now + dial_backoff(failures), failures));
+    }
+
+    /// Forgets the history of `address`: its next dial is unrestricted and its backoff restarts from
+    /// [`DIAL_COOLDOWN_BASE`].
+    fn forgive(&mut self, address: NetAddress) {
+        self.entries.remove(&address);
+    }
+
+    /// Drops elapsed holds. The map is keyed by remote-supplied addresses, so it needs a bound.
+    fn gc(&mut self, now: Instant) {
+        self.entries.retain(|_, (until, _)| *until > now);
+    }
+
+    fn len(&self) -> usize {
+        self.entries.len()
+    }
 }
 
 struct PingTimeoutRecord {
@@ -68,8 +160,11 @@ pub struct ConnectionManager {
     force_next_iteration: UnboundedSender<()>,
     shutdown_signal: SingleTrigger,
     ping_timeout_tracker: ParkingLotMutex<HashMap<IpAddr, PingTimeoutRecord>>,
-    /// Last protocol version negotiated with each IP, plus the instant it was learned. Used to
-    /// prefer peers that serve the compact proof encoding while keeping older ones dialable.
+    dial_cooldown: ParkingLotMutex<DialCooldown>,
+    last_health_log: ParkingLotMutex<Instant>,
+    /// Last known protocol version per IP, learned from successful handshakes, with the instant it
+    /// was learned. Used to prefer v11 peers while keeping v10 as fallback; expired by
+    /// `KNOWN_PROTOCOL_TTL` so a peer that upgrades is not written off forever.
     known_protocols: ParkingLotMutex<HashMap<IpAddr, (u32, Instant)>>,
 }
 
@@ -109,10 +204,12 @@ impl ConnectionManager {
             ban_exempt_seeders,
             default_port,
             ping_timeout_tracker: Default::default(),
+            dial_cooldown: Default::default(),
+            last_health_log: ParkingLotMutex::new(Instant::now()),
             known_protocols: Default::default(),
         });
         manager.clone().start_event_loop(rx);
-        manager.force_next_iteration.send(()).unwrap();
+        manager.trigger_iteration();
         manager
     }
 
@@ -123,8 +220,9 @@ impl ConnectionManager {
         let now = Instant::now();
         let mut known = self.known_protocols.lock();
         if known.len() >= MAX_KNOWN_PROTOCOL_ENTRIES && !known.contains_key(&ip) {
-            // Full, and this is a new IP: drop what already expired, and if that frees nothing, drop
-            // the oldest observation. Either way a peer cycling through addresses cannot grow the map.
+            // Full and this is a new IP: drop what is already expired, and if that frees nothing,
+            // drop the oldest entry. Either way the map cannot be grown without bound by a peer
+            // cycling through addresses.
             known.retain(|_, (_, learned_at)| now.duration_since(*learned_at) <= KNOWN_PROTOCOL_TTL);
             if known.len() >= MAX_KNOWN_PROTOCOL_ENTRIES
                 && let Some(oldest) = known.iter().min_by_key(|(_, (_, learned_at))| *learned_at).map(|(ip, _)| *ip)
@@ -153,23 +251,16 @@ impl ConnectionManager {
         }
     }
 
-    /// Drops expired protocol observations. Without this the map grows over the process lifetime.
-    fn gc_known_protocols(&self) {
-        let now = Instant::now();
-        self.known_protocols.lock().retain(|_, (_, learned_at)| now.duration_since(*learned_at) <= KNOWN_PROTOCOL_TTL);
-    }
-
     fn start_event_loop(self: Arc<Self>, mut rx: UnboundedReceiver<()>) {
-        let mut ticker = interval(Duration::from_secs(30));
-        ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
         tokio::spawn(async move {
             loop {
                 if self.shutdown_signal.trigger.is_triggered() {
                     break;
                 }
+                let delay = self.next_iteration_delay();
                 select! {
                     _ = rx.recv() => self.clone().handle_event().await,
-                    _ = ticker.tick() => self.clone().handle_event().await,
+                    _ = tokio::time::sleep(delay) => self.clone().handle_event().await,
                     _ = self.shutdown_signal.listener.clone() => break,
                 }
             }
@@ -177,21 +268,101 @@ impl ConnectionManager {
         });
     }
 
+    /// Time to wait before the next unforced iteration.
+    fn next_iteration_delay(&self) -> Duration {
+        let outbound = self.p2p_adaptor.active_peers().into_iter().filter(|peer| peer.is_outbound()).count();
+        if outbound * 2 < self.outbound_target {
+            LOOP_INTERVAL_STARVED
+        } else if outbound < self.outbound_target {
+            LOOP_INTERVAL_BELOW_TARGET
+        } else {
+            LOOP_INTERVAL_SATISFIED
+        }
+    }
+
+    /// Requests an immediate extra iteration of the connection loop.
+    fn trigger_iteration(&self) {
+        if self.force_next_iteration.send(()).is_err() {
+            debug!("Connection manager event loop is gone, cannot force an iteration");
+        }
+    }
+
     async fn handle_event(self: Arc<Self>) {
         debug!("Starting connection loop iteration");
         let peers = self.p2p_adaptor.active_peers();
         let peer_by_address: HashMap<SocketAddr, Peer> = peers.into_iter().map(|peer| (peer.net_address(), peer)).collect();
 
+        self.forgive_stable_peers(&peer_by_address);
         self.handle_connection_requests(&peer_by_address).await;
         self.handle_outbound_connections(&peer_by_address).await;
         self.handle_inbound_connections(&peer_by_address).await;
-        self.gc_known_protocols();
+        self.gc_transient_state();
+        self.log_health(&peer_by_address);
+    }
+
+    /// Drops expired entries from the per-IP trackers. Both are keyed by remote-controlled IPs, so
+    /// without this they grow without bound over the lifetime of the process.
+    fn gc_transient_state(&self) {
+        self.ping_timeout_tracker.lock().retain(|_, record| record.window_start.elapsed() <= PING_TIMEOUT_WINDOW);
+        self.dial_cooldown.lock().gc(Instant::now());
+        let now = Instant::now();
+        self.known_protocols.lock().retain(|_, (_, learned_at)| now.duration_since(*learned_at) <= KNOWN_PROTOCOL_TTL);
+    }
+
+    /// One line per minute answering "which peering problem do I have?": a small address store means
+    /// discovery is the bottleneck, a healthy store with low outbound means dials are failing, and
+    /// `advertised=NONE` or a stuck `inbound=0` means this node is unreachable from the outside.
+    fn log_health(&self, peer_by_address: &HashMap<SocketAddr, Peer>) {
+        {
+            let mut last = self.last_health_log.lock();
+            if last.elapsed() < HEALTH_LOG_INTERVAL {
+                return;
+            }
+            *last = Instant::now();
+        }
+        let outbound = peer_by_address.values().filter(|peer| peer.is_outbound()).count();
+        let inbound = peer_by_address.len() - outbound;
+        let (known, banned, advertised) = {
+            let mut amgr = self.address_manager.lock();
+            let banned = amgr.get_all_banned_addresses().len();
+            let advertised = amgr.best_local_address();
+            (amgr.address_count(), banned, advertised)
+        };
+        let cooling = self.dial_cooldown.lock().len();
+        let (v11_out, v10_out, other_out) = {
+            let mut v11 = 0usize;
+            let mut v10 = 0usize;
+            let mut other = 0usize;
+            for peer in peer_by_address.values().filter(|p| p.is_outbound()) {
+                let props = peer.properties();
+                match props.protocol_version {
+                    v if v >= 11 => v11 += 1,
+                    10 => v10 += 1,
+                    _ => other += 1,
+                }
+            }
+            (v11, v10, other)
+        };
+        info!(
+            "P2P health: outbound={}/{} (v11={} v10={} other={}) inbound={}/{} | addresses={} cooling_down={} banned={} | advertised={}",
+            outbound,
+            self.outbound_target,
+            v11_out,
+            v10_out,
+            other_out,
+            inbound,
+            self.inbound_limit,
+            known,
+            cooling,
+            banned,
+            advertised.map(|addr| addr.to_string()).unwrap_or_else(|| "NONE (this node cannot receive inbound peers)".to_owned()),
+        );
     }
 
     pub async fn add_connection_request(&self, address: SocketAddr, is_permanent: bool) {
         // If the request already exists, it resets the attempts count and overrides the `is_permanent` setting.
         self.connection_requests.lock().await.insert(address, ConnectionRequest::new(is_permanent));
-        self.force_next_iteration.send(()).unwrap(); // We force the next iteration of the connection loop.
+        self.trigger_iteration(); // We force the next iteration of the connection loop.
     }
 
     pub async fn stop(&self) {
@@ -245,6 +416,12 @@ impl ConnectionManager {
     }
 
     async fn handle_outbound_connections(self: &Arc<Self>, peer_by_address: &HashMap<SocketAddr, Peer>) {
+        // Exclude every active peer, not only the outbound ones. For an inbound peer
+        // `net_address()` carries the remote *ephemeral* port, so it never matched an address-store
+        // entry and we kept re-dialing nodes we were already connected to. Those dials fail with
+        // `PeerAlreadyExists` — correctly not counted as a failure, but they burned a dial slot on
+        // every single round of a well-connected node.
+        let active_ips: HashSet<IpAddr> = peer_by_address.values().map(|peer| canonical_ip(peer.net_address().ip())).collect();
         let active_outbound: HashSet<keryx_addressmanager::NetAddress> =
             peer_by_address.values().filter(|peer| peer.is_outbound()).map(|peer| peer.net_address().into()).collect();
         if active_outbound.len() >= self.outbound_target {
@@ -254,39 +431,51 @@ impl ConnectionManager {
         let mut missing_connections = self.outbound_target - active_outbound.len();
         let mut addr_iter = self.address_manager.lock().iterate_prioritized_random_addresses(active_outbound);
         let mut progressing = true;
-        let mut connecting = true;
-        while connecting && missing_connections > 0 {
+        let mut exhausted = false;
+        let mut cooling_down = 0usize;
+        let mut rounds = 0usize;
+        while !exhausted && missing_connections > 0 && rounds < MAX_DIAL_ROUNDS_PER_ITERATION {
             if self.shutdown_signal.trigger.is_triggered() {
                 return;
             }
+            rounds += 1;
             // Gather a pool larger than needed and rank it by proof encoding: a node whose outbound
             // slots all went to pre-v11 peers still syncs, but pays the legacy proof encoding on every
             // block — which is the bandwidth the v4 proof made expensive in the first place.
             let mut candidates = Vec::with_capacity(missing_connections * CANDIDATE_POOL_FACTOR);
             while candidates.len() < missing_connections * CANDIDATE_POOL_FACTOR {
                 let Some(net_addr) = addr_iter.next() else {
-                    connecting = false;
+                    exhausted = true;
                     break;
                 };
+                if active_ips.contains(&canonical_ip(net_addr.ip.into())) {
+                    continue;
+                }
+                if self.is_cooling_down(net_addr) {
+                    cooling_down += 1;
+                    continue;
+                }
                 candidates.push(net_addr);
             }
-            // `sort_by_key` is stable, so the failure-weighted random order the address store handed
-            // us survives inside each preference tier — the ranking re-orders tiers, it does not
-            // replace the selection policy.
+            // `sort_by_key` is stable, so the failure-weighted random order the store handed us is
+            // preserved inside each preference tier.
             let now = Instant::now();
             let known = self.known_protocols.lock().clone();
-            candidates.sort_by_key(|net_addr| Self::peer_protocol_preference(net_addr.ip.into(), &known, now));
-
-            let mut addrs_to_connect = Vec::with_capacity(missing_connections);
-            let mut jobs = Vec::with_capacity(missing_connections);
-            for net_addr in candidates.into_iter().take(missing_connections) {
-                let socket_addr = SocketAddr::new(net_addr.ip.into(), net_addr.port).to_string();
-                debug!("Connecting to {}", &socket_addr);
-                addrs_to_connect.push(net_addr);
-                jobs.push(self.p2p_adaptor.connect_peer(socket_addr.clone()));
+            candidates.sort_by_key(|addr| Self::peer_protocol_preference(addr.ip.into(), &known, now));
+            let addrs_to_connect = candidates.into_iter().take(missing_connections).collect::<Vec<_>>();
+            if addrs_to_connect.is_empty() {
+                continue;
             }
+            let jobs = addrs_to_connect
+                .iter()
+                .map(|net_addr| {
+                    let socket_addr = SocketAddr::new(net_addr.ip.into(), net_addr.port).to_string();
+                    debug!("Connecting to {}", &socket_addr);
+                    self.p2p_adaptor.connect_peer(socket_addr)
+                })
+                .collect_vec();
 
-            if progressing && !jobs.is_empty() {
+            if progressing {
                 // Log only if progress was made
                 info!(
                     "Connection manager: has {}/{} outgoing P2P connections, trying to obtain {} additional connection(s)...",
@@ -308,6 +497,12 @@ impl ConnectionManager {
                 match res {
                     Ok(_) => {
                         self.address_manager.lock().mark_connection_success(net_addr);
+                        // Deliberately a hold, not a clear. Clearing here meant that a peer which
+                        // connected cleanly and then died on a flow error carried no backoff at
+                        // all, so the loop re-dialed it on the very next iteration — every 2s under
+                        // the starved cadence. `forgive_stable_peers` lifts the hold once the
+                        // connection has actually lasted.
+                        self.back_off_dial(net_addr);
                         missing_connections -= 1;
                         progressing = true;
                     }
@@ -318,21 +513,74 @@ impl ConnectionManager {
                     Err(err) => {
                         debug!("Failed connecting to {:?}, err: {}", net_addr, err);
                         self.address_manager.lock().mark_connection_failure(net_addr);
+                        self.back_off_dial(net_addr);
                     }
                 }
             }
         }
 
-        if missing_connections > 0 && !self.dns_seeders.is_empty() {
-            if missing_connections > self.outbound_target / 2 {
-                // If we are missing more than half of our target, query all in parallel.
-                // This will always be the case on new node start-up and is the most resilient strategy in such a case.
-                self.dns_seed_many(self.dns_seeders.len()).await;
-            } else {
-                // Try to obtain at least twice the number of missing connections
-                self.dns_seed_with_address_target(2 * missing_connections).await;
-            }
+        if missing_connections == 0 {
+            return;
         }
+
+        // Every known address is connected, cooling down or written off. Decay the failure counts so
+        // that a node which was offline long enough to saturate its whole store can recover instead
+        // of treating every address as hopeless forever.
+        if exhausted && cooling_down == 0 {
+            self.address_manager.lock().decay_connection_failures();
+        }
+
+        if self.dns_seeders.is_empty() {
+            return;
+        }
+        let learned = if exhausted || missing_connections > self.outbound_target / 2 {
+            // If the store is exhausted, or we are missing more than half of our target, query all
+            // seeders in parallel. This is always the case on a new node start-up and is the most
+            // resilient strategy in such a case.
+            self.dns_seed_many(self.dns_seeders.len()).await
+        } else {
+            // Try to obtain at least twice the number of missing connections
+            self.dns_seed_with_address_target(2 * missing_connections).await
+        };
+        // Seeding used to be the last thing an iteration did, so freshly learned addresses sat
+        // unused until the next tick — a wasted round on every cold start, which is exactly when the
+        // node can least afford one. Re-run the loop right away, but only when we actually learned
+        // something new, so this can never turn into a spin.
+        if learned > 0 {
+            self.trigger_iteration();
+        }
+    }
+
+    /// Clears the dial backoff of outbound peers that have stayed connected past
+    /// [`STABLE_CONNECTION_GRACE`], so a peer that is simply long-lived never accumulates history,
+    /// while one that keeps connecting and dying keeps escalating.
+    fn forgive_stable_peers(&self, peer_by_address: &HashMap<SocketAddr, Peer>) {
+        let stable = peer_by_address
+            .values()
+            .filter(|peer| peer.is_outbound() && peer.time_connected() > STABLE_CONNECTION_GRACE.as_millis() as u64)
+            .map(|peer| NetAddress::from(peer.net_address()))
+            .collect_vec();
+        if stable.is_empty() {
+            return;
+        }
+        let mut cooldown = self.dial_cooldown.lock();
+        for address in stable {
+            cooldown.forgive(address);
+        }
+    }
+
+    /// Whether `address` is still inside its dial backoff window.
+    fn is_cooling_down(&self, address: NetAddress) -> bool {
+        self.dial_cooldown.lock().is_cooling_down(address, Instant::now())
+    }
+
+    /// Escalates the exponential dial backoff for `address`.
+    ///
+    /// Called both when a dial fails outright and when one succeeds — see the call site for why a
+    /// success also backs off. This is what makes the fast loop cadence safe: without it, a starved
+    /// node would re-dial the same unreachable (or flapping) addresses every 2s.
+    fn back_off_dial(&self, address: NetAddress) {
+        self.dial_cooldown.lock().back_off(address, Instant::now());
     }
 
     async fn handle_inbound_connections(self: &Arc<Self>, peer_by_address: &HashMap<SocketAddr, Peer>) {
@@ -342,34 +590,66 @@ impl ConnectionManager {
             return;
         }
 
-        let mut futures = Vec::with_capacity(active_inbound_len - self.inbound_limit);
-        for peer in active_inbound.choose_multiple(&mut thread_rng(), active_inbound_len - self.inbound_limit) {
-            debug!("Disconnecting from {} because we're above the inbound limit", peer.net_address());
-            futures.push(self.p2p_adaptor.terminate(peer.key()));
+        // Eviction used to be uniformly random, which dropped long-lived, well-behaved peers as
+        // readily as the freshly arrived ones that caused the overflow. Rank worst-first instead
+        // (see `inbound_eviction_rank`) and never evict a peer we deliberately keep.
+        let mut prefix_counter: HashMap<PrefixBucket, usize> = HashMap::new();
+        for peer in active_inbound.iter() {
+            *prefix_counter.entry(NetAddress::from(peer.net_address()).prefix_bucket()).or_insert(0) += 1;
         }
+        let mut candidates = Vec::with_capacity(active_inbound_len);
+        for peer in active_inbound {
+            let ip = canonical_ip(peer.net_address().ip());
+            if is_fixed_seed_ip(self.ban_exempt_seeders, ip) || self.ip_has_permanent_connection(ip).await {
+                continue;
+            }
+            let redundancy = prefix_counter.get(&NetAddress::from(peer.net_address()).prefix_bucket()).copied().unwrap_or(1);
+            candidates.push((inbound_eviction_rank(peer.time_connected(), peer.last_ping_duration(), redundancy), peer));
+        }
+        candidates.sort_by(|(a, _), (b, _)| b.cmp(a));
+
+        let futures = candidates
+            .into_iter()
+            .take(active_inbound_len - self.inbound_limit)
+            .map(|(_, peer)| {
+                debug!("Disconnecting from {} because we're above the inbound limit", peer.net_address());
+                self.p2p_adaptor.terminate(peer.key())
+            })
+            .collect_vec();
         join_all(futures).await;
     }
 
-    /// Queries DNS seeders in random order, one after the other, until obtaining `min_addresses_to_fetch` addresses
-    async fn dns_seed_with_address_target(self: &Arc<Self>, min_addresses_to_fetch: usize) {
+    /// Queries DNS seeders in random order, one after the other, until obtaining
+    /// `min_addresses_to_fetch` addresses. Returns the number of *newly learned* addresses.
+    async fn dns_seed_with_address_target(self: &Arc<Self>, min_addresses_to_fetch: usize) -> usize {
         let cmgr = self.clone();
-        tokio::task::spawn_blocking(move || cmgr.dns_seed_with_address_target_blocking(min_addresses_to_fetch)).await.unwrap();
+        match tokio::task::spawn_blocking(move || cmgr.dns_seed_with_address_target_blocking(min_addresses_to_fetch)).await {
+            Ok(learned) => learned,
+            Err(err) => {
+                warn!("DNS seeding task failed: {}", err);
+                0
+            }
+        }
     }
 
-    fn dns_seed_with_address_target_blocking(self: &Arc<Self>, mut min_addresses_to_fetch: usize) {
+    fn dns_seed_with_address_target_blocking(self: &Arc<Self>, mut min_addresses_to_fetch: usize) -> usize {
         let shuffled_dns_seeders = self.dns_seeders.choose_multiple(&mut thread_rng(), self.dns_seeders.len());
+        let mut learned = 0;
         for &seeder in shuffled_dns_seeders {
             // Query seeders sequentially until reaching the desired number of addresses
             let addrs_len = self.dns_seed_single(seeder);
+            learned += addrs_len;
             if addrs_len >= min_addresses_to_fetch {
                 break;
             } else {
                 min_addresses_to_fetch -= addrs_len;
             }
         }
+        learned
     }
 
-    /// Queries `num_seeders_to_query` random DNS seeders in parallel
+    /// Queries `num_seeders_to_query` random DNS seeders in parallel. Returns the number of newly
+    /// learned addresses.
     async fn dns_seed_many(self: &Arc<Self>, num_seeders_to_query: usize) -> usize {
         info!("Querying {} DNS seeders", num_seeders_to_query);
         let shuffled_dns_seeders = self.dns_seeders.choose_multiple(&mut thread_rng(), num_seeders_to_query);
@@ -377,10 +657,18 @@ impl ConnectionManager {
             let cmgr = self.clone();
             tokio::task::spawn_blocking(move || cmgr.dns_seed_single(seeder))
         });
-        try_join_all(jobs).await.unwrap().into_iter().sum()
+        match try_join_all(jobs).await {
+            Ok(counts) => counts.into_iter().sum(),
+            Err(err) => {
+                warn!("DNS seeding task failed: {}", err);
+                0
+            }
+        }
     }
 
-    /// Query a single DNS seeder and add the obtained addresses to the address manager.
+    /// Query a single DNS seeder and add the obtained addresses to the address manager. Returns the
+    /// number of addresses we did not already know — a seeder that only echoes back what we have is
+    /// not progress, and the caller uses this to decide whether an immediate re-dial is warranted.
     ///
     /// DNS lookup is a blocking i/o operation so this function is assumed to be called
     /// from a blocking execution context.
@@ -396,13 +684,11 @@ impl ConnectionManager {
         };
 
         let addrs_len = addrs.len();
-        info!("Retrieved {} addresses from DNS seeder {}", addrs_len, seeder);
         let mut amgr_lock = self.address_manager.lock();
-        for addr in addrs {
-            amgr_lock.add_address(NetAddress::new(addr.ip().into(), addr.port()));
-        }
-
-        addrs_len
+        let learned = addrs.filter(|addr| amgr_lock.add_address(NetAddress::new(addr.ip().into(), addr.port()))).count();
+        drop(amgr_lock);
+        info!("Retrieved {} addresses from DNS seeder {} ({} new)", addrs_len, seeder, learned);
+        learned
     }
 
     /// Bans the given IP and disconnects from all the peers with that IP.
@@ -479,6 +765,7 @@ impl ConnectionManager {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::str::FromStr;
 
     #[test]
     fn fixed_seed_ip_is_ban_exempt() {
@@ -489,13 +776,106 @@ mod tests {
         assert!(!is_fixed_seed_ip(seeders, "127.0.0.1".parse().unwrap()));
     }
 
+    #[test]
+    fn dial_backoff_grows_and_caps() {
+        assert_eq!(dial_backoff(0), DIAL_COOLDOWN_BASE, "a first failure must not be treated as a zeroth one");
+        assert_eq!(dial_backoff(1), DIAL_COOLDOWN_BASE);
+        assert_eq!(dial_backoff(2), DIAL_COOLDOWN_BASE * 2);
+        assert_eq!(dial_backoff(MAX_ACCOUNTABLE_DIAL_FAILURES), DIAL_COOLDOWN_BASE * 16);
+        assert_eq!(dial_backoff(MAX_ACCOUNTABLE_DIAL_FAILURES + 100), DIAL_COOLDOWN_BASE * 16, "backoff must saturate");
+    }
+
+    fn test_addr() -> NetAddress {
+        NetAddress::from_str("1.2.3.4:22111").unwrap()
+    }
+
+    /// The regression this guards: clearing the backoff on a successful dial meant a peer that
+    /// connected cleanly and then died on a flow error — being asked for a block body we only have
+    /// the header of, say — was re-dialed on the very next loop iteration, i.e. every 2s under the
+    /// starved cadence.
+    #[test]
+    fn a_dial_that_connects_still_takes_a_hold() {
+        let addr = test_addr();
+        let t0 = Instant::now();
+        let mut cooldown = DialCooldown::default();
+
+        cooldown.back_off(addr, t0);
+        assert!(cooldown.is_cooling_down(addr, t0), "a peer we just connected to must not be re-dialable at once");
+        assert!(!cooldown.is_cooling_down(addr, t0 + DIAL_COOLDOWN_BASE + Duration::from_secs(1)));
+    }
+
+    #[test]
+    fn flapping_escalates_instead_of_resetting() {
+        let addr = test_addr();
+        let t0 = Instant::now();
+        let mut cooldown = DialCooldown::default();
+
+        cooldown.back_off(addr, t0);
+        cooldown.back_off(addr, t0);
+        assert!(
+            cooldown.is_cooling_down(addr, t0 + DIAL_COOLDOWN_BASE + Duration::from_secs(1)),
+            "a second connect-then-die must double the hold, not restart it"
+        );
+        assert!(!cooldown.is_cooling_down(addr, t0 + DIAL_COOLDOWN_BASE * 2 + Duration::from_secs(1)));
+    }
+
+    #[test]
+    fn a_connection_that_lasts_clears_its_history() {
+        let addr = test_addr();
+        let t0 = Instant::now();
+        let mut cooldown = DialCooldown::default();
+
+        cooldown.back_off(addr, t0);
+        cooldown.back_off(addr, t0);
+        cooldown.forgive(addr);
+        assert!(!cooldown.is_cooling_down(addr, t0), "a stable peer must be immediately re-dialable if it drops");
+
+        cooldown.back_off(addr, t0);
+        assert!(
+            !cooldown.is_cooling_down(addr, t0 + DIAL_COOLDOWN_BASE + Duration::from_secs(1)),
+            "and its backoff must restart from the base rather than resume where it left off"
+        );
+    }
+
+    #[test]
+    fn elapsed_holds_are_collected() {
+        let addr = test_addr();
+        let t0 = Instant::now();
+        let mut cooldown = DialCooldown::default();
+
+        cooldown.back_off(addr, t0);
+        cooldown.gc(t0);
+        assert_eq!(cooldown.len(), 1, "a live hold survives collection");
+        cooldown.gc(t0 + DIAL_COOLDOWN_BASE + Duration::from_secs(1));
+        assert_eq!(cooldown.len(), 0, "an elapsed one does not");
+    }
+
+    #[test]
+    fn inbound_eviction_prefers_squatters_then_newcomers() {
+        let hour = Duration::from_secs(3600).as_millis() as u64;
+        let grace = INBOUND_SILENCE_GRACE.as_millis() as u64;
+
+        let established = inbound_eviction_rank(hour, 42, 1);
+        let newcomer = inbound_eviction_rank(1_000, 7, 1);
+        let squatter = inbound_eviction_rank(grace + 1, 0, 1);
+        let young_and_quiet = inbound_eviction_rank(1_000, 0, 1);
+
+        // Higher rank is evicted first
+        assert!(squatter > newcomer, "a peer that never ponged goes before a merely new one");
+        assert!(newcomer > established, "a burst of arrivals must not displace established peers");
+        assert!(young_and_quiet < squatter, "silence only counts after the grace period");
+
+        // Prefix redundancy breaks ties between otherwise identical peers
+        assert!(inbound_eviction_rank(hour, 42, 5) > inbound_eviction_rank(hour, 42, 1));
+    }
+
     /// v10 serves a perfectly valid v4 PoM proof, just in the legacy encoding rather than the compact
     /// multiproof v11 added — so this ranks by wire cost, and v10 must stay dialable. A peer we have
     /// never met also ranks above one known to be old: it may well be v11.
     #[test]
     fn outbound_dialing_prefers_v11_but_keeps_v10() {
         let now = Instant::now();
-        let ip = |s: &str| s.parse::<IpAddr>().unwrap();
+        let ip = |s: &str| IpAddr::from_str(s).unwrap();
         let known: HashMap<IpAddr, (u32, Instant)> = [
             (ip("1.1.1.1"), (11u32, now)),
             (ip("2.2.2.2"), (10u32, now)),
@@ -516,22 +896,22 @@ mod tests {
     #[test]
     fn protocol_observations_match_v4_mapped_addresses() {
         let now = Instant::now();
-        let known: HashMap<IpAddr, (u32, Instant)> = [("1.1.1.1".parse::<IpAddr>().unwrap(), (11u32, now))].into_iter().collect();
+        let known: HashMap<IpAddr, (u32, Instant)> = [(IpAddr::from_str("1.1.1.1").unwrap(), (11u32, now))].into_iter().collect();
 
         assert_eq!(
-            ConnectionManager::peer_protocol_preference("::ffff:1.1.1.1".parse().unwrap(), &known, now),
+            ConnectionManager::peer_protocol_preference(IpAddr::from_str("::ffff:1.1.1.1").unwrap(), &known, now),
             0,
             "a v4-mapped address must resolve to the same observation"
         );
     }
 
-    /// A stale entry must not pin a peer to an old version forever: a peer that upgrades has to
-    /// become indistinguishable from one we have never met.
+    /// The map is keyed by remote-supplied IPs, so a stale entry must not pin a peer to an old
+    /// version forever — a peer that upgrades has to become indistinguishable from an unknown one.
     #[test]
     fn a_stale_protocol_observation_is_ignored() {
         let now = Instant::now();
         let learned_at = now - KNOWN_PROTOCOL_TTL - Duration::from_secs(1);
-        let ip: IpAddr = "2.2.2.2".parse().unwrap();
+        let ip = IpAddr::from_str("2.2.2.2").unwrap();
         let known: HashMap<IpAddr, (u32, Instant)> = [(ip, (10u32, learned_at))].into_iter().collect();
         let unknown = HashMap::new();
 

--- a/docs/peer-discovery-and-retention.md
+++ b/docs/peer-discovery-and-retention.md
@@ -1,0 +1,202 @@
+# Peer discovery and retention
+
+Why a node is slow to find peers, drops the ones it has, never reaches `--outpeers`, and receives no
+inbound connections — and what this changes.
+
+**Scope: local policy only.** No consensus rule, no wire format, no new message type, no
+`PROTOCOL_VERSION` bump. Every change is a constant, a scheduling decision, or a transport (HTTP/2)
+setting. A patched node and an unpatched one accept the same blocks and speak the same protocol, so
+every benefit is unilateral — it does not require the peer to be patched.
+
+## Why now: the v4 PoM proof
+
+The v4 PoM proof is **~442 KiB per block** (~233 KiB for v2). It broke no explicit limit, but it
+halved the margin on every timeout and queue inherited from `rusty-kaspa`, which were sized for
+blocks of a few KB. Three of the five mechanisms below are upstream behaviour that only becomes
+pathological at 10 BPS with a 442 KiB witness.
+
+## The five mechanisms
+
+**1. `Pong` sits behind 44 MB of block bodies.** `Pong` is enqueued on the same single, unprioritized
+`outgoing_route` as block bodies. A peer serving an IBD chunk has `IBD_BATCH_SIZE = 99` bodies ahead
+of its pong — ~44 MB of head-of-line delay. Upstream allowed a single pong 120 s, so above ~370 KB/s
+it made it and below it did not. Then `Flow::launch` closes the router on **any** flow returning
+`Err`, so one late pong killed every other flow with that peer, and `record_ping_timeout` counted it
+towards a **24 h IP ban**. The v2→v4 proof doubling halved the bandwidth at which a node starts
+banning honest peers.
+
+**2. No keepalive on the serving side.** The client set `tcp_keepalive(10 s)`; the server set
+nothing. A NAT dropping its state left a half-open inbound connection that only the ping flow would
+notice — up to 240 s later, through the one code path that also bans.
+
+**3. The address store drains itself.** `add_address` inserts with `connection_failed_count = 1`, so
+a never-tried address is already one strike in; `mark_connection_failure` **removes** above
+`MAX_CONNECTION_FAILED_COUNT = 3`; `connect_timeout` was 1 s, below a single SYN retransmit; `ban()`
+also called `remove_by_ip`, so a 24 h ban became permanent amnesia; and `ReceiveAddressesFlow` asked
+for addresses **once per connection** then exited. A 300 ms-RTT peer fails three 1 s dials and is
+erased. Recovery needs fresh gossip, which needs a new connection, which is exactly what a drained
+store cannot make.
+
+**4. The connection loop blocks itself.** The dial loop had no round cap, so it could walk all 4096
+addresses in serialized rounds of ≤ 16 dials **before** reaching the DNS seeding at the end of the
+iteration — the only recovery path when the store is full of dead addresses. A cold start wasted a
+full 30 s tick: the first iteration seeded from DNS and then ended, dialing nothing. And the
+dial-exclusion set was built from `peer.net_address()`, which for an **inbound** peer is the remote
+*ephemeral* port, so it never matched a store entry and the loop kept re-dialing peers it was already
+connected to.
+
+**5. Inbound is invisible and evicted at random.** If no local address is publicly routable and UPnP
+does not map, the handshake `Version` advertises no address at all — zero inbound, permanently,
+reported only as a single `info!` at boot. Over-limit inbound peers were then evicted with
+`choose_multiple`, i.e. uniformly at random: a long-lived peer as likely to go as the newcomer that
+caused the overflow.
+
+Raising `--outpeers` reaches none of this. It already defaults to 16 (`--maxinpeers` to 128) and the
+target is not being *reached*; raising it only adds dial pressure against a store that is emptying
+itself.
+
+## What the code does
+
+### Tolerate a slow pong; ban only a peer that never ponged
+
+`PING_INTERVAL` 120 s → 30 s, an explicit `PONG_TIMEOUT` of 60 s, and `MAX_CONSECUTIVE_PING_TIMEOUTS
+= 3`. The load-bearing part is the **outstanding-nonce window**: `SendPingsFlow` keeps a `VecDeque`
+of up to three unanswered nonces and matches an incoming pong against the whole window, measuring RTT
+from the instant that round's ping was actually sent. Without it, tolerating misses would be unsound
+— a late pong arrives with a nonce that no longer matches the latest, and upstream treats a nonce
+mismatch as a disconnect. The window is what makes "wait longer" and "keep checking the nonce"
+compatible.
+
+| | before | after |
+|---|---|---|
+| slack for one pong before the peer is dropped | 120 s | ~240 s |
+| IBD bandwidth below which an honest peer is dropped | ~370 KB/s | ~190 KB/s |
+| a genuinely dead *connection* is detected in | ~240 s | ~50 s (HTTP/2 keepalive) |
+
+The ban gate is narrowed to the signature it was written for: a strike is recorded only when
+`router.last_ping_duration() == 0`, i.e. the peer has **never** spoken on this connection — connect
+silently, occupy an inbound slot, never answer, reconnect. An honest peer stalled behind its own body
+validation is excluded structurally, not by a threshold. Thresholds are widened anyway as defence in
+depth (3 → 5 strikes, 600 s → 1800 s window).
+
+### Keepalive on both sides
+
+`connect_timeout` 1 s → 8 s, `communication_timeout` 10 s → 30 s, `tcp_keepalive` 10 s → 30 s (now
+also on the server), plus HTTP/2 keepalive at 30 s with a 20 s timeout on both sides. HTTP/2 PING is
+a transport frame answered by every hyper/tonic peer, so this needs no protocol change and
+interoperates with unpatched nodes.
+
+`connect_timeout` is the one to argue about: 1 s is below a single SYN retransmit, so the old value
+did not measure reachability, it measured RTT and wrote off anything more than a few hundred
+milliseconds away. Round latency stays bounded because dials are `join_all`-parallel and the round
+count is now capped.
+
+### The address store stops deleting
+
+`mark_connection_failure` **saturates** instead of removing. The selection weight already handles
+this: a written-off address sits at `64` against a fresh address's `64^3` — **4096× less likely** to
+be picked — and one success resets it to 0. `decay_connection_failures()` decrements every non-zero
+count when the selection iterator is exhausted while the store is non-empty, so a node that was
+offline long enough to saturate its whole store does not treat every address as hopeless forever.
+`ban()` no longer removes: the filter moved to selection time, honouring the 24 h expiry.
+
+### The connection loop stops blocking itself
+
+Adaptive cadence replaces the fixed 30 s tick — 2 s while starved (`outbound * 2 < target`), 10 s
+below target, 30 s when satisfied. The prerequisite that makes the fast cadence safe is a
+**per-address dial cooldown** with exponential backoff (30 s, 1 m, 2 m, 4 m, 8 m); without it a 2 s
+loop would just hammer the same unreachable addresses. Rounds are capped at 4 per iteration so DNS
+seeding is always reached, seeding that learns something new triggers an immediate re-run instead of
+waiting for the next tick, and the dial-exclusion set is built from canonical IPs so inbound peers no
+longer consume outbound dial slots.
+
+### Periodic address requests, non-fatal on timeout
+
+`ReceiveAddressesFlow` becomes a loop: a 5 s random initial jitter so N peers are not all asked at
+once, then every 60 s while the store holds fewer than 64 addresses and every 600 s otherwise. A
+timeout logs at `debug!` and continues to the next cycle rather than killing the connection.
+
+**This is backward compatible without a protocol change**: `SendAddressesFlow` on every deployed node
+already answers `RequestAddresses` in an unbounded loop — the one-shot behaviour was on the
+*receiving* side only. Load is trivial: ≤ 1000 addresses is ~14 KB per peer per 10 minutes.
+
+### Inbound: say it out loud, and evict deliberately
+
+A `warn!` now names the consequence when no local address is routable ("will receive ZERO inbound
+connections") and the fix (`--externalip`). Inbound eviction is ranked worst-first: a peer that has
+never answered a pong past a 300 s grace (a silent squatter) goes first, then the newest connections
+so a burst of arrivals cannot displace established peers, then by how represented the peer's /16 (or
+/64) already is among inbound peers. Permanent requests and ban-exempt seeders are never candidates.
+
+A health line is logged once a minute, to make the four symptoms distinguishable in the field:
+
+```
+P2P health: outbound=3/16 (v11=2 v10=1 other=0) inbound=0/128 | addresses=41 cooling_down=7 banned=2 | advertised=NONE (...)
+```
+
+A small `addresses` means discovery is the bottleneck; a healthy `addresses` with low `outbound`
+means dials are failing; `advertised=NONE` or a stuck `inbound=0` means the node is unreachable from
+outside.
+
+## Two correctness traps
+
+**A successful dial is not evidence of a usable peer.** Clearing an address's cooldown on a
+*successful* dial produced a regression worse than the problem: a session can die seconds after
+connecting — most commonly a peer asking for a block body we only hold the header of, which raises
+`BlockNotFound` and tears down the whole router — and with the cooldown cleared that peer carried no
+backoff at all, so the loop re-dialed it every 2 s under the starved cadence against 30 s before.
+The fix inverts the default: a successful dial takes a **provisional hold**, lifted only by
+`forgive_stable_peers` for outbound peers that stayed connected past 60 s. A stable peer accumulates
+no history and is immediately re-dialable if it later drops; a flapping peer escalates 30 s → 8 m
+even though every dial "succeeds".
+
+**Ban matching must normalize the address form.** `AddressKey` maps IPv4 to its v6-mapped form,
+`Entry` stores the address as supplied, and `ban` canonicalizes to v4. Comparing `IpAddress` values
+directly would let a ban on `1.2.3.4` miss an entry stored as `::ffff:1.2.3.4` — a silently
+ineffective ban, in a filter whose whole purpose is to stop re-dialing a banned peer. Both sides go
+through `mapped_v6`.
+
+## Verification
+
+```bash
+cargo clippy -p keryx-addressmanager -p keryx-connectionmanager -p keryx-p2p-lib -p keryx-p2p-flows --tests
+cargo test -p keryx-addressmanager -p keryx-connectionmanager -p keryx-p2p-lib
+```
+
+Clippy clean on all four crates; 27 tests pass, including `echo::tests::test_handshake`, which
+exercises the new connect timeout and keepalives through a real handshake. The three `DialCooldown`
+tests exist specifically to pin the first correctness trap above.
+
+**No live two-node test has been run.** The remaining verification is a bandwidth-limited pair, one
+node in IBD from the other: before these changes the expected observation is `SendPingsFlow flow
+error: timeout` and a disconnect; after, the connection should survive the whole IBD.
+
+## Known gaps
+
+Deliberately out of scope, in rough priority order:
+
+1. **Inbound handshakes are serialized in the hub event loop.** `hub.rs` awaits
+   `initialize_connection` inline against a 4+4+8 s handshake budget, so one stalling inbound peer
+   blocks all inbound acceptance for up to ~12 s. Largest remaining item for the inbound symptom; the
+   fix is a spawned task behind a `Semaphore`.
+2. **Mainnet has one DNS seeder and one hardcoded IP.** Needs real operator-run hosts, not a code
+   change.
+3. **`Pong` still shares the bulk send queue.** This removes the *damage* from head-of-line blocking,
+   not the blocking. The structural fix is a small priority channel merged into the outgoing stream
+   with a biased `select!`. It also invites shrinking `outgoing_network_channel_size()` from 131 328
+   — at 442 KiB per message that is ~55 GB of theoretical buffering, which is why backpressure never
+   surfaces as `OutgoingRouteCapacityReached` and surfaces as pong delay instead.
+4. **A `BlockNotFound` while serving costs a connection.** `route_to_flow` intercepts
+   `Payload::Reject` before any routing and always returns `Err`, and the receive loop breaks on
+   that. Skipping the hash instead is worse: the requester asks one hash per request and waits with a
+   120 s timeout. This needs a protocol-level "not found" response, so that "I don't have that body"
+   costs a request rather than a connection. It is the churn this change stops *amplifying* but
+   cannot stop.
+
+## Deployment
+
+No lockstep of any kind — no miner change, no consensus change, no protocol version. Roll out one
+node at a time and read the `P2P health:` line; the symptoms have different fixes here and it is
+worth knowing which one a given node actually had. Rollback is safe: the only persistent state
+touched is the address store, where rows now survive that used to be deleted, and an older binary
+reads it unchanged.

--- a/protocol/flows/src/flow_context.rs
+++ b/protocol/flows/src/flow_context.rs
@@ -947,6 +947,12 @@ impl ConnectionInitializer for FlowContext {
         });
         router.set_properties(peer_properties);
 
+        // Remember the version we actually negotiated — not the one advertised — so outbound dialing
+        // can prefer peers that serve the compact proof encoding, keeping older ones as a fallback.
+        if let Some(connection_manager) = self.connection_manager() {
+            connection_manager.record_peer_protocol_version(router.net_address().ip(), applied_protocol_version);
+        }
+
         // Send and receive the ready signal
         handshake.exchange_ready_messages().await?;
 

--- a/protocol/flows/src/v7/address.rs
+++ b/protocol/flows/src/v7/address.rs
@@ -1,6 +1,7 @@
 use crate::{flow_context::FlowContext, flow_trait::Flow};
 use itertools::Itertools;
 use keryx_addressmanager::NetAddress;
+use keryx_core::{debug, task::tick::TickReason};
 use keryx_p2p_lib::{
     IncomingRoute, Router,
     common::ProtocolError,
@@ -8,8 +9,11 @@ use keryx_p2p_lib::{
     pb::{AddressesMessage, RequestAddressesMessage, kaspad_message::Payload},
 };
 use keryx_utils::networking::IpAddress;
-use rand::seq::SliceRandom;
-use std::sync::Arc;
+use rand::{Rng, seq::SliceRandom};
+use std::{
+    sync::{Arc, Weak},
+    time::Duration,
+};
 
 /// The maximum number of addresses that are sent in a single kaspa Addresses message.
 const MAX_ADDRESSES_SEND: usize = 1000;
@@ -18,16 +22,46 @@ const MAX_ADDRESSES_SEND: usize = 1000;
 /// If a peer exceeds this value we consider it a protocol error.
 const MAX_ADDRESSES_RECEIVE: usize = 2500;
 
+/// How long we wait for a peer to answer a `RequestAddresses`. Missing the deadline is not fatal —
+/// see [`ReceiveAddressesFlow`].
+const ADDRESS_RESPONSE_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// Interval between address requests once the local store is comfortably stocked.
+const ADDRESS_REQUEST_INTERVAL: Duration = Duration::from_secs(600);
+
+/// Interval used while the store holds fewer than [`WELL_STOCKED_ADDRESS_COUNT`] addresses, i.e.
+/// while discovery is the bottleneck.
+const ADDRESS_REQUEST_INTERVAL_STARVED: Duration = Duration::from_secs(60);
+
+/// Address-store size above which we consider discovery satisfied and slow the requests down.
+const WELL_STOCKED_ADDRESS_COUNT: usize = 64;
+
+/// Upper bound of the random delay before the first request, so that a node coming up with many
+/// peers does not ask all of them in the same instant.
+const ADDRESS_REQUEST_JITTER: Duration = Duration::from_secs(5);
+
+/// Asks a peer for its known addresses, periodically.
+///
+/// This used to ask exactly once per connection and then exit, which made the address store grow
+/// only when a *new* connection was established — precisely what a node cannot do once the store has
+/// drained. Re-requesting on an interval is backward compatible: `SendAddressesFlow` on every
+/// deployed node already answers `RequestAddresses` in an unbounded loop, so no protocol change is
+/// involved.
+///
+/// A missed response is also no longer fatal. `Flow::launch` closes the whole router when a flow
+/// returns `Err`, so the old 120s timeout on this one message meant that a peer which simply chose
+/// not to share addresses cost us an otherwise healthy block-relay connection.
 pub struct ReceiveAddressesFlow {
     ctx: FlowContext,
-    router: Arc<Router>,
+    // Weak, so waiting between requests does not keep a closed connection's router alive
+    router: Weak<Router>,
     incoming_route: IncomingRoute,
 }
 
 #[async_trait::async_trait]
 impl Flow for ReceiveAddressesFlow {
     fn router(&self) -> Option<Arc<Router>> {
-        Some(self.router.clone())
+        self.router.upgrade()
     }
 
     async fn start(&mut self) -> Result<(), ProtocolError> {
@@ -37,28 +71,58 @@ impl Flow for ReceiveAddressesFlow {
 
 impl ReceiveAddressesFlow {
     pub fn new(ctx: FlowContext, router: Arc<Router>, incoming_route: IncomingRoute) -> Self {
-        Self { ctx, router, incoming_route }
+        Self { ctx, router: Arc::downgrade(&router), incoming_route }
     }
 
     async fn start_impl(&mut self) -> Result<(), ProtocolError> {
-        self.router
-            .enqueue(make_message!(
-                Payload::RequestAddresses,
-                RequestAddressesMessage { include_all_subnetworks: false, subnetwork_id: None }
-            ))
-            .await?;
-
-        let msg = dequeue_with_timeout!(self.incoming_route, Payload::Addresses)?;
-        let address_list: Vec<(IpAddress, u16)> = msg.try_into()?;
-        if address_list.len() > MAX_ADDRESSES_RECEIVE {
-            return Err(ProtocolError::OtherOwned(format!("address count {} exceeded {}", address_list.len(), MAX_ADDRESSES_RECEIVE)));
+        let jitter = Duration::from_millis(rand::thread_rng().gen_range(0..ADDRESS_REQUEST_JITTER.as_millis() as u64));
+        if let TickReason::Shutdown = self.ctx.tick_service.tick(jitter).await {
+            return Ok(());
         }
-        let mut amgr_lock = self.ctx.address_manager.lock();
-        for (ip, port) in address_list {
-            amgr_lock.add_address(NetAddress::new(ip, port))
-        }
+        loop {
+            let Some(router) = self.router.upgrade() else {
+                return Err(ProtocolError::ConnectionClosed);
+            };
+            router
+                .enqueue(make_message!(
+                    Payload::RequestAddresses,
+                    RequestAddressesMessage { include_all_subnetworks: false, subnetwork_id: None }
+                ))
+                .await?;
+            drop(router);
 
-        Ok(())
+            match dequeue_with_timeout!(self.incoming_route, Payload::Addresses, ADDRESS_RESPONSE_TIMEOUT) {
+                Ok(msg) => {
+                    let address_list: Vec<(IpAddress, u16)> = msg.try_into()?;
+                    if address_list.len() > MAX_ADDRESSES_RECEIVE {
+                        // Over-sharing is a genuine protocol violation, so this one still disconnects
+                        return Err(ProtocolError::OtherOwned(format!(
+                            "address count {} exceeded {}",
+                            address_list.len(),
+                            MAX_ADDRESSES_RECEIVE
+                        )));
+                    }
+                    let mut amgr_lock = self.ctx.address_manager.lock();
+                    let learned =
+                        address_list.into_iter().filter(|&(ip, port)| amgr_lock.add_address(NetAddress::new(ip, port))).count();
+                    drop(amgr_lock);
+                    debug!("Learned {} new addresses from peer {:?}", learned, self.router.upgrade().map(|r| r.to_string()));
+                }
+                Err(ProtocolError::Timeout(_)) => {
+                    debug!("Peer did not answer our address request in time, will retry later");
+                }
+                Err(err) => return Err(err),
+            }
+
+            let interval = if self.ctx.address_manager.lock().address_count() < WELL_STOCKED_ADDRESS_COUNT {
+                ADDRESS_REQUEST_INTERVAL_STARVED
+            } else {
+                ADDRESS_REQUEST_INTERVAL
+            };
+            if let TickReason::Shutdown = self.ctx.tick_service.tick(interval).await {
+                return Ok(());
+            }
+        }
     }
 }
 

--- a/protocol/flows/src/v7/ping.rs
+++ b/protocol/flows/src/v7/ping.rs
@@ -8,6 +8,7 @@ use keryx_p2p_lib::{
 };
 use rand::Rng;
 use std::{
+    collections::VecDeque,
     sync::{Arc, Weak},
     time::{Duration, Instant},
 };
@@ -46,7 +47,19 @@ impl ReceivePingsFlow {
     }
 }
 
-pub const PING_INTERVAL: Duration = Duration::from_secs(120); // 2 minutes
+pub const PING_INTERVAL: Duration = Duration::from_secs(30);
+
+/// How long we wait for a pong before counting a strike.
+const PONG_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Consecutive missed pongs tolerated before the peer is dropped.
+///
+/// A single miss is not evidence of a dead peer. `Pong` shares the peer's single, unprioritized
+/// outgoing queue with block bodies, so an IBD chunk of `IBD_BATCH_SIZE` bodies — each carrying a
+/// PoM proof of a few hundred KiB — can legitimately sit in front of it, and the receiving side can
+/// be stalled just as long validating them. Dropping the connection on the first miss turned a slow
+/// minute into a lost peer, and (through `record_ping_timeout`) into a 24h ban of an honest node.
+const MAX_CONSECUTIVE_PING_TIMEOUTS: u32 = 3;
 
 /// Flow for managing a loop sending pings and waiting for pongs
 pub struct SendPingsFlow {
@@ -76,6 +89,12 @@ impl SendPingsFlow {
     }
 
     async fn start_impl(&mut self) -> Result<(), ProtocolError> {
+        let mut consecutive_timeouts = 0u32;
+        // Nonces still unanswered, with the instant they were sent. Because we now tolerate missed
+        // pongs, a pong for an earlier round can legitimately arrive during a later one — it is
+        // proof of liveness, not a protocol violation, so we match against the whole window instead
+        // of only the latest nonce.
+        let mut outstanding: VecDeque<(u64, Instant)> = VecDeque::with_capacity(MAX_CONSECUTIVE_PING_TIMEOUTS as usize);
         loop {
             // Wait `PING_INTERVAL` between pings
             if let TickReason::Shutdown = self.ctx.tick_service.tick(PING_INTERVAL).await {
@@ -85,27 +104,46 @@ impl SendPingsFlow {
             // Create a fresh random nonce for each ping
             let nonce = rand::thread_rng().r#gen::<u64>();
             let ping = make_message!(Payload::Ping, PingMessage { nonce });
-            let ping_time = Instant::now();
             let Some(router) = self.router.upgrade() else {
                 return Err(ProtocolError::ConnectionClosed);
             };
             router.enqueue(ping).await?;
-            let pong = match dequeue_with_timeout!(self.incoming_route, Payload::Pong) {
+            if outstanding.len() == MAX_CONSECUTIVE_PING_TIMEOUTS as usize {
+                outstanding.pop_front();
+            }
+            outstanding.push_back((nonce, Instant::now()));
+
+            let pong = match dequeue_with_timeout!(self.incoming_route, Payload::Pong, PONG_TIMEOUT) {
                 Err(e @ ProtocolError::Timeout(_)) => {
-                    if let Some(cm) = self.ctx.connection_manager() {
+                    consecutive_timeouts += 1;
+                    // Only a peer that has never answered a single pong on this connection is
+                    // counted towards an automatic ban. That is precisely the phantom-node
+                    // signature the ban was written for — connect silently, occupy a slot, never
+                    // speak — and it structurally excludes an honest peer that is merely stalled.
+                    if router.last_ping_duration() == 0
+                        && let Some(cm) = self.ctx.connection_manager()
+                    {
                         cm.record_ping_timeout(router.net_address().ip()).await;
                     }
-                    return Err(e);
+                    if consecutive_timeouts >= MAX_CONSECUTIVE_PING_TIMEOUTS {
+                        return Err(e);
+                    }
+                    debug!(
+                        "Ping timeout {}/{} with peer {} (nonce: {}), still giving it a chance",
+                        consecutive_timeouts, MAX_CONSECUTIVE_PING_TIMEOUTS, self.peer, nonce
+                    );
+                    continue;
                 }
                 Err(e) => return Err(e),
                 Ok(p) => p,
             };
-            if pong.nonce != nonce {
+            let Some(&(_, sent_at)) = outstanding.iter().find(|(sent_nonce, _)| *sent_nonce == pong.nonce) else {
                 return Err(ProtocolError::Other("nonce mismatch between ping and pong"));
-            } else {
-                debug!("Successful ping with peer {} (nonce: {})", self.peer, pong.nonce);
-            }
-            router.set_last_ping_duration(ping_time.elapsed().as_millis() as u64);
+            };
+            debug!("Successful ping with peer {} (nonce: {})", self.peer, pong.nonce);
+            consecutive_timeouts = 0;
+            outstanding.clear();
+            router.set_last_ping_duration(sent_at.elapsed().as_millis() as u64);
         }
     }
 }

--- a/protocol/p2p/src/core/connection_handler.rs
+++ b/protocol/p2p/src/core/connection_handler.rs
@@ -77,8 +77,15 @@ impl ConnectionHandler {
                 .send_compressed(tonic::codec::CompressionEncoding::Gzip)
                 .max_decoding_message_size(P2P_MAX_MESSAGE_SIZE);
 
-            // TODO: check whether we should set tcp_keepalive
+            // Inbound connections had no keepalive at all, so a NAT or firewall dropping its state
+            // left a half-open connection that only the 30s ping flow would eventually notice —
+            // and that flow is the one which disconnects and counts strikes towards a ban.
+            // HTTP/2 PING is a transport frame every hyper/tonic peer answers, so this needs no
+            // protocol change and interoperates with unpatched nodes.
             let serve_result = TonicServer::builder()
+                .tcp_keepalive(Some(Duration::from_millis(Self::keep_alive())))
+                .http2_keepalive_interval(Some(Duration::from_millis(Self::http2_keep_alive_interval())))
+                .http2_keepalive_timeout(Some(Duration::from_millis(Self::http2_keep_alive_timeout())))
                 .layer(MapRequestBodyLayer::new(move |body| CountBytesBody::new(body, bytes_rx.clone()).boxed_unsync()))
                 .layer(MapResponseBodyLayer::new(move |body| CountBytesBody::new(body, bytes_tx.clone())))
                 .add_service(proto_server)
@@ -104,6 +111,9 @@ impl ConnectionHandler {
             .timeout(Duration::from_millis(Self::communication_timeout()))
             .connect_timeout(Duration::from_millis(Self::connect_timeout()))
             .tcp_keepalive(Some(Duration::from_millis(Self::keep_alive())))
+            .http2_keep_alive_interval(Duration::from_millis(Self::http2_keep_alive_interval()))
+            .keep_alive_timeout(Duration::from_millis(Self::http2_keep_alive_timeout()))
+            .keep_alive_while_idle(true)
             .connect()
             .await?;
 
@@ -181,16 +191,35 @@ impl ConnectionHandler {
         (1 << 17) + 256
     }
 
+    /// Wait for a request's response headers. Note this is a tower per-request timeout: for the
+    /// long-lived `message_stream` streaming RPC it bounds the handshake of the stream, not its
+    /// lifetime.
     fn communication_timeout() -> u64 {
-        10_000
+        30_000
     }
 
     fn keep_alive() -> u64 {
-        10_000
+        30_000
     }
 
+    /// Interval between HTTP/2 PING frames on an otherwise idle connection.
+    fn http2_keep_alive_interval() -> u64 {
+        30_000
+    }
+
+    /// How long we wait for the peer to answer an HTTP/2 PING before considering the connection dead.
+    fn http2_keep_alive_timeout() -> u64 {
+        20_000
+    }
+
+    /// TCP + HTTP/2 + gRPC connection establishment budget.
+    ///
+    /// One second is below a single SYN retransmit, so any packet loss — or simply a peer more than
+    /// a few hundred milliseconds away — failed deterministically. Each such failure is recorded
+    /// against the address, and since `Adaptor::connect_peer` makes exactly one attempt per round,
+    /// a handful of unlucky rounds used to write an honest intercontinental peer off entirely.
     fn connect_timeout() -> u64 {
-        1_000
+        8_000
     }
 }
 


### PR DESCRIPTION
> **Stacked on #36.** This branch has #36's commit as its parent, so the diff below includes it. Merge #36 first and this becomes a clean 7-file diff. The two touch the same file (`connectionmanager/src/lib.rs`), which is why they are stacked rather than parallel.

## Why this exists

The v4 PoM proof is **~442 KiB per block** (~233 KiB for v2). It broke no explicit limit, but it halved the margin on every timeout and queue we inherited from `rusty-kaspa`, which were sized for blocks of a few KB. Most of what follows is upstream behaviour that only turns pathological at 10 BPS with a 442 KiB witness — which is to say the node is not slow to find peers because the network is small, it is slow because it drops and forgets the peers it already has.

Four symptoms — slow discovery, dropped peers, never reaching `--outpeers`, zero inbound — over five independent mechanisms. Raising `--outpeers` reaches none of them: it already defaults to 16, and the target is not being *reached*.

## The five mechanisms

**1. `Pong` sits behind 44 MB of block bodies.** It is enqueued on the same single, unprioritized `outgoing_route` as block bodies. A peer serving an IBD chunk has `IBD_BATCH_SIZE = 99` bodies ahead of its pong. Upstream allowed a single pong 120 s, so above ~370 KB/s it made it and below it did not — and `Flow::launch` closes the router on **any** flow returning `Err`, so one late pong killed every other flow with that peer, while `record_ping_timeout` counted it towards a 24 h IP ban. The v2 to v4 doubling halved the bandwidth at which a node starts banning honest peers.

**2. No keepalive on the serving side.** The client set `tcp_keepalive(10 s)`; the server set nothing. A NAT dropping its state left a half-open inbound connection that only the ping flow would notice — up to 240 s later, through the one code path that also bans.

**3. The address store drains itself.** Insert at `connection_failed_count = 1`, remove above 3, `connect_timeout` of 1 s (below a single SYN retransmit), and `ban()` also calling `remove_by_ip`. A 300 ms-RTT peer fails three 1 s dials and is erased. Recovery needs fresh gossip, which needs a new connection, which is exactly what a drained store cannot make — and `ReceiveAddressesFlow` asked for addresses once per connection, then exited.

**4. The dial loop starves its own recovery path.** No round cap, so it could walk all 4096 addresses in serialized rounds of at most 16 dials **before** reaching the DNS seeding at the end of the iteration — the only recovery path when the store is full of dead addresses. A cold start wasted a full 30 s tick. And the dial-exclusion set was built from `peer.net_address()`, which for an inbound peer is the remote *ephemeral* port, so it never matched a store entry and the loop re-dialed peers it was already connected to.

**5. Inbound is invisible and evicted at random.** With no routable local address and no UPnP, the handshake `Version` advertises no address at all — zero inbound, permanently, reported as one `info!` at boot. Over-limit inbound peers were then evicted with `choose_multiple`, uniformly at random.

## What the code does

**Tolerate a slow pong; ban only a peer that never ponged.** `PING_INTERVAL` 120 s to 30 s, explicit `PONG_TIMEOUT` 60 s, `MAX_CONSECUTIVE_PING_TIMEOUTS = 3`. The load-bearing part is the **outstanding-nonce window**: `SendPingsFlow` keeps a `VecDeque` of up to three unanswered nonces and matches an incoming pong against the whole window, measuring RTT from the instant that round's ping was sent. Without it, tolerating misses would be unsound — a late pong carries a nonce that no longer matches the latest, and a nonce mismatch is a disconnect. The window is what makes "wait longer" and "keep checking the nonce" compatible.

| | before | after |
|---|---|---|
| slack for one pong before the peer is dropped | 120 s | ~240 s |
| IBD bandwidth below which an honest peer is dropped | ~370 KB/s | ~190 KB/s |
| a dead *connection* is detected in | ~240 s | ~50 s |

The ban gate is narrowed to `router.last_ping_duration() == 0` — a peer that has **never** spoken on this connection. An honest peer stalled behind its own body validation is excluded structurally, not by a threshold.

**Keepalive on both sides.** TCP and HTTP/2 keepalive at 30 s, `connect_timeout` 1 s to 8 s. HTTP/2 PING is a transport frame answered by every hyper/tonic peer, so it interoperates with unpatched nodes.

**The address store stops deleting.** Failures **saturate** instead of removing — the selection weight already makes a written-off address 4096x less likely to be picked, and one success resets it — with a decay pass when the iterator is exhausted, so a node that was offline does not treat every address as hopeless forever. Bans filter at selection time, honouring the 24 h expiry, instead of deleting the row.

**The loop stops blocking itself.** Adaptive cadence (2 s starved / 10 s below target / 30 s satisfied) behind a per-address exponential backoff — the cooldown is the prerequisite that makes the fast cadence safe. Rounds capped at 4 so DNS seeding is always reached; seeding that learns something triggers an immediate re-run; exclusion by canonical IP so inbound peers stop consuming outbound dial slots.

**Periodic address requests, non-fatal on timeout.** `ReceiveAddressesFlow` becomes a loop with 5 s jitter, every 60 s while under-stocked and 600 s otherwise. Backward compatible without a protocol change: `SendAddressesFlow` on every deployed node already answers `RequestAddresses` in an unbounded loop — the one-shot behaviour was on the *receiving* side only. About 14 KB per peer per 10 minutes.

**Inbound: say it out loud, evict deliberately.** A `warn!` naming the consequence and the fix (`--externalip`), and eviction ranked worst-first: silent squatters past a 300 s grace, then newest connections, then prefix redundancy. A health line once a minute makes the symptoms distinguishable in the field:

```
P2P health: outbound=3/16 (v11=2 v10=1 other=0) inbound=0/128 | addresses=41 cooling_down=7 banned=2 | advertised=NONE (...)
```

## Two correctness traps

**A successful dial is not evidence of a usable peer.** Clearing an address's cooldown on a *successful* dial produced a regression worse than the problem: a session can die seconds after connecting — a peer asking for a block body we only hold the header of raises `BlockNotFound` and tears down the router — and with the cooldown cleared, the loop re-dialed that peer every 2 s under the starved cadence, against 30 s before. A successful dial now takes a **provisional hold**, lifted only for outbound peers that stay connected past 60 s. A stable peer accumulates no history; a flapping peer escalates 30 s to 8 m even though every dial "succeeds".

**Ban matching must normalize the address form.** `AddressKey` maps IPv4 to its v6-mapped form, `Entry` stores it as supplied, `ban` canonicalizes to v4. Comparing directly would let a ban on `1.2.3.4` miss `::ffff:1.2.3.4` — a silently ineffective ban, in a filter whose whole purpose is to stop re-dialing a banned peer.

## Protocol changes

**None.** No consensus rule, no wire format, no message type, no `PROTOCOL_VERSION` bump, no DAA gate, no miner lockstep. Two changes look like protocol changes and are not: periodic `RequestAddresses` re-uses a request every deployed node already serves, and HTTP/2 keepalive sits below the p2p protocol. Every benefit is unilateral — it does not require the peer to be patched.

## Verification

Clippy clean on `keryx-addressmanager`, `keryx-connectionmanager`, `keryx-p2p-lib`, `keryx-p2p-flows`. **27 tests pass**, including `echo::tests::test_handshake`, which exercises the new connect timeout and keepalives through a real handshake. The three `DialCooldown` tests exist specifically to pin the first correctness trap.

**No live two-node test has been run yet.** The remaining verification is a bandwidth-limited pair, one node in IBD from the other: before, the expected observation is `SendPingsFlow flow error: timeout` and a disconnect; after, the connection should survive the whole IBD.

## Known gaps (deliberately out of scope)

1. Inbound handshakes are serialized in the hub event loop — one stalling peer blocks all inbound acceptance for up to ~12 s. Largest remaining item for the inbound symptom.
2. Mainnet has one DNS seeder and one hardcoded IP. Needs real hosts, not a code change.
3. `Pong` still shares the bulk send queue. This removes the *damage* from head-of-line blocking, not the blocking. The structural fix is a priority channel with a biased `select!`.
4. A `BlockNotFound` while serving still costs a connection: `route_to_flow` intercepts `Payload::Reject` before any routing and always returns `Err`. It needs a protocol-level "not found" response. This change stops *amplifying* that churn but cannot stop it.

## Deployment

Roll out one node at a time and read the `P2P health:` line — the symptoms have different fixes here and it is worth knowing which one a given node had. Rollback is safe: the only persistent state touched is the address store, where rows now survive that used to be deleted, and an older binary reads it unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
