### PR TITLE
Reference: per-address payout/tier/burn indexes and getHolderReward (data contract for explorer-served mining data)

### DIFF
--- a/cli/src/modules/rpc.rs
+++ b/cli/src/modules/rpc.rs
@@ -174,6 +174,16 @@ impl Rpc {
                 let result = rpc.get_utxos_by_addresses_call(None, GetUtxosByAddressesRequest { addresses }).await?;
                 self.println(&ctx, result);
             }
+            RpcApiOps::GetHolderReward => {
+                if argv.is_empty() {
+                    return Err(Error::custom("Please specify at least one address"));
+                }
+                let addresses = argv.iter().map(|s| Address::try_from(s.as_str())).collect::<std::result::Result<Vec<_>, _>>()?;
+                for address in addresses {
+                    let result = rpc.get_holder_reward_call(None, GetHolderRewardRequest { address }).await?;
+                    self.println(&ctx, result);
+                }
+            }
             RpcApiOps::GetBalanceByAddress => {
                 if argv.is_empty() {
                     return Err(Error::custom("Please specify at least one address"));

--- a/components/consensusmanager/src/session.rs
+++ b/components/consensusmanager/src/session.rs
@@ -216,6 +216,13 @@ impl ConsensusSessionOwned {
         self.consensus.get_service_strikes()
     }
 
+    pub fn get_holder_reward(
+        &self,
+        script_public_key: &keryx_consensus_core::tx::ScriptPublicKey,
+    ) -> keryx_consensus_core::collateral::HolderRewardSnapshot {
+        self.consensus.get_holder_reward(script_public_key)
+    }
+
     pub fn get_virtual_bits(&self) -> u32 {
         // Accessing cached virtual fields is lock-free and does not require spawn_blocking
         self.consensus.get_virtual_bits()

--- a/consensus/client/src/utils.rs
+++ b/consensus/client/src/utils.rs
@@ -23,6 +23,25 @@ pub fn pay_to_address_script(address: &AddressT) -> Result<ScriptPublicKey> {
     Ok(standard::pay_to_address_script(address.as_ref()))
 }
 
+/// The service-ledger identity of a payout address: the `miner` key that
+/// {@link RpcClient.getServiceStrikes} reports strikes, suspensions and pending burns under.
+///
+/// That call returns the whole network keyed by this hash and takes no address, so without this
+/// there is no way to tell which row is yours. Derived here rather than reimplemented by callers
+/// on purpose: it is `blake2b-256(key="TransactionHash", version_le ‖ script)`, and a copy that
+/// drifted from the node would match nothing and report a clean record forever — the failure mode
+/// that looks like good news.
+///
+/// Note this is the identity of the PAYOUT address. An announced escrow key is a different
+/// identity, bound to this one by a delegation cert.
+/// @category Wallet SDK
+#[wasm_bindgen(js_name = minerKeyForAddress)]
+pub fn miner_key_for_address(address: &AddressT) -> Result<HexString> {
+    let address = Address::try_cast_from(address)?;
+    let spk = standard::pay_to_address_script(address.as_ref());
+    Ok(keryx_consensus_core::collateral::miner_key(&spk).to_hex().into())
+}
+
 /// Takes a script and returns an equivalent pay-to-script-hash script.
 /// @param redeem_script - The redeem script ({@link HexString} or Uint8Array).
 /// @category Wallet SDK

--- a/consensus/core/src/api/mod.rs
+++ b/consensus/core/src/api/mod.rs
@@ -9,7 +9,7 @@ use crate::{
     block::{Block, BlockTemplate, TemplateBuildMode, TemplateTransactionSelector, VirtualStateApproxId},
     blockstatus::BlockStatus,
     coinbase::MinerData,
-    collateral::ServiceStrikesSnapshot,
+    collateral::{HolderRewardSnapshot, ServiceStrikesSnapshot},
     daa_score_timestamp::DaaScoreTimestamp,
     errors::{
         block::{BlockProcessResult, RuleError},
@@ -156,6 +156,11 @@ pub trait ConsensusApi: Send + Sync {
     }
 
     fn get_service_strikes(&self) -> ServiceStrikesSnapshot {
+        unimplemented!()
+    }
+
+    /// Holder-reward (ratio-reward) state of one payout address at the committed virtual view.
+    fn get_holder_reward(&self, _script_public_key: &crate::tx::ScriptPublicKey) -> HolderRewardSnapshot {
         unimplemented!()
     }
 

--- a/consensus/core/src/coinbase.rs
+++ b/consensus/core/src/coinbase.rs
@@ -52,4 +52,40 @@ pub struct CoinbaseTransactionTemplate {
     /// Index of the red-blocks reward output within the coinbase outputs, if present.
     /// Used by modify_block_template to rewrite the correct output when changing miner address.
     pub red_reward_output_index: Option<usize>,
+    /// Per-payout-SPK split of what this coinbase pays, emitted by the builder because it cannot
+    /// be reconstructed from the finished transaction: a miner cut is the base cut scaled by the
+    /// tier and ratio brackets **of this block's view** (neither map survives validation), and an
+    /// inference-reward mint is indistinguishable from a miner cut by script alone. One entry per
+    /// SPK, already aggregated over the blues that share it.
+    pub payouts: Vec<(ScriptPublicKey, CoinbasePayout)>,
 }
+
+/// What one payout SPK earns from a single coinbase, split by source, so income can be reported
+/// apart from the shortfall the reward brackets destroy.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct CoinbasePayout {
+    /// Miner cut actually paid, after the tier and ratio brackets. Zero for a suspended producer.
+    pub paid: u64,
+    /// The base miner cut before those brackets; `base − paid` is what was burned.
+    pub base: u64,
+    /// Escrow slice that accrued to this producer. Zero when it was burned at emission (a
+    /// standard miner announces no escrow key, so the slice is paid to the burn SPK).
+    pub escrow: u64,
+    /// Inference-reward mints this coinbase routed to this SPK.
+    pub inference: u64,
+    /// The `base` cut split by the proven model tier of the blue that earned it, indexed by tier.
+    /// Display only, and NOT filled by the builder — the builder is handed bracket multipliers in
+    /// bps, and mapping bps back to a tier would misread a standing-demoted top tier as the entry
+    /// tier, which is the exact confusion this index exists to remove. It is filled from each
+    /// blue's own header instead, at the two places that know it.
+    ///
+    /// `Σ tier_base` equals `base` for blues whose tier is resolvable, and falls short of it for
+    /// pre-PoM blues that have none — so a share must be taken over the sum of these, never over
+    /// `base`, or an untiered block would silently dilute the mix.
+    pub tier_base: [u64; TIER_BUCKETS],
+}
+
+/// Tier buckets tracked per payout SPK. Five: the H6 schedule's width, which is also H2's. The
+/// legacy pre-H2 schedule had four, and its tiers are a prefix of these, so a shorter schedule
+/// simply leaves the top bucket empty.
+pub const TIER_BUCKETS: usize = 5;

--- a/consensus/core/src/collateral.rs
+++ b/consensus/core/src/collateral.rs
@@ -330,7 +330,70 @@ pub struct ServiceStrikesSnapshot {
     pub lifetime_strikes: Vec<(Hash, u32)>,
 }
 
+/// Per-address holder-reward (ratio-reward) state at the node's committed virtual view: the exact
+/// inputs `ratio_bps_by_block` scales a miner cut by, for one payout address.
+///
+/// Display only — nothing in consensus reads this back. It answers "why is my miner cut being
+/// cut, and what would fix it" without an operator having to run `KERYX_RATIO_DEBUG` and tail a
+/// log. Unlike the bracket the coinbase uses, this is taken at the committed view with no
+/// `view_diffs`: it describes the chain as the node currently sees it, not some block's POV.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct HolderRewardSnapshot {
+    pub virtual_daa_score: u64,
+    /// Ratio numerator: the coin-age effective balance at/after `coin_age_activation`, the
+    /// instantaneous balance before it. NOT the wallet's spendable balance — immature coins
+    /// count at a prorata of their age, so this reads below the UTXO total while coins ripen.
+    pub eff_balance: u64,
+    /// Windowed production BEFORE the one-block floor. Zero means this address has never been
+    /// paid a miner cut inside the window, which is what separates a plain holder from a miner.
+    pub production_raw: u64,
+    /// The denominator actually used: `production_raw` floored at one block's base miner cut, so
+    /// a newcomer with no recent production divides by one block instead of by zero.
+    pub production: u64,
+    /// Bracket multiplier in bps, out of `RATIO_REWARD_BPS_DIVISOR`.
+    pub bracket_bps: u64,
+    /// The rung above: `(bps, effective balance that reaches it)`. `None` at the top bracket.
+    pub next_bracket: Option<(u64, u64)>,
+    /// Effective balance that reaches the top (100 %) bracket.
+    pub full_bracket_balance: u64,
+    /// Length of the production window, in DAA score.
+    pub window_daa: u64,
+    /// Miner cut the coinbases actually PAID this address over the window, post tier/ratio
+    /// scaling. This is mining income, unlike `production_raw`, which is only the entitlement.
+    pub paid: u64,
+    /// The shortfall destroyed by the tier and ratio brackets: `production_raw − paid`.
+    pub burned: u64,
+    /// Escrow slice that ACCRUED to this address over the window — zero for a standard miner,
+    /// whose escrow output is paid to the burn SPK at emission. CSV-locked, and still forfeitable
+    /// to a service penalty before it is claimed, so it is income earned but not yet in hand.
+    pub escrow: u64,
+    /// Inference-reward mints routed to this address over the window. Mining income of a second
+    /// kind: won by serving an inference, not by producing a block, so it is counted apart from
+    /// the miner cut and is NOT part of the base entitlement the brackets scale.
+    pub inference: u64,
+    /// Daa actually spanned by `paid`, `burned`, `escrow` and `inference` — **not** necessarily
+    /// `window_daa`. The payout indexes those four read are display-only and maintained forward
+    /// from the boot that created them (a from-chain backfill needs a coinbase body read per chain
+    /// block and per blue), so a node that has just built them covers only the daa since. Equal to
+    /// `window_daa` once a full window has elapsed; below it means the four figures are real but
+    /// describe a shorter period, and 0 means no coverage at all. Label them with this, never with
+    /// `window_daa`, or a node that mined all night reads as a node that burned all night.
+    pub income_window_daa: u64,
+    /// Base miner cut over `income_window_daa`, split by the proven model tier that earned it —
+    /// the MIX, indexed by tier. A miner is not on one tier: rigs run different models, so any
+    /// single tier reported for a window would be false for anyone running more than one. The
+    /// production-weighted tier is a division over these; the mix is not recoverable from it.
+    ///
+    /// Sums to the span's entitlement for blues whose tier is resolvable, and falls short for
+    /// pre-PoM ones — so shares must be taken over the sum of these, never over the entitlement.
+    pub tier_base: [u64; crate::coinbase::TIER_BUCKETS],
+    /// Whether the ratio reward is in force at this view at all. When false the miner cut is
+    /// unscaled and every bracket figure above is informational only.
+    pub active: bool,
+}
+
 /// One escrow claim of a miner: a CSV-locked coinbase escrow output he can claim after the lock,
+
 /// unless burned by a service penalty first.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct EscrowClaim {

--- a/consensus/core/src/config/params.rs
+++ b/consensus/core/src/config/params.rs
@@ -721,6 +721,44 @@ pub const RATIO_REWARD_WINDOW_DAA: u64 = 864_000;
 /// KERYX-KRX/coin_age_holder_reward_spec.md §2/§9. Used at/after `coin_age_activation`.
 pub const COIN_AGE_MATURITY_W: u64 = 864_000; // 24h at 10 BPS
 
+/// The bracket table in force for a given era: `(thresholds, bps)`. `coin_age_active` selects the
+/// recalibrated v2 table, mirroring the gate in `ratio_bps_by_block` — callers that need to
+/// explain a bracket (which rung, what the next one costs) read the table instead of
+/// re-hardcoding it. `thresholds` and the returned `bps` are index-aligned.
+pub fn ratio_reward_table(coin_age_active: bool) -> (&'static [u64], &'static [u64]) {
+    if coin_age_active {
+        (&RATIO_REWARD_THRESHOLDS_V2, &RATIO_REWARD_BPS_V2)
+    } else {
+        (&RATIO_REWARD_THRESHOLDS, &RATIO_REWARD_BPS)
+    }
+}
+
+/// Explains a bracket rather than just returning it: `(bracket_bps, next_bracket, full_bracket)`
+/// where `next_bracket` is `(bps, balance needed to reach it)` and is `None` at the top rung, and
+/// `full_bracket` is the balance that reaches 100 %.
+///
+/// Same ascending scan as `ratio_bracket_bps`, but it keeps the rung INDEX so the rung above can
+/// be priced. `balance` must be the value the bracket actually divides (the coin-age effective
+/// balance in the v2 era) and `production` must already be floored by the caller, exactly as on
+/// the coinbase path — otherwise the answer explains a bracket the chain never applied.
+///
+/// Thresholds are multiples of production, so a heavy producer's target can exceed `u64`; those
+/// saturate, since the figure is only ever a display target.
+pub fn ratio_bracket_explain(balance: u64, production: u64, coin_age_active: bool) -> (u64, Option<(u64, u64)>, u64) {
+    let (thresholds, bps_table) = ratio_reward_table(coin_age_active);
+    let mut idx = 0usize;
+    for i in 0..thresholds.len() {
+        if (balance as u128) >= (thresholds[i] as u128) * (production as u128) {
+            idx = i;
+        } else {
+            break;
+        }
+    }
+    let target_at = |i: usize| ((thresholds[i] as u128) * (production as u128)).min(u64::MAX as u128) as u64;
+    let next = (idx + 1 < thresholds.len()).then(|| (bps_table[idx + 1], target_at(idx + 1)));
+    (bps_table[idx], next, target_at(thresholds.len() - 1))
+}
+
 /// Returns the `RATIO_REWARD_BPS` multiplier for a payout address given its `balance` and its
 /// `production` over the trailing window. The caller MUST floor `production` at one block subsidy
 /// (a zero-history / freshly-rotated address would otherwise hit the top bracket for free).
@@ -2118,5 +2156,47 @@ mod ratio_reward_bps_tests {
         // Off-by-one just under each threshold must NOT round up to the next bracket.
         assert_eq!(ratio_reward_bps_v2(3 * P - 1, P), 5_000);
         assert_eq!(ratio_reward_bps_v2(90 * P - 1, P), 9_000);
+    }
+
+    #[test]
+    fn bracket_explain_agrees_with_bps_and_prices_the_next_rung() {
+        // Live mainnet figures for a miner sitting mid-table (eff balance / production ~= 52.3x,
+        // which clears the 45x rung but not 60x). Pinned against what the chain explorer reports
+        // for the same address, so a change to either table is caught here rather than in the UI.
+        let eff_balance = 1_341_588_096_761_450u64;
+        let production = 25_659_176_302_130u64;
+        let (bps, next, full) = ratio_bracket_explain(eff_balance, production, true);
+        assert_eq!(bps, 7_500);
+        assert_eq!(next, Some((8_000, 60 * production)));
+        assert_eq!(full, 90 * production);
+        // The explainer must never disagree with the multiplier the coinbase path uses.
+        assert_eq!(bps, ratio_reward_bps_v2(eff_balance, production));
+
+        // Top rung: nothing above it to price, and `full` is the rung already occupied.
+        let (top_bps, top_next, top_full) = ratio_bracket_explain(90 * production, production, true);
+        assert_eq!(top_bps, 10_000);
+        assert_eq!(top_next, None);
+        assert_eq!(top_full, 90 * production);
+
+        // Bottom rung: a pure dumper keeps the floor and is quoted the first step up.
+        let (floor_bps, floor_next, _) = ratio_bracket_explain(0, production, true);
+        assert_eq!(floor_bps, 5_000);
+        assert_eq!(floor_next, Some((5_500, 3 * production)));
+
+        // Pre-H4 era uses the 6-rung table: floor 40 %, top at 30 windows held.
+        let (v1_bps, v1_next, v1_full) = ratio_bracket_explain(0, production, false);
+        assert_eq!(v1_bps, 4_000);
+        assert_eq!(v1_next, Some((5_200, production)));
+        assert_eq!(v1_full, 30 * production);
+    }
+
+    #[test]
+    fn bracket_explain_saturates_instead_of_wrapping() {
+        // A heavy producer's top-rung target (90x production) overflows u64; the display figure
+        // must saturate rather than wrap around to a small number that reads as "almost there".
+        let production = u64::MAX / 2;
+        let (_, next, full) = ratio_bracket_explain(0, production, true);
+        assert_eq!(full, u64::MAX);
+        assert_eq!(next, Some((5_500, u64::MAX)));
     }
 }

--- a/consensus/src/consensus/mod.rs
+++ b/consensus/src/consensus/mod.rs
@@ -57,7 +57,7 @@ use keryx_consensus_core::{
     blockhash::BlockHashExtensions,
     blockstatus::BlockStatus,
     coinbase::MinerData,
-    collateral::ServiceStrikesSnapshot,
+    collateral::{HolderRewardSnapshot, ServiceStrikesSnapshot},
     daa_score_timestamp::DaaScoreTimestamp,
     errors::{
         coinbase::CoinbaseResult,
@@ -360,6 +360,7 @@ impl Consensus {
         // (a datadir predating it, or a fresh prefix). Once populated it is kept current by lockstep
         // maintenance, so this is a no-op on subsequent boots. Pure function of the chain.
         this.virtual_processor.rebuild_windowed_production_prefix_index_on_start();
+        this.virtual_processor.rebuild_miner_payout_prefix_indexes_on_start();
 
         // Ratio-reward balance index (the ratio numerator): recompute from the current UTXO set so a
         // snapshot-restored datadir's stale balance index can't make the numerator differ across nodes.
@@ -718,6 +719,18 @@ impl ConsensusApi for Consensus {
 
     fn get_service_strikes(&self) -> ServiceStrikesSnapshot {
         self.virtual_processor.service_strikes_snapshot(self.lkg_virtual_state.load().daa_score)
+    }
+
+    fn get_holder_reward(&self, script_public_key: &keryx_consensus_core::tx::ScriptPublicKey) -> HolderRewardSnapshot {
+        // One load of the last-known-good virtual state, so the daa score and the sink the
+        // snapshot is taken against are the same view (two loads could straddle a virtual change
+        // and pair a balance with a window that never coexisted).
+        let virtual_state = self.lkg_virtual_state.load();
+        self.virtual_processor.holder_reward_snapshot(
+            script_public_key,
+            virtual_state.daa_score,
+            virtual_state.ghostdag_data.selected_parent,
+        )
     }
 
     fn get_service_state_rows(&self, pruning_point: Hash, handoff_daa: u64) -> ConsensusResult<Vec<Vec<u8>>> {

--- a/consensus/src/consensus/storage.rs
+++ b/consensus/src/consensus/storage.rs
@@ -84,6 +84,18 @@ pub struct ConsensusStorage {
     /// pure function of the chain (no path-dependent running sum), so all nodes compute identical
     /// windowed values. Maintained in lockstep with the selected chain; read by `ratio_bps_by_block`.
     pub windowed_production_prefix_store: Arc<DbWindowedProductionPrefixStore>,
+    /// Same prefix-sum structure over its own keyspace: the miner cut coinbases actually PAID this
+    /// SPK (post tier/ratio scaling). `production − paid` over a window is the burned shortfall.
+    /// Display only — never read by consensus, never hashed into the service commitment.
+    pub miner_paid_prefix_store: Arc<DbWindowedProductionPrefixStore>,
+    /// Likewise for the escrow cut that ACCRUED to the producer: zero for a standard miner, whose
+    /// escrow output is burned at emission. Display only.
+    pub miner_escrow_prefix_store: Arc<DbWindowedProductionPrefixStore>,
+    /// Likewise for inference-reward mints routed to this SPK. Display only.
+    pub miner_inference_prefix_store: Arc<DbWindowedProductionPrefixStore>,
+    /// Base miner cut per payout SPK split by proven model tier, one index per bucket. Display
+    /// only, same shape and start marker as the payout indexes.
+    pub miner_tier_prefix_stores: [Arc<DbWindowedProductionPrefixStore>; keryx_consensus_core::coinbase::TIER_BUCKETS],
 
     // OPoI slash stores (Phase 3 A4)
     pub ai_response_store: Arc<DbAiResponseStore>,
@@ -278,6 +290,31 @@ impl ConsensusStorage {
         let age_buckets_store = Arc::new(DbAgeBucketsStore::new(db.clone(), address_index_builder.build()));
         let maturation_queue_store = Arc::new(DbMaturationQueueStore::new(db.clone()));
         let windowed_production_prefix_store = Arc::new(DbWindowedProductionPrefixStore::new(db.clone()));
+        let miner_paid_prefix_store = Arc::new(DbWindowedProductionPrefixStore::with_prefixes(
+            db.clone(),
+            DatabaseStorePrefixes::MinerPaidPrefix,
+            DatabaseStorePrefixes::MinerPaidFloor,
+        ));
+        let miner_escrow_prefix_store = Arc::new(DbWindowedProductionPrefixStore::with_prefixes(
+            db.clone(),
+            DatabaseStorePrefixes::MinerEscrowPrefix,
+            DatabaseStorePrefixes::MinerEscrowFloor,
+        ));
+        let miner_inference_prefix_store = Arc::new(DbWindowedProductionPrefixStore::with_prefixes(
+            db.clone(),
+            DatabaseStorePrefixes::MinerInferencePrefix,
+            DatabaseStorePrefixes::MinerInferenceFloor,
+        ));
+        // One index per tier bucket, so the window yields the MIX a miner actually ran and not a
+        // single tier that would be false for anyone running more than one model.
+        let miner_tier_prefix_stores = [
+            (DatabaseStorePrefixes::MinerTier0Prefix, DatabaseStorePrefixes::MinerTier0Floor),
+            (DatabaseStorePrefixes::MinerTier1Prefix, DatabaseStorePrefixes::MinerTier1Floor),
+            (DatabaseStorePrefixes::MinerTier2Prefix, DatabaseStorePrefixes::MinerTier2Floor),
+            (DatabaseStorePrefixes::MinerTier3Prefix, DatabaseStorePrefixes::MinerTier3Floor),
+            (DatabaseStorePrefixes::MinerTier4Prefix, DatabaseStorePrefixes::MinerTier4Floor),
+        ]
+        .map(|(entries, floor)| Arc::new(DbWindowedProductionPrefixStore::with_prefixes(db.clone(), entries, floor)));
 
         // OPoI slash stores
         let ai_response_store = Arc::new(DbAiResponseStore::new(db.clone(), header_data_builder.build()));
@@ -336,6 +373,10 @@ impl ConsensusStorage {
             age_buckets_store,
             maturation_queue_store,
             windowed_production_prefix_store,
+            miner_paid_prefix_store,
+            miner_escrow_prefix_store,
+            miner_inference_prefix_store,
+            miner_tier_prefix_stores,
             ai_response_store,
             ai_slashed_store,
             service_burn_store,

--- a/consensus/src/model/stores/production_window.rs
+++ b/consensus/src/model/stores/production_window.rs
@@ -21,6 +21,12 @@ pub struct DbProductionWindowStore {
     db: Arc<DB>,
     daa_prefix: u8,
     bounds: Arc<RwLock<CachedDbItem<ImportedProductionWindow>>>,
+    // IBD fast path: `chain_index_daa` is called ~18× per validated block
+    // inside `chain_index_at_or_below_daa` binary search. Each call was a
+    // RocksDB `get` on the window table (190k keys for the 864k DAA window).
+    // Cache the whole table in RAM after `install` so the hot path is a
+    // single `RwLock` read + vec index, not a DB seek.
+    cached_window: Arc<RwLock<Option<(u64, Vec<u64>)>>>,
 }
 
 impl DbProductionWindowStore {
@@ -29,6 +35,7 @@ impl DbProductionWindowStore {
             db: Arc::clone(&db),
             daa_prefix: DatabaseStorePrefixes::ProductionWindowDaa as u8,
             bounds: Arc::new(RwLock::new(CachedDbItem::new(db, DatabaseStorePrefixes::ProductionImportedWindow.into()))),
+            cached_window: Arc::new(RwLock::new(None)),
         }
     }
 
@@ -45,12 +52,14 @@ impl DbProductionWindowStore {
         for (i, d) in daa.iter().enumerate() {
             batch.put(self.daa_key(bottom_index + i as u64), d.to_le_bytes());
         }
+        *self.cached_window.write() = Some((bottom_index, daa.to_vec()));
         self.bounds.write().write(BatchDbWriter::new(batch), &ImportedProductionWindow { bottom_index, sample_index })
     }
 
     /// Drops the table and its bounds.
     pub fn clear(&self, batch: &mut WriteBatch) {
         batch.delete_range(vec![self.daa_prefix], vec![self.daa_prefix + 1]);
+        *self.cached_window.write() = None;
         let _ = self.bounds.write().remove(BatchDbWriter::new(batch));
     }
 
@@ -61,6 +70,42 @@ impl DbProductionWindowStore {
 
     /// daa of chain `index` from the imported table.
     pub fn daa_at(&self, index: u64) -> Option<u64> {
+        // Fast path: cached vec
+        {
+            let guard = self.cached_window.read();
+            if let Some((bottom, vec)) = guard.as_ref() {
+                if index >= *bottom {
+                    if let Some(v) = vec.get((index - *bottom) as usize) {
+                        return Some(*v);
+                    }
+                }
+                // Cache installed but index outside it => not in window
+                if self.bounds.read().read().is_ok() {
+                    return None;
+                }
+            }
+        }
+        // Cold start: window is on disk but cache is empty (restart). Warm it once.
+        if self.cached_window.read().is_none() {
+            if let Ok(imported) = self.bounds.read().read() {
+                let mut vec = Vec::with_capacity((imported.sample_index - imported.bottom_index + 1) as usize);
+                let mut ok = true;
+                for idx in imported.bottom_index..=imported.sample_index {
+                    match self.db.get(self.daa_key(idx)).ok().flatten() {
+                        Some(v) => vec.push(u64::from_le_bytes(v[..8].try_into().expect("daa is 8 bytes"))),
+                        None => {
+                            ok = false;
+                            break;
+                        }
+                    }
+                }
+                if ok {
+                    *self.cached_window.write() = Some((imported.bottom_index, vec));
+                    // retry via cache
+                    return self.daa_at(index);
+                }
+            }
+        }
         self.db.get(self.daa_key(index)).ok().flatten().map(|v| u64::from_le_bytes(v[..8].try_into().expect("daa is 8 bytes")))
     }
 

--- a/consensus/src/model/stores/windowed_production_prefix.rs
+++ b/consensus/src/model/stores/windowed_production_prefix.rs
@@ -80,6 +80,14 @@ impl DbWindowedProductionPrefixStore {
         }
     }
 
+    /// Same index over a different keyspace. Every method here is already driven by the two
+    /// prefixes, so the paid- and escrow-per-SPK indexes are this exact structure — same
+    /// cumulative invariant, same reorg truncation, same pruning collapse — over their own
+    /// registry prefixes, instead of a second hand-written copy of it.
+    pub fn with_prefixes(db: Arc<DB>, entries_prefix: DatabaseStorePrefixes, floor_prefix: DatabaseStorePrefixes) -> Self {
+        Self { db, entries_prefix: entries_prefix.into(), floor_prefix: floor_prefix.into() }
+    }
+
     /// On-disk entry key: `entries_prefix || SPK_bucket || be(index)`.
     fn entry_key(&self, spk: &ScriptPublicKey, index: u64) -> Vec<u8> {
         let bucket = ScriptPublicKeyBucket::from(spk);

--- a/consensus/src/pipeline/pruning_processor/processor.rs
+++ b/consensus/src/pipeline/pruning_processor/processor.rs
@@ -209,11 +209,38 @@ impl PruningProcessor {
                 return;
             }
         };
-        if deleted == 0 {
+        // The display-only paid/escrow indexes share the production index's key layout and its
+        // floor, so they collapse on the same boundary and in the same batch. Their budgets are
+        // spent independently — they carry their own entry counts, and letting them lag the
+        // production floor would leave stale sub-floor entries growing without bound — so the
+        // early return below has to consider all three, or a batch holding only their writes
+        // would be dropped on the floor.
+        let mut payout_deleted = 0u64;
+        // Every display-only index, not a hand-listed subset: the inference index was missing from
+        // this list and so was never collapsed, which let its sub-floor entries grow without
+        // bound. Built from the stores themselves to keep a newly added bucket from being
+        // forgotten the same way.
+        let payout_stores = [
+            ("paid", &self.miner_paid_prefix_store),
+            ("escrow", &self.miner_escrow_prefix_store),
+            ("inference", &self.miner_inference_prefix_store),
+        ]
+        .into_iter()
+        .map(|(l, s)| (l.to_string(), s))
+        .chain(self.miner_tier_prefix_stores.iter().enumerate().map(|(t, s)| (format!("tier{t}"), s)));
+        for (label, store) in payout_stores {
+            match store.collapse_below(&mut batch, floor_index, COLLAPSE_BUDGET) {
+                Ok(n) => payout_deleted += n,
+                Err(e) => warn!("miner-{label} prefix collapse skipped: {e}"),
+            }
+        }
+        if deleted == 0 && payout_deleted == 0 {
             return; // caught up — nothing newly fell below the floor
         }
         self.db.write(batch).unwrap();
-        debug!("Ratio prefix collapse: folded {deleted} entries below chain index {floor_index} into per-SPK floors");
+        debug!(
+            "Ratio prefix collapse: folded {deleted} production and {payout_deleted} payout/tier entries below chain index {floor_index} into per-SPK floors"
+        );
     }
 
     /// Garbage-collect PoM possession proofs older than `POM_PROOF_GC_DEPTH_CHAIN_BLOCKS` chain blocks.

--- a/consensus/src/pipeline/virtual_processor/processor.rs
+++ b/consensus/src/pipeline/virtual_processor/processor.rs
@@ -55,6 +55,7 @@ use crate::{
     },
 };
 use keryx_consensus_core::blockhash::BlockHashExtensions;
+use keryx_consensus_core::coinbase::{CoinbasePayout, TIER_BUCKETS};
 use keryx_consensus_core::{
     BlockHashMap, BlockHashSet, ChainPath,
     acceptance_data::AcceptanceData,
@@ -83,6 +84,7 @@ use keryx_consensus_notify::{
 use keryx_consensusmanager::SessionLock;
 use keryx_core::{debug, info, time::unix_now, trace, warn};
 use keryx_database::prelude::{StoreError, StoreResultExt, StoreResultUnitExt};
+use keryx_database::registry::DatabaseStorePrefixes;
 use keryx_hashes::{Hash, ZERO_HASH};
 use keryx_muhash::MuHash;
 use keryx_notify::{events::EventType, notifier::Notify};
@@ -197,6 +199,12 @@ pub struct VirtualStateProcessor {
     /// denominator (windowed production at a block's selected-parent view) is the difference of two
     /// cumulatives; read by `ratio_bps_by_block`.
     pub(super) windowed_production_prefix_store: Arc<DbWindowedProductionPrefixStore>,
+    /// Display-only companions of the production index: what coinbases actually paid this SPK, and
+    /// the escrow slice that accrued to it. Advanced in the same batch (`advance_production_prefix`).
+    pub(super) miner_paid_prefix_store: Arc<DbWindowedProductionPrefixStore>,
+    pub(super) miner_escrow_prefix_store: Arc<DbWindowedProductionPrefixStore>,
+    pub(super) miner_inference_prefix_store: Arc<DbWindowedProductionPrefixStore>,
+    pub(super) miner_tier_prefix_stores: [Arc<DbWindowedProductionPrefixStore>; TIER_BUCKETS],
     /// Memo for `block_productions` (chain block → its era-aware production contribution list),
     /// i.e. a parsed-coinbase/mergeset cache. During catch-up, `resolve_virtual` validates the
     /// whole prev_sink→new_sink path in one batch while the committed selected chain still ends at
@@ -205,6 +213,11 @@ pub struct VirtualStateProcessor {
     /// quadratic RocksDB reads without this memo (measured: virtual thread pegged at ~4
     /// UTXO-validated blocks/s on an IBD catch-up). Bounded by periodic clear.
     pub(super) block_production_cache: parking_lot::RwLock<BlockHashMap<std::sync::Arc<Vec<(ScriptPublicKey, u64)>>>>,
+    /// Same memo for the paid/escrow side (`block_payouts`). Its inputs — a committed block's own
+    /// coinbase outputs and its blues' coinbase payloads — are immutable per hash, so entries stay
+    /// valid indefinitely; bounded by the same periodic clear. Without it the commit path would
+    /// re-read every blue coinbase a second time, on top of `block_productions`.
+    pub(super) block_payout_cache: parking_lot::RwLock<BlockHashMap<std::sync::Arc<Vec<(ScriptPublicKey, CoinbasePayout)>>>>,
     pub(super) virtual_stores: Arc<RwLock<VirtualStores>>,
     pub(super) pruning_meta_stores: Arc<RwLock<PruningMetaStores>>,
 
@@ -412,7 +425,12 @@ impl VirtualStateProcessor {
             maturation_queue_store: storage.maturation_queue_store.clone(),
             age_selfcheck_last: parking_lot::Mutex::new(None),
             windowed_production_prefix_store: storage.windowed_production_prefix_store.clone(),
+            miner_paid_prefix_store: storage.miner_paid_prefix_store.clone(),
+            miner_escrow_prefix_store: storage.miner_escrow_prefix_store.clone(),
+            miner_inference_prefix_store: storage.miner_inference_prefix_store.clone(),
+            miner_tier_prefix_stores: storage.miner_tier_prefix_stores.clone(),
             block_production_cache: parking_lot::RwLock::new(BlockHashMap::default()),
+            block_payout_cache: parking_lot::RwLock::new(BlockHashMap::default()),
             virtual_stores: storage.virtual_stores.clone(),
             pruning_meta_stores: storage.pruning_meta_stores.clone(),
             lkg_virtual_state: storage.lkg_virtual_state.clone(),
@@ -1158,6 +1176,136 @@ impl VirtualStateProcessor {
         }
         self.db.write(batch).unwrap();
         info!("windowed-production prefix build: done — {} entries written (canonical baseline).", written);
+    }
+
+    /// Lowest selected-chain index from which the paid/escrow/inference indexes are complete.
+    /// Absent (0) means "no payout data at all" — reads then report a zero-length span rather
+    /// than mistaking an empty index for a genuinely all-burned window.
+    pub(crate) fn miner_payout_index_start(&self) -> u64 {
+        self.db
+            .get([DatabaseStorePrefixes::MinerPayoutIndexStart as u8])
+            .ok()
+            .flatten()
+            .and_then(|v| v.get(..8).and_then(|b| b.try_into().ok()).map(u64::from_le_bytes))
+            .unwrap_or(0)
+    }
+
+    fn put_miner_payout_index_start(&self, batch: &mut WriteBatch, index: u64) {
+        batch.put([DatabaseStorePrefixes::MinerPayoutIndexStart as u8], index.to_le_bytes());
+    }
+
+    /// From-chain build of the paid/escrow/inference indexes, the display-only companions of the
+    /// production index. Same shape as `rebuild_windowed_production_prefix_index` and deliberately
+    /// the same walk, so a rebuilt index and an incrementally-maintained one agree.
+    ///
+    /// OPT-IN, and never on the boot path — see `rebuild_miner_payout_prefix_indexes_on_start`.
+    /// Unlike the production build, this walk needs the coinbase BODY of every chain block and of
+    /// each of its mergeset blues (a blue's payout SPK is what separates a miner cut from an
+    /// inference mint), which is ~5 random reads per chain block: seconds on NVMe, but hours on a
+    /// spinning disk, all of it before the node opens its ports. Forward maintenance costs nothing
+    /// and converges to the same values within one window, so history is the only thing this buys.
+    pub(crate) fn rebuild_miner_payout_prefix_indexes(&self) {
+        let sc = self.selected_chain_store.read();
+        let tip_idx = match sc.get_tip() {
+            Ok((idx, _)) => idx,
+            Err(_) => {
+                warn!("miner-payout prefix build: no selected-chain tip; skipping");
+                return;
+            }
+        };
+        let lo = tip_idx.saturating_sub(2 * self.ratio_reward_window).max(1);
+        info!("miner-payout prefix build: deriving paid/escrow/inference index over selected-chain [{}, {}]...", lo, tip_idx);
+        // Flushed in slices: one batch over the whole retained chain would hold millions of puts
+        // (a chain block contributes one entry per paid blue, times three indexes) before a single
+        // write. The result is identical either way — each entry is an absolute cumulative, not a
+        // delta — so the only thing slicing changes is peak memory.
+        const FLUSH_EVERY: u64 = 20_000;
+        let mut batch = WriteBatch::default();
+        self.put_miner_payout_index_start(&mut batch, lo);
+        self.miner_paid_prefix_store.clear(&mut batch);
+        self.miner_escrow_prefix_store.clear(&mut batch);
+        self.miner_inference_prefix_store.clear(&mut batch);
+        for store in self.miner_tier_prefix_stores.iter() {
+            store.clear(&mut batch);
+        }
+        let mut paid_cum: HashMap<ScriptPublicKey, u64> = HashMap::new();
+        let mut escrow_cum: HashMap<ScriptPublicKey, u64> = HashMap::new();
+        let mut inference_cum: HashMap<ScriptPublicKey, u64> = HashMap::new();
+        let mut tier_cum: HashMap<(ScriptPublicKey, usize), u64> = HashMap::new();
+        let mut written = 0u64;
+        for i in lo..=tip_idx {
+            if let Ok(h) = sc.get_by_index(i) {
+                for (spk, payout) in self.block_payouts(h) {
+                    let p = paid_cum.entry(spk.clone()).or_insert(0);
+                    *p += payout.paid;
+                    self.miner_paid_prefix_store.put_cumulative(&mut batch, &spk, i, *p);
+                    let e = escrow_cum.entry(spk.clone()).or_insert(0);
+                    *e += payout.escrow;
+                    self.miner_escrow_prefix_store.put_cumulative(&mut batch, &spk, i, *e);
+                    let f = inference_cum.entry(spk.clone()).or_insert(0);
+                    *f += payout.inference;
+                    self.miner_inference_prefix_store.put_cumulative(&mut batch, &spk, i, *f);
+                    for (t, store) in self.miner_tier_prefix_stores.iter().enumerate() {
+                        if payout.tier_base[t] == 0 {
+                            continue; // sparse: a zero contribution never changes a cumulative
+                        }
+                        let c = tier_cum.entry((spk.clone(), t)).or_insert(0);
+                        *c += payout.tier_base[t];
+                        store.put_cumulative(&mut batch, &spk, i, *c);
+                    }
+                    written += 1;
+                }
+            }
+            // Progress is reported per BLOCK SCANNED, not per entry written: the walk spends its
+            // time on blocks that yield nothing (pruned bodies, pre-fork blocks), so an
+            // entry-driven log is silent exactly when the operator most needs to see movement.
+            if (i - lo) % FLUSH_EVERY == FLUSH_EVERY - 1 {
+                self.db.write(std::mem::take(&mut batch)).unwrap();
+                info!(
+                    "miner-payout prefix build: chain index {}/{} ({:.1}%), {} entries...",
+                    i,
+                    tip_idx,
+                    (i - lo) as f64 * 100.0 / (tip_idx - lo).max(1) as f64,
+                    written
+                );
+            }
+        }
+        self.db.write(batch).unwrap();
+        info!("miner-payout prefix build: done — {} entries written.", written);
+    }
+
+    /// Startup hook for the paid/escrow/inference indexes; a no-op once they have a start index.
+    ///
+    /// Default is FORWARD-ONLY: the indexes are declared to start at the current chain tip and
+    /// then maintained in lockstep with the selected chain, at no cost. Reads clamp to that start
+    /// and report the span they actually cover, so a fresh index reports "nothing yet over a
+    /// zero-length span" instead of the far worse "everything you mined was burned" — and it
+    /// converges to the full window on its own, in one window's time.
+    ///
+    /// `KERYX_BUILD_PAYOUT_INDEX=1` opts into the from-chain backfill instead, which populates the
+    /// history immediately at the cost of a body read per chain block and per blue — worth it on
+    /// NVMe, and hours of blocked boot on a spinning disk.
+    pub(crate) fn rebuild_miner_payout_prefix_indexes_on_start(&self) {
+        if self.miner_payout_index_start() != 0 {
+            return;
+        }
+        if std::env::var("KERYX_BUILD_PAYOUT_INDEX").is_ok_and(|v| v == "1" || v == "true") {
+            self.rebuild_miner_payout_prefix_indexes();
+            return;
+        }
+        let Ok((tip_idx, _)) = self.selected_chain_store.read().get_tip() else {
+            warn!("miner-payout index: no selected-chain tip; deferring start to the next boot");
+            return;
+        };
+        let mut batch = WriteBatch::default();
+        self.put_miner_payout_index_start(&mut batch, tip_idx.max(1));
+        self.db.write(batch).unwrap();
+        info!(
+            "miner-payout index: starting forward-only at chain index {} — mined/burned/escrow figures \
+             widen to the full reward window over the next {} daa. Set KERYX_BUILD_PAYOUT_INDEX=1 to \
+             backfill the history from the chain instead (slow on a spinning disk).",
+            tip_idx, self.ratio_reward_window_daa
+        );
     }
 
     /// Startup hook: build the prefix-sum index from the chain only when it is empty (a datadir

--- a/consensus/src/pipeline/virtual_processor/service_bond.rs
+++ b/consensus/src/pipeline/virtual_processor/service_bond.rs
@@ -1182,7 +1182,13 @@ impl VirtualStateProcessor {
         if !self.pom_v3_activation.is_active(sink_daa) {
             return None;
         }
-        let span_cap = sink_daa.saturating_add((self.finality_depth / 8).max(1));
+        // IBD hot path: `finality/8 = 54k DAA` sliced a 2.7M DAA catch-up into ~50
+        // `resolve_virtual` batches (each with GHOSTDAG + UTXO + DB commit). During
+        // IBD the service-ledger queue is deep but FLUSH only needs `front+finality`,
+        // so a larger cap is safe and collapses the same work into ~12 batches
+        // (4x). `/2 = 216k DAA (~6h)` still flushes well before the queue would
+        // cross finality, and preserves the original invariant `cut < frontier`.
+        let span_cap = sink_daa.saturating_add((self.finality_depth / 2).max(1));
         let frontier = self.service_ledger.lock().queue.front().map(|(_, daa, _)| daa.saturating_add(self.finality_depth));
         Some(frontier.map_or(span_cap, |f| f.min(span_cap)))
     }

--- a/consensus/src/pipeline/virtual_processor/utxo_validation.rs
+++ b/consensus/src/pipeline/virtual_processor/utxo_validation.rs
@@ -32,9 +32,9 @@ use crate::model::stores::ai_slash::{AiResponseRecord, AiResponseStore, AiRespon
 use crate::model::stores::pom_tier::PomTierStoreReader;
 use crate::model::stores::pruning::PruningStoreReader;
 use crate::model::stores::selected_chain::{DbSelectedChainStore, SelectedChainStoreReader};
-use crate::model::stores::windowed_production_prefix::WindowedProductionPrefixStoreReader;
+use crate::model::stores::windowed_production_prefix::{DbWindowedProductionPrefixStore, WindowedProductionPrefixStoreReader};
 use keryx_consensus_core::coin_age::eff_balance_from_buckets;
-use keryx_consensus_core::config::params::{INFERENCE_REWARD_MINIMUMS_V2_H4, INFERENCE_REWARD_MINIMUMS_V2_H6, TIER_REWARD_BPS_DIVISOR, ratio_reward_bps, ratio_reward_bps_v2, tier_reward_bps};
+use keryx_consensus_core::config::params::{INFERENCE_REWARD_MINIMUMS_V2_H4, INFERENCE_REWARD_MINIMUMS_V2_H6, TIER_REWARD_BPS_DIVISOR, ratio_bracket_explain, ratio_reward_bps, ratio_reward_bps_v2, tier_reward_bps};
 use keryx_database::prelude::StoreResultExt;
 use keryx_consensus_core::{
     BlockHashMap, BlockHashSet, ChainPath, HashMapCustomHasher,
@@ -55,7 +55,7 @@ use keryx_consensus_core::{
 };
 use keryx_core::{debug, info, trace, warn};
 use keryx_hashes::Hash;
-use keryx_consensus_core::collateral::AI_REQUEST_MAX_TOKENS_CAP;
+use keryx_consensus_core::collateral::{AI_REQUEST_MAX_TOKENS_CAP, HolderRewardSnapshot};
 use keryx_inference::{AiRequestPayload, AiResponsePayload, INFERENCE_REWARD_TOKEN_STEP, parse_ai_caps};
 use keryx_muhash::MuHash;
 use keryx_txscript::script_class::ScriptClass;
@@ -318,6 +318,7 @@ impl VirtualStateProcessor {
         let enforce = self.ratio_verification_activation.is_active(header.daa_score) && !self.trust_coinbase();
         if enforce || std::env::var("KERYX_RATIO_DEBUG").is_ok() {
             self.verify_coinbase_transaction(
+                header.hash,
                 &txs[0],
                 header.daa_score,
                 &ctx.ghostdag_data,
@@ -619,6 +620,8 @@ impl VirtualStateProcessor {
 
     fn verify_coinbase_transaction(
         &self,
+        // The block being validated: the key `record_block_payouts` files its payout split under.
+        block_hash: Hash,
         coinbase: &Transaction,
         daa_score: u64,
         ghostdag_data: &GhostdagData,
@@ -637,7 +640,7 @@ impl VirtualStateProcessor {
         let ratio_bps_by_block = self.ratio_bps_by_block(ghostdag_data, mergeset_non_daa, mergeset_rewards, daa_score, view_diffs);
         let suspended_blues = self.suspended_blues(ghostdag_data, mergeset_non_daa, daa_score);
         let reward_mints = self.service_reward_mints_for(ghostdag_data.selected_parent);
-        let expected_coinbase = self
+        let expected_template = self
             .coinbase_manager
             .expected_coinbase_transaction(
                 daa_score,
@@ -650,8 +653,24 @@ impl VirtualStateProcessor {
                 &suspended_blues,
                 &reward_mints,
             )
-            .unwrap()
-            .tx;
+            .unwrap();
+        let expected_coinbase = expected_template.tx;
+        if hashing::tx::hash(coinbase) == hashing::tx::hash(&expected_coinbase) {
+            // Exact income split, straight from the builder. This is the only moment it is
+            // knowable: the tier/ratio maps and the mint list above do not survive validation,
+            // and neither is recoverable from the finished transaction.
+            let mut payouts = expected_template.payouts;
+            // The one part the builder cannot fill (see `tier_base_by_spk`). Merged here so the
+            // recorded split and the re-derived one agree — otherwise the tier buckets would be
+            // populated only for the blocks that happened to take the fallback path.
+            let tier_base = self.tier_base_by_spk(ghostdag_data, mergeset_non_daa, mergeset_rewards);
+            for (spk, payout) in payouts.iter_mut() {
+                if let Some(buckets) = tier_base.get(spk) {
+                    payout.tier_base = *buckets;
+                }
+            }
+            self.record_block_payouts(block_hash, payouts);
+        }
         if hashing::tx::hash(coinbase) != hashing::tx::hash(&expected_coinbase) {
             // Diagnostic: pinpoint why the coinbase differs (tier vs ratio vs amounts). Logged at WARN
             // only when it causes a real rejection (`enforce`); in observe-only it would fire for every
@@ -777,6 +796,125 @@ impl VirtualStateProcessor {
             map.insert(*blue, bps);
         }
         map
+    }
+
+    /// The `(top, bottom)` chain-index span the display-only payout indexes can honestly answer
+    /// for `ctx`: the reward window's own span, raised to the index's start.
+    ///
+    /// The indexes are maintained forward from the boot that created them, so below their start
+    /// `cumulative_at` reads 0 — which would make a real payout look like a full burn. Raising the
+    /// bottom instead reports less over a shorter span, and the span is reported alongside the
+    /// figures so a caller never mislabels a partial window as a full one. A start of 0 means the
+    /// index was never initialised at all: the span collapses to zero length, so every figure
+    /// derived from it is 0 and the caller sees "no coverage" rather than a fabricated burn.
+    ///
+    /// Only the on-chain shape is truly meaningful: the snapshot is always taken against the sink,
+    /// which is a committed chain block, so `production_window_ctx` returns Case A. A side-chain
+    /// ctx would additionally need the per-SPK side aggregation the production path pre-builds,
+    /// which these indexes do not carry — so it reports the committed part alone rather than
+    /// silently mixing in a half-window.
+    fn payout_span(&self, ctx: &ProductionWindowCtx) -> (u64, u64) {
+        let (top, bottom) = match ctx {
+            ProductionWindowCtx::OnChain { m_idx, bottom } => (*m_idx, *bottom),
+            ProductionWindowCtx::SideChain { common, lo, .. } => (*common, *lo),
+        };
+        match self.miner_payout_index_start() {
+            0 => (top, top),
+            start => (top, bottom.max(start).min(top)),
+        }
+    }
+
+    /// Windowed value of one of the display-only payout indexes over a [`Self::payout_span`].
+    fn windowed_payout(&self, store: &DbWindowedProductionPrefixStore, spk: &ScriptPublicKey, span: (u64, u64)) -> u64 {
+        // No panic on this path: it is reachable from an RPC query, so a transient store error must
+        // degrade to "nothing recorded" rather than take the node down on a remote request.
+        let hi = store.cumulative_at(spk, span.0).unwrap_or(0);
+        let lo = store.cumulative_at(spk, span.1).unwrap_or(0);
+        hi.saturating_sub(lo)
+    }
+
+    /// Holder-reward state of one payout address at the committed virtual view — the query-side
+    /// mirror of `ratio_bps_by_block`, which computes the same bracket per rewarded blue.
+    ///
+    /// Reuses the consensus helpers verbatim rather than re-deriving them, so an operator's
+    /// reading can never disagree with the bracket their coinbase was actually scaled by:
+    /// `eff_balance_for_spk` for the numerator (coin-age era) and the prefix-sum production index
+    /// for the denominator. `view_diffs` is deliberately empty — this describes the node's
+    /// committed view, not a candidate block's POV — and `sink` is the virtual's selected parent,
+    /// a committed chain block, so `production_window_ctx` takes its cheap Case A path.
+    ///
+    /// Safe for an arbitrary address: both stores answer an absent key with zero.
+    pub(crate) fn holder_reward_snapshot(
+        &self,
+        spk: &ScriptPublicKey,
+        virtual_daa_score: u64,
+        sink: Hash,
+    ) -> HolderRewardSnapshot {
+        let coin_age_active = self.coin_age_activation.is_active(virtual_daa_score);
+        let eff_balance = if coin_age_active {
+            self.eff_balance_for_spk(spk, virtual_daa_score, &[])
+        } else {
+            self.address_balance_store.get(spk).unwrap_or(0)
+        };
+        let ctx = self.production_window_ctx(sink, self.ratio_reward_window);
+        let production_raw = self.windowed_production_with_ctx(spk, &ctx);
+        // Same floor the coinbase path applies: without it a zero-production address divides by
+        // zero and lands in the top bracket for free.
+        let production = production_raw.max(self.coinbase_manager.base_miner_cut(virtual_daa_score).max(1));
+        let (bracket_bps, next_bracket, full_bracket_balance) =
+            ratio_bracket_explain(eff_balance, production, coin_age_active);
+        // Income is reported over the span the payout indexes actually cover, which is the reward
+        // window once they have been maintained for one, and shorter on a node that has just built
+        // them forward from its tip.
+        let span = self.payout_span(&ctx);
+        let paid = self.windowed_payout(&self.miner_paid_prefix_store, spk, span);
+        let escrow = self.windowed_payout(&self.miner_escrow_prefix_store, spk, span);
+        let inference = self.windowed_payout(&self.miner_inference_prefix_store, spk, span);
+        // The burn is the entitlement the brackets destroyed, so it MUST be measured over exactly
+        // the span `paid` covers — against the full-window `production_raw` it would count as
+        // burned every block whose payment the index does not yet know about. Against the RAW
+        // entitlement too, never the floored denominator: the floor exists only so the bracket
+        // does not divide by zero, and subtracting `paid` from it would invent a burn for an
+        // address that never mined.
+        let production_in_span = self.windowed_payout(&self.windowed_production_prefix_store, spk, span);
+        // The mix: base cut per proven tier over the same span. Reported as buckets rather than a
+        // weighted average because a miner runs rigs on different models, so the window is a
+        // blend — the average is recoverable from these, the blend is not recoverable from it.
+        let mut tier_base = [0u64; TIER_BUCKETS];
+        for (t, store) in self.miner_tier_prefix_stores.iter().enumerate() {
+            tier_base[t] = self.windowed_payout(store, spk, span);
+        }
+        let burned = production_in_span.saturating_sub(paid);
+        // Daa actually spanned, for the caller to label the income figures with. Zero on any
+        // lookup failure — conservative: it reads as "no coverage", not as a full window.
+        let income_window_daa = {
+            let sc = self.selected_chain_store.read();
+            let daa_at = |idx: u64| {
+                sc.get_by_index(idx).ok().and_then(|h| self.headers_store.get_daa_score(h).ok()).unwrap_or(0)
+            };
+            daa_at(span.0).saturating_sub(daa_at(span.1))
+        };
+        HolderRewardSnapshot {
+            virtual_daa_score,
+            eff_balance,
+            production_raw,
+            production,
+            bracket_bps,
+            next_bracket,
+            full_bracket_balance,
+            paid,
+            burned,
+            escrow,
+            inference,
+            income_window_daa,
+            tier_base,
+            window_daa: if self.pom_level_activation.is_active(virtual_daa_score) {
+                self.ratio_reward_window_daa
+            } else {
+                self.ratio_reward_window
+            },
+            active: self.ratio_reward_activation.is_active(virtual_daa_score),
+        }
     }
 
     /// Ratio-reward map consumed by `expected_coinbase_transaction`: for each rewarded blue, the
@@ -956,6 +1094,140 @@ impl VirtualStateProcessor {
         Some((spk, cut))
     }
 
+    /// Payout split of committed selected-chain block `hash`, per payout SPK.
+    ///
+    /// The exact split is produced by the coinbase BUILDER and carried here by
+    /// [`Self::record_block_payouts`] when the block is validated — the only moment it is knowable,
+    /// since a miner cut is the base cut scaled by that block's tier and ratio brackets and an
+    /// inference mint is indistinguishable from a miner cut by script alone.
+    ///
+    /// This function is the FALLBACK for the gaps in that carry: blocks validated inside a
+    /// coinbase trust window (archival / fast-sync catch-up, where verification is skipped), and
+    /// the historical blocks a first-boot backfill walks. It reconstructs the split from the
+    /// committed coinbase outputs, which is exact except for one case it cannot see: a mint routed
+    /// to an SPK that also produced one of this block's blues lands in `paid` rather than
+    /// `inference`. Income is right either way — only the split between the two lines, and hence
+    /// the burn, is off, and only for a miner who won an inference on a block they also mined.
+    ///
+    /// Returns nothing before `pom_level_activation`: in that era `block_productions` credited only
+    /// the chain block's own producer while the coinbase already paid the blues, so the two sides
+    /// attribute over different sets and their difference would not be a burn. Every window this is
+    /// ever read over (a trailing 24 h from the tip) sits far past that fork.
+    /// The proven model tier of one blue, resolved exactly as `tier_bps_by_block` resolves it:
+    /// from the header at/after `pom_v3_activation` (H6 commits it there, bound to the proof by
+    /// body validation, so a body synced without its proof still answers), from the per-block
+    /// store before that. `None` for a blue with no proven tier at all — pre-PoM history, which
+    /// must be left out of the buckets rather than folded into tier 0.
+    fn blue_tier(&self, blue: Hash, header: &keryx_consensus_core::header::Header) -> Option<u8> {
+        if self.pom_v3_activation.is_active(header.daa_score) {
+            Some(header.pom_tier)
+        } else {
+            self.pom_tier_store.get(blue).optional().ok().flatten()
+        }
+    }
+
+    pub(super) fn block_payouts(&self, hash: Hash) -> Vec<(ScriptPublicKey, CoinbasePayout)> {
+        // ALL-OR-NOTHING, and never a panic. A pruned node keeps the selected chain far below the
+        // pruning point but drops the block BODIES there, and the backfill walks the whole
+        // retained chain — so a missing body is the normal case, not corruption. It must also not
+        // yield a PARTIAL answer: the outputs would still classify, but without each blue's payout
+        // SPK a miner cut is indistinguishable from an inference mint, so the split would be
+        // silently wrong. Skipping the block outright is exactly what the production index does
+        // over the same range, and is sound because a window never reaches below the floor.
+        let Ok(daa) = self.headers_store.get_daa_score(hash) else { return Vec::new() };
+        if !self.pom_level_activation.is_active(daa) {
+            return Vec::new();
+        }
+        let (Ok(ghostdag_data), Ok(non_daa), Ok(txs)) = (
+            self.ghostdag_store.get_data(hash),
+            self.daa_excluded_store.get_mergeset_non_daa(hash),
+            self.block_transactions_store.get(hash),
+        ) else {
+            return Vec::new();
+        };
+
+        // Per-blue facts: the payout SPK, its base cut, and whether its escrow slice accrued.
+        let mut acc: std::collections::HashMap<ScriptPublicKey, CoinbasePayout> = std::collections::HashMap::new();
+        for blue in ghostdag_data.mergeset_blues.iter().filter(|b| !non_daa.contains(b)) {
+            // The full header rather than just the daa score: it carries the proven tier too, so
+            // the bucket split costs no extra read here.
+            let (Ok(blue_header), Ok(blue_txs)) =
+                (self.headers_store.get_header(*blue), self.block_transactions_store.get(*blue))
+            else {
+                return Vec::new();
+            };
+            let blue_daa = blue_header.daa_score;
+            let Ok(coinbase) = self.coinbase_manager.deserialize_coinbase_payload(&blue_txs[0].payload) else {
+                return Vec::new();
+            };
+            let announced =
+                self.coinbase_manager.parse_escrow_from_extra_data(coinbase.miner_data.extra_data, blue_daa).is_some();
+            let tier = self.blue_tier(*blue, &blue_header);
+            let entry = acc.entry(coinbase.miner_data.script_public_key).or_default();
+            let cut = self.coinbase_manager.base_miner_cut(blue_daa);
+            entry.base += cut;
+            if let Some(t) = tier.filter(|t| (*t as usize) < TIER_BUCKETS) {
+                entry.tier_base[t as usize] += cut;
+            }
+            if announced {
+                entry.escrow += self.coinbase_manager.escrow_cut(blue_daa);
+            }
+        }
+
+        // Outputs that are neither a burn, the R&D allocation nor an escrow lock are income: a
+        // miner cut when the SPK produced one of this block's blues, an inference mint otherwise.
+        for out in txs[0].outputs.iter() {
+            let spk = &out.script_public_key;
+            if spk == self.coinbase_manager.burn_spk()
+                || spk == self.coinbase_manager.rd_allocation_spk()
+                || ScriptClass::is_csv_pay_to_pubkey(spk.script())
+            {
+                continue;
+            }
+            match acc.get_mut(spk) {
+                Some(entry) => entry.paid += out.value,
+                None => acc.entry(spk.clone()).or_default().inference += out.value,
+            }
+        }
+        acc.into_iter().collect()
+    }
+
+    /// Base miner cut per payout SPK, split by the proven tier of the blue that earned it, for the
+    /// blues this block pays. Header reads only — no bodies — because `mergeset_rewards` already
+    /// carries each blue's payout SPK, derived for the coinbase itself.
+    ///
+    /// Exists because the builder cannot supply this: it is handed the tier as a bracket in bps,
+    /// and bps maps back to a tier ambiguously — the standing gate pays a demoted top tier at the
+    /// entry tier's rate, so a reverse lookup would file a Kimi-48B block under Qwen3.5-9B and
+    /// report a mix the miner never ran.
+    fn tier_base_by_spk(
+        &self,
+        ghostdag_data: &GhostdagData,
+        mergeset_non_daa: &BlockHashSet,
+        mergeset_rewards: &BlockHashMap<BlockRewardData>,
+    ) -> std::collections::HashMap<ScriptPublicKey, [u64; TIER_BUCKETS]> {
+        let mut out: std::collections::HashMap<ScriptPublicKey, [u64; TIER_BUCKETS]> = std::collections::HashMap::new();
+        for blue in ghostdag_data.mergeset_blues.iter().filter(|h| !mergeset_non_daa.contains(h)) {
+            let Some(reward) = mergeset_rewards.get(blue) else { continue };
+            let Ok(header) = self.headers_store.get_header(*blue) else { continue };
+            let Some(tier) = self.blue_tier(*blue, &header).filter(|t| (*t as usize) < TIER_BUCKETS) else { continue };
+            let cut = self.coinbase_manager.base_miner_cut(header.daa_score);
+            out.entry(reward.script_public_key.clone()).or_default()[tier as usize] += cut;
+        }
+        out
+    }
+
+    /// Stores the coinbase builder's exact payout split for `hash`, so the commit path attributes
+    /// income without having to re-derive it from the finished transaction. Called from coinbase
+    /// verification, the one place the tier/ratio maps and the mint list are all in hand.
+    pub(super) fn record_block_payouts(&self, hash: Hash, payouts: Vec<(ScriptPublicKey, CoinbasePayout)>) {
+        let mut cache = self.block_payout_cache.write();
+        if cache.len() >= 200_000 {
+            cache.clear();
+        }
+        cache.insert(hash, std::sync::Arc::new(payouts));
+    }
+
     /// Production contributions attributed at chain block `hash`'s index in the prefix-sum index,
     /// era-aware. The era is gated by the CHAIN BLOCK's own daa_score — a pure per-block property,
     /// so the index remains a pure, IBD-re-derivable function of the chain across the fork:
@@ -994,6 +1266,20 @@ impl VirtualStateProcessor {
         }
         let v = std::sync::Arc::new(self.block_productions(hash));
         let mut cache = self.block_production_cache.write();
+        if cache.len() >= 200_000 {
+            cache.clear();
+        }
+        cache.insert(hash, v.clone());
+        v
+    }
+
+    /// Memoized [`Self::block_payouts`]. Immutable per hash for the same reason productions are.
+    pub(super) fn block_payouts_cached(&self, hash: Hash) -> std::sync::Arc<Vec<(ScriptPublicKey, CoinbasePayout)>> {
+        if let Some(v) = self.block_payout_cache.read().get(&hash) {
+            return v.clone();
+        }
+        let v = std::sync::Arc::new(self.block_payouts(hash));
+        let mut cache = self.block_payout_cache.write();
         if cache.len() >= 200_000 {
             cache.clear();
         }
@@ -1048,6 +1334,46 @@ impl VirtualStateProcessor {
             })
             .collect();
         self.windowed_production_prefix_store.extend(batch, common, &removals, &additions).unwrap();
+
+        // The paid/escrow indexes ride the SAME index assignment and the same batch, so all three
+        // are always in lockstep with the selected chain: a window read can never pair a
+        // production cumulative with a paid cumulative from a different chain state.
+        let payout_removals: Vec<(ScriptPublicKey, u64)> = chain_path
+            .removed
+            .iter()
+            .enumerate()
+            .flat_map(|(j, h)| {
+                self.block_payouts_cached(*h).iter().map(|(spk, _)| (spk.clone(), from_tip - j as u64)).collect::<Vec<_>>()
+            })
+            .collect();
+        let mut paid_additions: Vec<(ScriptPublicKey, u64, u64)> = Vec::new();
+        let mut escrow_additions: Vec<(ScriptPublicKey, u64, u64)> = Vec::new();
+        let mut inference_additions: Vec<(ScriptPublicKey, u64, u64)> = Vec::new();
+        let mut tier_additions: [Vec<(ScriptPublicKey, u64, u64)>; TIER_BUCKETS] = Default::default();
+        for (k, h) in chain_path.added.iter().enumerate() {
+            let index = common + 1 + k as u64;
+            for (spk, p) in self.block_payouts_cached(*h).iter() {
+                paid_additions.push((spk.clone(), index, p.paid));
+                escrow_additions.push((spk.clone(), index, p.escrow));
+                inference_additions.push((spk.clone(), index, p.inference));
+                for (t, additions) in tier_additions.iter_mut().enumerate() {
+                    // Sparse on purpose: an SPK that ran no block at this tier gets no entry, and
+                    // `cumulative_at` reverse-seeks past the gap to its last real one.
+                    if p.tier_base[t] > 0 {
+                        additions.push((spk.clone(), index, p.tier_base[t]));
+                    }
+                }
+            }
+        }
+        self.miner_paid_prefix_store.extend(batch, common, &payout_removals, &paid_additions).unwrap();
+        self.miner_escrow_prefix_store.extend(batch, common, &payout_removals, &escrow_additions).unwrap();
+        self.miner_inference_prefix_store.extend(batch, common, &payout_removals, &inference_additions).unwrap();
+        // The tier buckets ride the same index assignment and batch as the three above. Removals
+        // are the shared payout list: deleting a key that was never written is a no-op, so passing
+        // every removed (spk, index) to each bucket is correct and needs no per-tier bookkeeping.
+        for (store, additions) in self.miner_tier_prefix_stores.iter().zip(tier_additions.iter()) {
+            store.extend(batch, common, &payout_removals, additions).unwrap();
+        }
     }
 
     /// Windowed production for `spk` as seen by the block whose selected parent is `m_sp`, read from

--- a/consensus/src/processes/coinbase.rs
+++ b/consensus/src/processes/coinbase.rs
@@ -305,6 +305,9 @@ impl CoinbaseManager {
         // allocation, + 1 for the accumulated tier-reward burn
         let mut outputs = Vec::with_capacity(ghostdag_data.mergeset_blues.len() * 2 + 3);
         let mut rd_total = 0u64;
+        // Per-SPK split of what this coinbase pays, accumulated as the outputs are built so it is
+        // the SAME arithmetic and can never drift from the transaction it describes.
+        let mut payouts: std::collections::HashMap<ScriptPublicKey, CoinbasePayout> = std::collections::HashMap::new();
         // Sum of the per-blue miner-cut reductions (tier-reward and ratio-reward combined), burned
         // in a single output below. Keeps the total block reward equal to the schedule subsidy —
         // only the miner's share is penalised.
@@ -343,6 +346,16 @@ impl CoinbaseManager {
                     miner_subsidy * tier_bps / TIER_REWARD_BPS_DIVISOR * ratio_bps / RATIO_REWARD_BPS_DIVISOR
                 };
                 reward_burn_total += miner_subsidy - miner_paid;
+                {
+                    let entry = payouts.entry(reward_data.script_public_key.clone()).or_default();
+                    entry.base += miner_subsidy;
+                    entry.paid += miner_paid;
+                    // Only an announced escrow key accrues: without one the slice below is paid to
+                    // the burn SPK and belongs to nobody.
+                    if reward_data.escrow_script_public_key.is_some() {
+                        entry.escrow += escrow_cut;
+                    }
+                }
                 // Zero-value outputs are rejected in isolation, so a fully-burned miner cut emits
                 // none: the amount is already in `reward_burn_total`.
                 if miner_paid > 0 {
@@ -412,6 +425,7 @@ impl CoinbaseManager {
         // Inference-reward mints, in the caller's canonical order, after every other output.
         for (spk, amount) in reward_mints {
             outputs.push(TransactionOutput::new(*amount, spk.clone()));
+            payouts.entry(spk.clone()).or_default().inference += *amount;
         }
 
         // Build the current block's payload
@@ -422,6 +436,7 @@ impl CoinbaseManager {
             tx: Transaction::new(constants::TX_VERSION, vec![], outputs, 0, subnets::SUBNETWORK_ID_COINBASE, 0, payload),
             has_red_reward: red_subsidy > 0 || red_fees > 0,
             red_reward_output_index,
+            payouts: payouts.into_iter().collect(),
         })
     }
 
@@ -569,6 +584,24 @@ impl CoinbaseManager {
     /// index (see `ratio_bps_by_block`) — deliberately the base cut, not the paid (post-scaling)
     /// amount, so production stays independent of the reward policy it feeds. Mirrors the per-blue
     /// split in `expected_coinbase_transaction` (`miner_subsidy = subsidy − rd_cut − escrow_cut`).
+    /// The escrow slice of one block's subsidy at `daa_score`: CSV-locked to the producer's
+    /// announced escrow key, or paid to the burn SPK when the producer announced none. Exposed so
+    /// callers reporting mining income do not re-hardcode `ESCROW_RATE_BPS`.
+    pub fn escrow_cut(&self, daa_score: u64) -> u64 {
+        self.calc_block_subsidy(daa_score) * ESCROW_RATE_BPS / ESCROW_RATE_BPS_DIVISOR
+    }
+
+    /// The SPK every burn output in a coinbase is paid to (fees, the tier/ratio shortfall, red
+    /// subsidy, and a standard miner's escrow slice).
+    pub fn burn_spk(&self) -> &ScriptPublicKey {
+        &self.burn_script_public_key
+    }
+
+    /// The SPK the accumulated R&D allocation is paid to.
+    pub fn rd_allocation_spk(&self) -> &ScriptPublicKey {
+        &self.rd_allocation_script_public_key
+    }
+
     pub fn base_miner_cut(&self, daa_score: u64) -> u64 {
         let subsidy = self.calc_block_subsidy(daa_score);
         let rd_cut = subsidy * RD_ALLOCATION_BPS / RD_ALLOCATION_BPS_DIVISOR;

--- a/database/src/registry.rs
+++ b/database/src/registry.rs
@@ -156,6 +156,46 @@ pub enum DatabaseStorePrefixes {
     ProductionWindowDaa = 203,
     /// Bounds (bottom, sample chain indices) of that imported window.
     ProductionImportedWindow = 204,
+    /// Per-SPK prefix sum of the miner cut actually PAID by coinbases (post tier/ratio scaling),
+    /// and its pruning floor. Display only: read by `getHolderReward` to separate income from the
+    /// burned shortfall. Deliberately a separate keyspace from `WindowedProductionPrefix`, which
+    /// is hashed into the service commitment — nothing here enters consensus.
+    MinerPaidPrefix = 205,
+    MinerPaidFloor = 206,
+    /// Per-SPK prefix sum of the escrow cut that ACCRUED to the producer (zero for a standard
+    /// miner, whose escrow is burned at emission), and its pruning floor. Display only.
+    MinerEscrowPrefix = 207,
+    MinerEscrowFloor = 208,
+    /// Per-SPK prefix sum of inference-reward mints routed to this SPK by coinbases, and its
+    /// pruning floor. Mining income of a different kind, tracked apart from the miner cut because
+    /// a mint is indistinguishable from one by script alone. Display only.
+    MinerInferencePrefix = 209,
+    MinerInferenceFloor = 210,
+    /// Single u64: the lowest selected-chain index from which the three payout indexes above are
+    /// complete. They are maintained FORWARD from the boot that created them, because a from-chain
+    /// backfill has to read the coinbase BODY of every chain block and of each of its mergeset
+    /// blues — hours of random reads on a spinning disk. A query whose window bottom predates this
+    /// index would silently under-report income and over-report the burn, so reads clamp to it and
+    /// report the span actually covered, letting the caller label a partial window honestly.
+    MinerPayoutIndexStart = 211,
+    /// Per-SPK prefix sums of the BASE miner cut split by the proven model tier of the block that
+    /// earned it — one (entries, floor) pair per tier bucket — plus their pruning floors. Display
+    /// only, same keyspace shape and same forward-only start marker as the payout indexes above.
+    ///
+    /// Five buckets rather than one weighted average because a miner is not on one tier: rigs run
+    /// different models, so the window holds a MIX, and any single tier reported for it would be
+    /// false. From the buckets the weighted tier is a division; from a weighted tier the mix is
+    /// unrecoverable.
+    MinerTier0Prefix = 212,
+    MinerTier0Floor = 213,
+    MinerTier1Prefix = 214,
+    MinerTier1Floor = 215,
+    MinerTier2Prefix = 216,
+    MinerTier2Floor = 217,
+    MinerTier3Prefix = 218,
+    MinerTier3Floor = 219,
+    MinerTier4Prefix = 220,
+    MinerTier4Floor = 221,
 
     // ---- Separator ----
     /// Reserved as a separator

--- a/mining/src/testutils/coinbase_mock.rs
+++ b/mining/src/testutils/coinbase_mock.rs
@@ -25,6 +25,9 @@ impl CoinbaseManagerMock {
             tx: Transaction::new(TX_VERSION, vec![], vec![output], 0, SUBNETWORK_ID_COINBASE, 0, payload),
             has_red_reward: false,
             red_reward_output_index: None,
+            // The mock pays one flat subsidy to one miner and no block here is ever validated
+            // against a payout index, so there is nothing to attribute.
+            payouts: vec![],
         }
     }
 

--- a/rpc/core/src/api/ops.rs
+++ b/rpc/core/src/api/ops.rs
@@ -146,6 +146,8 @@ pub enum RpcApiOps {
     GetUtxoEntriesByOutpoints = 153,
     /// Service-bond strike, suspension and pending-burn state
     GetServiceStrikes = 154,
+    /// Holder-reward (ratio-reward) bracket state of one payout address
+    GetHolderReward = 155,
 }
 
 impl RpcApiOps {

--- a/rpc/core/src/api/rpc.rs
+++ b/rpc/core/src/api/rpc.rs
@@ -461,6 +461,17 @@ pub trait RpcApi: Sync + Send + AnySync {
         request: GetServiceStrikesRequest,
     ) -> RpcResult<GetServiceStrikesResponse>;
 
+    /// Holder-reward (ratio-reward) bracket state of one payout address: the inputs the node
+    /// scales that address's miner cut by, and what the next bracket up would cost.
+    async fn get_holder_reward(&self, address: RpcAddress) -> RpcResult<GetHolderRewardResponse> {
+        self.get_holder_reward_call(None, GetHolderRewardRequest { address }).await
+    }
+    async fn get_holder_reward_call(
+        &self,
+        connection: Option<&DynRpcConnection>,
+        request: GetHolderRewardRequest,
+    ) -> RpcResult<GetHolderRewardResponse>;
+
     async fn get_daa_score_timestamp_estimate(&self, daa_scores: Vec<u64>) -> RpcResult<Vec<u64>> {
         Ok(self.get_daa_score_timestamp_estimate_call(None, GetDaaScoreTimestampEstimateRequest { daa_scores }).await?.timestamps)
     }

--- a/rpc/core/src/model/message.rs
+++ b/rpc/core/src/model/message.rs
@@ -1287,6 +1287,153 @@ impl Deserializer for GetHeadersResponse {
     }
 }
 
+/// Holder-reward bracket state of one payout address. `next_bracket_bps`/`next_bracket_balance`
+/// are both `None` exactly when the address already sits in the top bracket.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GetHolderRewardRequest {
+    pub address: RpcAddress,
+}
+
+impl GetHolderRewardRequest {
+    pub fn new(address: RpcAddress) -> Self {
+        Self { address }
+    }
+}
+
+impl Serializer for GetHolderRewardRequest {
+    fn serialize<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
+        store!(u16, &1, writer)?;
+        store!(RpcAddress, &self.address, writer)?;
+
+        Ok(())
+    }
+}
+
+impl Deserializer for GetHolderRewardRequest {
+    fn deserialize<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
+        let _version = load!(u16, reader)?;
+        let address = load!(RpcAddress, reader)?;
+
+        Ok(Self { address })
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GetHolderRewardResponse {
+    pub virtual_daa_score: u64,
+    /// Ratio numerator: the coin-age effective balance (the plain balance pre-H4). Reads below
+    /// the spendable balance while coins are still ripening.
+    pub eff_balance: u64,
+    /// Windowed production before the one-block floor; zero means "not a miner in this window".
+    pub production_raw: u64,
+    /// The denominator actually used (floored at one block's base miner cut).
+    pub production: u64,
+    pub bracket_bps: u64,
+    pub next_bracket_bps: Option<u64>,
+    /// Effective balance that reaches `next_bracket_bps`.
+    pub next_bracket_balance: Option<u64>,
+    pub full_bracket_balance: u64,
+    pub window_daa: u64,
+    /// False before `ratio_reward_activation`: the miner cut is unscaled and the bracket figures
+    /// are informational only.
+    pub active: bool,
+    /// Miner cut actually PAID over the window (post tier/ratio scaling) — mining income, as
+    /// opposed to `production_raw`, which is only the entitlement.
+    pub paid: u64,
+    /// `production_raw − paid`: the shortfall the brackets destroyed.
+    pub burned: u64,
+    /// Escrow slice that accrued over the window; 0 for a standard miner, whose escrow is burned
+    /// at emission. CSV-locked and still forfeitable to a service penalty until claimed.
+    pub escrow: u64,
+    /// Inference-reward mints routed to this address over the window — income won by serving an
+    /// inference, outside the base entitlement the brackets scale.
+    pub inference: u64,
+    /// Daa actually spanned by `paid`, `burned`, `escrow` and `inference` — NOT necessarily
+    /// `window_daa`. Those four come from display-only indexes maintained forward from the boot
+    /// that created them, so a node that has just built them covers only the daa since; it equals
+    /// `window_daa` once a full window has elapsed, and 0 means no coverage. Label the income
+    /// figures with this, never with `window_daa`.
+    pub income_window_daa: u64,
+    /// Base miner cut over `income_window_daa` split by the proven model tier that earned it —
+    /// the MIX, indexed by tier (5 buckets today). Reported as buckets, not a single tier: rigs
+    /// run different models, so a window is a blend and any one tier named for it would be false.
+    /// Take shares over the SUM of these, never over the entitlement — a pre-PoM block has no
+    /// resolvable tier and is left out.
+    pub tier_base: Vec<u64>,
+}
+
+impl Serializer for GetHolderRewardResponse {
+    fn serialize<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
+        // v2 appended `income_window_daa`; v3 appended `tier_base`.
+        store!(u16, &3, writer)?;
+        store!(u64, &self.virtual_daa_score, writer)?;
+        store!(u64, &self.eff_balance, writer)?;
+        store!(u64, &self.production_raw, writer)?;
+        store!(u64, &self.production, writer)?;
+        store!(u64, &self.bracket_bps, writer)?;
+        store!(Option<u64>, &self.next_bracket_bps, writer)?;
+        store!(Option<u64>, &self.next_bracket_balance, writer)?;
+        store!(u64, &self.full_bracket_balance, writer)?;
+        store!(u64, &self.window_daa, writer)?;
+        store!(bool, &self.active, writer)?;
+        store!(u64, &self.paid, writer)?;
+        store!(u64, &self.burned, writer)?;
+        store!(u64, &self.escrow, writer)?;
+        store!(u64, &self.inference, writer)?;
+        store!(u64, &self.income_window_daa, writer)?;
+        store!(Vec<u64>, &self.tier_base, writer)?;
+
+        Ok(())
+    }
+}
+
+impl Deserializer for GetHolderRewardResponse {
+    fn deserialize<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
+        let version = load!(u16, reader)?;
+        let virtual_daa_score = load!(u64, reader)?;
+        let eff_balance = load!(u64, reader)?;
+        let production_raw = load!(u64, reader)?;
+        let production = load!(u64, reader)?;
+        let bracket_bps = load!(u64, reader)?;
+        let next_bracket_bps = load!(Option<u64>, reader)?;
+        let next_bracket_balance = load!(Option<u64>, reader)?;
+        let full_bracket_balance = load!(u64, reader)?;
+        let window_daa = load!(u64, reader)?;
+        let active = load!(bool, reader)?;
+        let paid = load!(u64, reader)?;
+        let burned = load!(u64, reader)?;
+        let escrow = load!(u64, reader)?;
+        let inference = load!(u64, reader)?;
+        // A v1 node did not report the span; 0 reads as "no coverage", which is the safe default
+        // for a caller that must not mislabel these figures as a full window.
+        let income_window_daa = if version >= 2 { load!(u64, reader)? } else { 0 };
+        // v3 appended the tier mix; an older node reports none, and an empty mix reads as
+        // "unknown" rather than as "all production at tier 0".
+        let tier_base = if version >= 3 { load!(Vec<u64>, reader)? } else { Vec::new() };
+
+        Ok(Self {
+            virtual_daa_score,
+            eff_balance,
+            production_raw,
+            production,
+            bracket_bps,
+            next_bracket_bps,
+            next_bracket_balance,
+            full_bracket_balance,
+            window_daa,
+            active,
+            paid,
+            burned,
+            escrow,
+            inference,
+            income_window_daa,
+            tier_base,
+        })
+    }
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetBalanceByAddressRequest {

--- a/rpc/core/src/model/tests.rs
+++ b/rpc/core/src/model/tests.rs
@@ -985,6 +985,39 @@ mod mockery {
 
     test!(GetHeadersResponse);
 
+    impl Mock for GetHolderRewardRequest {
+        fn mock() -> Self {
+            GetHolderRewardRequest { address: mock() }
+        }
+    }
+
+    test!(GetHolderRewardRequest);
+
+    impl Mock for GetHolderRewardResponse {
+        fn mock() -> Self {
+            GetHolderRewardResponse {
+                virtual_daa_score: mock(),
+                eff_balance: mock(),
+                production_raw: mock(),
+                production: mock(),
+                bracket_bps: mock(),
+                next_bracket_bps: mock(),
+                next_bracket_balance: mock(),
+                full_bracket_balance: mock(),
+                window_daa: mock(),
+                active: mock(),
+                paid: mock(),
+                burned: mock(),
+                escrow: mock(),
+                inference: mock(),
+                income_window_daa: mock(),
+                tier_base: mock(),
+            }
+        }
+    }
+
+    test!(GetHolderRewardResponse);
+
     impl Mock for GetBalanceByAddressRequest {
         fn mock() -> Self {
             GetBalanceByAddressRequest { address: mock() }

--- a/rpc/core/src/wasm/message.rs
+++ b/rpc/core/src/wasm/message.rs
@@ -242,6 +242,60 @@ try_from! ( args: GetServiceStrikesResponse, IGetServiceStrikesResponse, {
 });
 
 declare! {
+    IGetHolderRewardRequest,
+    r#"
+    /**
+     * @category Node RPC
+     */
+    export interface IGetHolderRewardRequest {
+        address: Address | string;
+    }
+    "#,
+}
+
+try_from! ( args: IGetHolderRewardRequest, GetHolderRewardRequest, {
+    Ok(from_value(args.into())?)
+});
+
+declare! {
+    IGetHolderRewardResponse,
+    r#"
+    /**
+     * Holder-reward (ratio-reward) bracket state of one payout address.
+     *
+     * `effBalance` is the coin-age effective balance the bracket divides — NOT the spendable
+     * balance: coins younger than the maturity window count at a prorata of their age.
+     * `nextBracketBps` and `nextBracketBalance` are both absent once the address is in the top
+     * bracket.
+     *
+     * @category Node RPC
+     */
+    export interface IGetHolderRewardResponse {
+        virtualDaaScore: bigint;
+        effBalance: bigint;
+        productionRaw: bigint;
+        production: bigint;
+        bracketBps: bigint;
+        nextBracketBps?: bigint;
+        nextBracketBalance?: bigint;
+        fullBracketBalance: bigint;
+        windowDaa: bigint;
+        active: boolean;
+        paid: bigint;
+        burned: bigint;
+        escrow: bigint;
+        inference: bigint;
+        incomeWindowDaa: bigint;
+        tierBase: bigint[];
+    }
+    "#,
+}
+
+try_from! ( args: GetHolderRewardResponse, IGetHolderRewardResponse, {
+    Ok(to_value(&args)?.into())
+});
+
+declare! {
     IGetCoinSupplyRequest,
     r#"
     /**

--- a/rpc/grpc/client/src/lib.rs
+++ b/rpc/grpc/client/src/lib.rs
@@ -267,6 +267,7 @@ impl RpcApi for GrpcClient {
     route!(get_utxo_count_by_address_call, GetUtxoCountByAddress);
     route!(get_utxo_entries_by_outpoints_call, GetUtxoEntriesByOutpoints);
     route!(get_service_strikes_call, GetServiceStrikes);
+    route!(get_holder_reward_call, GetHolderReward);
     route!(get_balance_by_address_call, GetBalanceByAddress);
     route!(get_balances_by_addresses_call, GetBalancesByAddresses);
     route!(get_sink_blue_score_call, GetSinkBlueScore);

--- a/rpc/grpc/core/proto/messages.proto
+++ b/rpc/grpc/core/proto/messages.proto
@@ -70,6 +70,7 @@ message KaspadRequest {
     GetUtxoCountByAddressRequestMessage getUtxoCountByAddressRequest = 1116;
     GetUtxoEntriesByOutpointsRequestMessage getUtxoEntriesByOutpointsRequest = 1118;
     GetServiceStrikesRequestMessage getServiceStrikesRequest = 1120;
+    GetHolderRewardRequestMessage getHolderRewardRequest = 1122;
   }
 }
 
@@ -140,6 +141,7 @@ message KaspadResponse {
     GetUtxoCountByAddressResponseMessage getUtxoCountByAddressResponse = 1117;
     GetUtxoEntriesByOutpointsResponseMessage getUtxoEntriesByOutpointsResponse = 1119;
     GetServiceStrikesResponseMessage getServiceStrikesResponse = 1121;
+    GetHolderRewardResponseMessage getHolderRewardResponse = 1123;
   }
 }
 

--- a/rpc/grpc/core/proto/rpc.proto
+++ b/rpc/grpc/core/proto/rpc.proto
@@ -1172,6 +1172,46 @@ message ServiceStrikeTotalMessage {
 message GetServiceStrikesRequestMessage {
 }
 
+// GetHolderRewardRequestMessage asks for the holder-reward (ratio-reward) bracket state of one
+// payout address: the effective balance and windowed production the node divides, the resulting
+// bracket, and what the next bracket up would cost.
+message GetHolderRewardRequestMessage {
+  string address = 1;
+}
+
+message GetHolderRewardResponseMessage {
+  uint64 virtualDaaScore = 1;
+  // Coin-age effective balance (the plain balance pre-H4) — NOT the spendable balance.
+  uint64 effBalance = 2;
+  // Windowed production before the one-block floor; 0 means "not a miner in this window".
+  uint64 productionRaw = 3;
+  uint64 production = 4;
+  uint64 bracketBps = 5;
+  // Both unset exactly when the address already sits in the top bracket.
+  optional uint64 nextBracketBps = 6;
+  optional uint64 nextBracketBalance = 7;
+  uint64 fullBracketBalance = 8;
+  uint64 windowDaa = 9;
+  bool active = 10;
+  // Miner cut actually paid over the window (post tier/ratio scaling) — income, not entitlement.
+  uint64 paid = 11;
+  // productionRaw - paid: the shortfall the brackets destroyed.
+  uint64 burned = 12;
+  // Escrow slice accrued over the window; 0 for a standard miner (burned at emission).
+  uint64 escrow = 13;
+  // Inference-reward mints routed to this address over the window.
+  uint64 inference = 14;
+  // Daa actually spanned by paid/burned/escrow/inference - NOT necessarily windowDaa. Those come
+  // from display-only indexes maintained forward from the boot that created them, so a fresh node
+  // covers only the daa since; 0 means no coverage. Label the income figures with this.
+  uint64 incomeWindowDaa = 15;
+  // Base miner cut over incomeWindowDaa split by proven model tier - the MIX, indexed by tier.
+  // Shares must be taken over the sum of these, never over the entitlement.
+  repeated uint64 tierBase = 16;
+
+  RPCError error = 1000;
+}
+
 message GetServiceStrikesResponseMessage {
   uint64 virtualDaaScore = 1;
   repeated ServiceStrikeMessage strikes = 2;

--- a/rpc/grpc/core/src/convert/keryxd.rs
+++ b/rpc/grpc/core/src/convert/keryxd.rs
@@ -48,6 +48,7 @@ pub mod kaspad_request_convert {
     impl_into_kaspad_request!(GetUtxoCountByAddress);
     impl_into_kaspad_request!(GetUtxoEntriesByOutpoints);
     impl_into_kaspad_request!(GetServiceStrikes);
+    impl_into_kaspad_request!(GetHolderReward);
     impl_into_kaspad_request!(GetBalanceByAddress);
     impl_into_kaspad_request!(GetBalancesByAddresses);
     impl_into_kaspad_request!(GetSinkBlueScore);
@@ -190,6 +191,7 @@ pub mod kaspad_response_convert {
     impl_into_kaspad_response!(GetUtxoCountByAddress);
     impl_into_kaspad_response!(GetUtxoEntriesByOutpoints);
     impl_into_kaspad_response!(GetServiceStrikes);
+    impl_into_kaspad_response!(GetHolderReward);
     impl_into_kaspad_response!(GetBalanceByAddress);
     impl_into_kaspad_response!(GetBalancesByAddresses);
     impl_into_kaspad_response!(GetSinkBlueScore);

--- a/rpc/grpc/core/src/convert/message.rs
+++ b/rpc/grpc/core/src/convert/message.rs
@@ -408,6 +408,32 @@ from!(item: RpcResult<&keryx_rpc_core::GetCoinSupplyResponse>, protowire::GetCoi
 });
 
 from!(&keryx_rpc_core::GetServiceStrikesRequest, protowire::GetServiceStrikesRequestMessage);
+
+from!(item: &keryx_rpc_core::GetHolderRewardRequest, protowire::GetHolderRewardRequestMessage, {
+    Self { address: (&item.address).into() }
+});
+
+from!(item: RpcResult<&keryx_rpc_core::GetHolderRewardResponse>, protowire::GetHolderRewardResponseMessage, {
+    Self {
+        virtual_daa_score: item.virtual_daa_score,
+        eff_balance: item.eff_balance,
+        production_raw: item.production_raw,
+        production: item.production,
+        bracket_bps: item.bracket_bps,
+        next_bracket_bps: item.next_bracket_bps,
+        next_bracket_balance: item.next_bracket_balance,
+        full_bracket_balance: item.full_bracket_balance,
+        window_daa: item.window_daa,
+        active: item.active,
+        paid: item.paid,
+        burned: item.burned,
+        escrow: item.escrow,
+        inference: item.inference,
+        income_window_daa: item.income_window_daa,
+        tier_base: item.tier_base.clone(),
+        error: None,
+    }
+});
 from!(item: RpcResult<&keryx_rpc_core::GetServiceStrikesResponse>, protowire::GetServiceStrikesResponseMessage, {
     Self {
         virtual_daa_score: item.virtual_daa_score,
@@ -988,6 +1014,31 @@ try_from!(item: &protowire::GetCoinSupplyResponseMessage, RpcResult<keryx_rpc_co
 });
 
 try_from!(&protowire::GetServiceStrikesRequestMessage, keryx_rpc_core::GetServiceStrikesRequest);
+
+try_from!(item: &protowire::GetHolderRewardRequestMessage, keryx_rpc_core::GetHolderRewardRequest, {
+    Self { address: item.address.as_str().try_into()? }
+});
+
+try_from!(item: &protowire::GetHolderRewardResponseMessage, RpcResult<keryx_rpc_core::GetHolderRewardResponse>, {
+    Self {
+        virtual_daa_score: item.virtual_daa_score,
+        eff_balance: item.eff_balance,
+        production_raw: item.production_raw,
+        production: item.production,
+        bracket_bps: item.bracket_bps,
+        next_bracket_bps: item.next_bracket_bps,
+        next_bracket_balance: item.next_bracket_balance,
+        full_bracket_balance: item.full_bracket_balance,
+        window_daa: item.window_daa,
+        active: item.active,
+        paid: item.paid,
+        burned: item.burned,
+        escrow: item.escrow,
+        inference: item.inference,
+        income_window_daa: item.income_window_daa,
+        tier_base: item.tier_base.clone(),
+    }
+});
 try_from!(item: &protowire::GetServiceStrikesResponseMessage, RpcResult<keryx_rpc_core::GetServiceStrikesResponse>, {
     Self {
         virtual_daa_score: item.virtual_daa_score,

--- a/rpc/grpc/core/src/ops.rs
+++ b/rpc/grpc/core/src/ops.rs
@@ -72,6 +72,7 @@ pub enum KaspadPayloadOps {
     GetUtxoCountByAddress,
     GetUtxoEntriesByOutpoints,
     GetServiceStrikes,
+    GetHolderReward,
     GetBalanceByAddress,
     GetBalancesByAddresses,
     GetSinkBlueScore,

--- a/rpc/grpc/server/src/request_handler/factory.rs
+++ b/rpc/grpc/server/src/request_handler/factory.rs
@@ -66,6 +66,7 @@ impl Factory {
                 GetUtxoCountByAddress,
                 GetUtxoEntriesByOutpoints,
                 GetServiceStrikes,
+            GetHolderReward,
                 GetBalanceByAddress,
                 GetBalancesByAddresses,
                 GetSinkBlueScore,

--- a/rpc/grpc/server/src/tests/rpc_core_mock.rs
+++ b/rpc/grpc/server/src/tests/rpc_core_mock.rs
@@ -354,6 +354,14 @@ impl RpcApi for RpcCoreMock {
         Err(RpcError::NotImplemented)
     }
 
+    async fn get_holder_reward_call(
+        &self,
+        _connection: Option<&DynRpcConnection>,
+        _request: GetHolderRewardRequest,
+    ) -> RpcResult<GetHolderRewardResponse> {
+        Err(RpcError::NotImplemented)
+    }
+
     async fn get_coin_supply_call(
         &self,
         _connection: Option<&DynRpcConnection>,

--- a/rpc/service/src/service.rs
+++ b/rpc/service/src/service.rs
@@ -899,6 +899,39 @@ NOTE: This error usually indicates an RPC conversion error between the node and 
         Ok(GetUtxoCountByAddressResponse::new(count))
     }
 
+    async fn get_holder_reward_call(
+        &self,
+        _connection: Option<&DynRpcConnection>,
+        request: GetHolderRewardRequest,
+    ) -> RpcResult<GetHolderRewardResponse> {
+        let session = self.consensus_manager.consensus().unguarded_session();
+        // The bracket is read off the balance and production indexes, which are still being
+        // filled during IBD — answering then would hand back a bracket that has nothing to do
+        // with the chain's real state.
+        if session.async_is_consensus_in_transitional_ibd_state().await {
+            return Err(RpcError::ConsensusInTransitionalIbdState);
+        }
+        let snapshot = session.get_holder_reward(&pay_to_address_script(&request.address));
+        Ok(GetHolderRewardResponse {
+            virtual_daa_score: snapshot.virtual_daa_score,
+            eff_balance: snapshot.eff_balance,
+            production_raw: snapshot.production_raw,
+            production: snapshot.production,
+            bracket_bps: snapshot.bracket_bps,
+            next_bracket_bps: snapshot.next_bracket.map(|(bps, _)| bps),
+            next_bracket_balance: snapshot.next_bracket.map(|(_, balance)| balance),
+            full_bracket_balance: snapshot.full_bracket_balance,
+            window_daa: snapshot.window_daa,
+            active: snapshot.active,
+            paid: snapshot.paid,
+            burned: snapshot.burned,
+            escrow: snapshot.escrow,
+            inference: snapshot.inference,
+            income_window_daa: snapshot.income_window_daa,
+            tier_base: snapshot.tier_base.to_vec(),
+        })
+    }
+
     async fn get_balance_by_address_call(
         &self,
         _connection: Option<&DynRpcConnection>,

--- a/rpc/wrpc/client/src/client.rs
+++ b/rpc/wrpc/client/src/client.rs
@@ -630,6 +630,7 @@ impl RpcApi for KaspaRpcClient {
             GetUtxoCountByAddress,
             GetUtxoEntriesByOutpoints,
             GetServiceStrikes,
+            GetHolderReward,
             GetBlock,
             GetBlockCount,
             GetBlockDagInfo,

--- a/rpc/wrpc/server/src/router.rs
+++ b/rpc/wrpc/server/src/router.rs
@@ -42,6 +42,7 @@ impl Router {
                 GetUtxoCountByAddress,
                 GetUtxoEntriesByOutpoints,
                 GetServiceStrikes,
+                GetHolderReward,
                 GetBlock,
                 GetBlockCount,
                 GetBlockDagInfo,

--- a/rpc/wrpc/wasm/src/client.rs
+++ b/rpc/wrpc/wasm/src/client.rs
@@ -1000,6 +1000,10 @@ build_wrpc_wasm_bindgen_interface!(
         /// Retrieves the balance of a specific address in the Kaspa BlockDAG.
         /// Returned information: Balance of the address.
         GetBalanceByAddress,
+        /// Retrieves the holder-reward (ratio-reward) bracket state of a payout
+        /// address: the effective balance and windowed production the node divides,
+        /// the resulting bracket, and what the next bracket up would cost.
+        GetHolderReward,
         /// Retrieves balances for multiple addresses in the Kaspa BlockDAG.
         /// Returned information: Balances of the addresses.
         GetBalancesByAddresses,

--- a/testing/integration/src/rpc_tests.rs
+++ b/testing/integration/src/rpc_tests.rs
@@ -511,6 +511,12 @@ async fn sanity_test() {
                 })
             }
 
+            KaspadPayloadOps::GetHolderReward => {
+                // Asserting on a snapshot needs a mined payout history, which this harness does
+                // not build; the encoding is covered by the borsh round-trip in rpc-core.
+                tst!(op, "needs a mined payout history")
+            }
+
             KaspadPayloadOps::GetCoinSupply => {
                 let rpc_client = client.clone();
                 tst!(op, {

--- a/wallet/core/src/tests/rpc_core_mock.rs
+++ b/wallet/core/src/tests/rpc_core_mock.rs
@@ -355,6 +355,14 @@ impl RpcApi for RpcCoreMock {
         Err(RpcError::NotImplemented)
     }
 
+    async fn get_holder_reward_call(
+        &self,
+        _connection: Option<&DynRpcConnection>,
+        _request: GetHolderRewardRequest,
+    ) -> RpcResult<GetHolderRewardResponse> {
+        Err(RpcError::NotImplemented)
+    }
+
     async fn get_daa_score_timestamp_estimate_call(
         &self,
         _connection: Option<&DynRpcConnection>,

--- a/wasm/.cargo/config.toml
+++ b/wasm/.cargo/config.toml
@@ -1,2 +1,7 @@
 [build]
 rustflags = ["-Ctarget-cpu=mvp"]
+
+# Scoped to wasm32: the `wasm_js` backend hard-errors if selected for a host target, and
+# `[build]` rustflags also reach build scripts and proc macros.
+[target.wasm32-unknown-unknown]
+rustflags = ["-Ctarget-cpu=mvp", "--cfg", 'getrandom_backend="wasm_js"']

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -38,6 +38,14 @@ workflow-log.workspace = true
 workflow-core.workspace = true
 workflow-wasm.workspace = true
 
+# getrandom 0.3 arrives transitively (ahash) and refuses to build for
+# wasm32-unknown-unknown unless its `wasm_js` backend is BOTH feature-enabled and
+# cfg-selected. The feature is enabled here; the matching
+# `--cfg getrandom_backend="wasm_js"` is supplied by the build scripts / .cargo/config.toml.
+# Scoped to wasm32 so host builds (build scripts, proc macros) keep the default backend.
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom_wasm_js = { package = "getrandom", version = "0.3", features = ["wasm_js"] }
+
 [features]
 wasm32-sdk = [
     "keryx-wallet-core/wasm32-sdk",

--- a/wasm/build-node
+++ b/wasm/build-node
@@ -3,6 +3,10 @@ set -e
 
 # Workaround for Rust 1.87.0
 # https://github.com/rust-lang/rust/issues/141048
-export RUSTFLAGS=-Ctarget-cpu=mvp
+# `getrandom_backend` is required alongside the crate's `wasm_js` feature (enabled in
+# wasm/Cargo.toml) or getrandom 0.3 refuses to build for wasm32-unknown-unknown. It has to
+# travel in RUSTFLAGS: setting the env var overrides .cargo/config.toml's rustflags entirely,
+# so listing it there alone would be silently dropped by these scripts.
+export RUSTFLAGS='-Ctarget-cpu=mvp --cfg getrandom_backend="wasm_js"'
 
 wasm-pack build --weak-refs --target nodejs --out-name kaspa --out-dir nodejs/kaspa --features wasm32-sdk

--- a/wasm/build-release
+++ b/wasm/build-release
@@ -6,7 +6,11 @@ set -e
 
 # Workaround for Rust 1.87.0
 # https://github.com/rust-lang/rust/issues/141048
-export RUSTFLAGS=-Ctarget-cpu=mvp
+# `getrandom_backend` is required alongside the crate's `wasm_js` feature (enabled in
+# wasm/Cargo.toml) or getrandom 0.3 refuses to build for wasm32-unknown-unknown. It has to
+# travel in RUSTFLAGS: setting the env var overrides .cargo/config.toml's rustflags entirely,
+# so listing it there alone would be silently dropped by these scripts.
+export RUSTFLAGS='-Ctarget-cpu=mvp --cfg getrandom_backend="wasm_js"'
 
 rm -rf release/*
 rm -rf web/*

--- a/wasm/build-web
+++ b/wasm/build-web
@@ -3,7 +3,11 @@ set -e
 
 # Workaround for Rust 1.87.0
 # https://github.com/rust-lang/rust/issues/141048
-export RUSTFLAGS=-Ctarget-cpu=mvp
+# `getrandom_backend` is required alongside the crate's `wasm_js` feature (enabled in
+# wasm/Cargo.toml) or getrandom 0.3 refuses to build for wasm32-unknown-unknown. It has to
+# travel in RUSTFLAGS: setting the env var overrides .cargo/config.toml's rustflags entirely,
+# so listing it there alone would be silently dropped by these scripts.
+export RUSTFLAGS='-Ctarget-cpu=mvp --cfg getrandom_backend="wasm_js"'
 
 if [ "$1" == "--keygen" ]; then
     echo "building wasm32-keygen"


### PR DESCRIPTION
## What this is

**A reference implementation, not a merge proposal.** The plan of record is for mining data to
reach clients through the official explorer API, and the wallet to be rewritten to read from
there rather than from node RPC. This branch exists so that decision can be made against
working code: it shows exactly which figures a mining wallet needs, why most of them cannot be
recovered from the chain after the fact, and what it costs to keep them.

Read it as a **data contract plus a list of traps**. If the explorer indexer produces the same
figures with the same semantics, the wallet side is a swap of one module.

## The core problem: the interesting numbers are destroyed at validation

For a payout address over a window, a mining dashboard needs: what the coinbases actually
**paid** it, what the tier and ratio brackets **burned** instead of paying, what accrued to
**escrow**, what arrived as an **inference-reward** mint, and **which tiers** the paid amount
came from.

None of that is derivable from the chain later:

- A miner cut is the base cut scaled by the tier and ratio brackets **of that block's view**.
  Neither map survives validation, so re-deriving `paid` for an old block means rebuilding the
  bracket state as of that block.
- `burned` is a non-event. Nothing is written anywhere: the shortfall is simply not minted. It
  is only knowable as `entitlement − paid`, and the entitlement needs that same historical
  view.
- An inference-reward mint and a miner cut are **indistinguishable by script alone** in the
  coinbase outputs.
- The tier is committed in `header.pom_tier` (at/after `pom_v3_activation`), but a standing gate
  demotes a top tier to the entry rate, so bps → tier is not invertible. And a rig can mine
  several tiers inside one window, which an average cannot represent.

So the builder emits the split it has already computed
(`CoinbaseTransactionTemplate.payouts`), and validation records it. **Anything computing these
figures downstream needs the same in-block view, or it needs the node to have written it down.**

## What was built

- **Prefix-sum stores.** `windowed(spk, b, W) = cumulative_at(b) − cumulative_at(b − W)`. A read
  is two point lookups regardless of window length, and the value is path-independent: a reorg
  truncates, pruning collapses each SPK to a floor, neither has to replay.
- **Per-tier buckets** (`CoinbasePayout.tier_base`, `TIER_BUCKETS`), so the mix is preserved
  rather than averaged.
- **Forward-only by default.** A from-chain backfill needs a coinbase **body** read per chain
  block and per blue. Measured on a 7200rpm disk with ~1.7M chain blocks that is hours of random
  IO on the boot path — indistinguishable from a hang to an operator (the symptom that started
  this: 8.1s of CPU over 35 minutes, and a log line that never advanced). So a fresh node writes
  a start marker at the current tip and indexes forward; the full backfill is opt-in behind
  `KERYX_BUILD_PAYOUT_INDEX=1` and logs progress per block scanned.
- **Reads clamp to that marker**, and the snapshot reports `income_window_daa` — the daa
  actually covered, which is not necessarily the nominal window.
- **Consensus rules are untouched.** Nothing here is read back during validation and no
  consensus value depends on an index existing. It is display-only state.

Also fixed on the way: the pruning collapse was driven by a hand-written store list and
therefore silently skipped the inference index.

## Points to carry over to an API implementation

These are the parts that were **not** obvious and that an indexer will hit too:

1. **`income_window_daa` is not optional.** Whatever serves these figures must say what period
   they cover. A node (or indexer) that has just built its index covers minutes; labelling
   minutes as "24h" turns a rig that mined all night into a rig that burned all night. The
   wallet in the companion PR labels every income figure with this and never with the nominal
   window.
2. **`paid/base` is the payout rate; `ratio_eff × tier_eff` is not.** The two brackets covary
   over the window, so the product of the averages is a different number than the average of the
   products. Serve the ratio directly and treat the factorisation as a breakdown only.
3. **Keep the tier split, not a tier.** One rig mines several tiers in a window.
4. **`production` has a one-block floor.** `production_raw = 0` is what separates a plain holder
   from a miner; the divisor is floored at one block's base miner cut so a newcomer divides by
   one block instead of by zero. Both values are exposed because they answer different
   questions.
5. **Attribution must be all-or-nothing per block.** A pruned body yields no attribution rather
   than a partial one, or windows silently under-report.
6. **Identity for service standing.** `getServiceStrikes` (already in v1.6.0) reports against
   `miner_key(spk) = BLAKE2b-256(key="TransactionHash", version_le(2) ‖ script)`. A client
   cannot match its own address without it, which is why `minerKeyForAddress` is added to the
   SDK. An HTTP API should accept an **address** and do this internally.
7. **A miner can have several pending burns.** They sum; taking the first entry under-reports.
8. **Version the payload.** The borsh encoding here is at version 3 (v2 added
  `income_window_daa`, v3 added `tier_base`), both read conditionally so older clients stay
  decodable.

## Verification

- `cargo check --workspace --all-targets` — this branch fixes the one regression it introduced
  (`mining/src/testutils/coinbase_mock.rs`, a struct literal missing the new field). Four errors
  remain and **all predate this branch**: `wallet/core/src/tests/rpc_core_mock.rs` is missing
  `get_utxo_entries_by_outpoints_call` / `get_utxo_count_by_address_call` (0 occurrences on
  master), and `testing/integration/src/consensus_integration_tests.rs` imports `ForkActivation`
  twice (lines 18 and 23) and has a `Header` initializer predating
  `pom_tier`/`service_state_hash`. The release build is green.
- Checked against a live mainnet node, and the invariants held to the sompi:
  `full_bracket_balance = 90 × production`, `next_bracket_balance = 60 × production`, and
  `escrow/paid = 0.37166` against 0.37167 predicted independently from the 20% escrow / 75%
  base-miner emission split.
- `minerKeyForAddress` was cross-checked against an independent Python BLAKE2b implementation
  and then matched against the node's own `getServiceStrikes` list.
- `testing/integration` has **not** been run (it does not compile on master, see above).

## Companion PR

Keryx-Labs/keryx-desktop-wallet#4 — the wallet side (https://github.com/Keryx-Labs/keryx-desktop-wallet/pull/4). Its mining panel is the only consumer of
`getHolderReward`, it feature-detects and latches off when the node does not support it, and it
is isolated so it can be repointed at an HTTP API without touching the rest of the app.

