### PR TITLE
PoC: shard-possession PoM (network-fatia) — incomplete, exploratory

### DIFF
--- a/SHARD_POSSESSION_POC.md
+++ b/SHARD_POSSESSION_POC.md
@@ -1,0 +1,152 @@
+# Shard-Possession PoM PoC ("network-fatia")
+
+Status: **PROOF OF CONCEPT — incomplete, exploratory.** Not activated on Mainnet or Testnet.
+Only exercised on an isolated, private Simnet build created for this work. Nothing in this
+branch changes consensus on any shared network; `shard_poc_activation` is `never()` everywhere
+except the private `SIMNET_PARAMS` added here.
+Branch: `shard-poc` in both `keryx-miner` and `keryx-node`.
+Companion repo: this document is duplicated verbatim in both `keryx-node` and `keryx-miner`
+(the two halves of the PoC live in separate repos and have to be read together).
+
+## 1. Motivation
+
+PoM tiers currently require one GPU to hold and walk an entire model's weights. As served
+models grow (e.g. a 48B-parameter tier), that stops fitting on a single consumer GPU. This PoC
+explores an alternative: split a model into fixed-byte-size **shards** along layer boundaries,
+and let a GPU prove possession of only its own shard instead of the whole model — so a model
+too large for any one card can still be mined, cooperatively, across several cards.
+
+This is a possession-proof question, not a serving question: it does **not** attempt to make a
+shard device capable of running real OPoI inference over the full model (see §6, "Not done").
+
+## 2. What changed — miner side (`keryx-miner`, branch `shard-poc`)
+
+- `src/shard.rs`: `ShardManifest { index: u16, layer_lo: u32, layer_hi: u32, tensor_names:
+  Vec<String> }` and `pack_shards(meta, target_bytes) -> Vec<ShardManifest>` — splits a GGUF's
+  tensors into layer-range shards, each close to `target_bytes` on disk.
+- `src/pom.rs`: `WeightIndex::build_from_gguf_subset(...)` — builds a host chunk index (the same
+  Merkle-style structure used for a whole-tier index) over only a shard's tensor subset.
+- `src/pom_gpu.rs`:
+  - `load_raw_subset(...)` — raw GPU upload restricted to a shard's tensor subset only. Shard
+    devices never run the llama engine and never zero-dup against a resident whole-model tree —
+    always a raw scoped upload.
+  - Per-device shard registry (`set_shard_for_device` / `shard_for_device`) and
+    `ensure_shard_installed_inner`, which contains the **N-guard**: after installing, it compares
+    the GPU gather's chunk count against the host index's chunk count and refuses to install a
+    miner (`"gather N != shard index N — refusing to mine"`) on any mismatch, rather than
+    silently producing a proof over the wrong data. Verified live on real hardware — see §5.
+- `src/models.rs`: `pom_shard_tier_index(model_id, target_bytes, shard_index, daa)` — maps a
+  shard assignment to a PoM tier index. In this PoC: `5 + shard_index` for a 4-shard, 8 GB split
+  of the `very-high` tier (tiers 5, 6, 7, 8). This offset is a **hand-kept convention**, not
+  negotiated by any protocol — see §6.
+- `src/cli.rs` / `src/main.rs`: `--shard TIER:TARGET_GIB:IDX[,...]` (mine one fixed-size shard
+  instead of the whole tier) and `--print-shards TIER:TARGET_GIB` (compute and print a shard
+  manifest, then exit — used to produce the exact values pasted into the node's shard tier
+  table; see §3).
+- Two real defects found and fixed while running this live (`src/client/grpc.rs`):
+  1. The existing "OPoI is mandatory: refuse to mine with no model loaded" gate had no exemption
+     for shard-only devices, which never load a full model by design. Fixed with
+     `pom_gpu::any_shard_devices_active()` and a gate exemption for processes that only run
+     shard devices — no change for ordinary whole-tier mining.
+  2. A sole-producer / idle chain (this PoC's Simnet, with zero peers) never re-requested a
+     fresh block template outside of an in-flight inference cycle, so mining stalled at DAA 0
+     indefinitely. Fixed with an unconditional ~500ms fallback re-poll.
+- `examples/shard_walk_poc.rs` and `examples/shard_guard_poc.rs` — see §5.
+
+## 3. What changed — node side (`keryx-node`, branch `shard-poc`)
+
+- `consensus/core/src/config/params.rs`:
+  - `POM_SHARDS_POC`: a shard tier table (`crate::pom::PomTier { model_id, root, chunks }` per
+    shard) — real, measured values pasted verbatim from `keryx-miner --print-shards
+    very-high:8` run against the real model file (see §4). Gated behind `shard_poc_activation`.
+  - `shard_poc_activation`: a new fork-activation gate. `never()` on `MAINNET_PARAMS` and the
+    shared public `TESTNET_PARAMS` — this PoC never touches either. Set to `new(1)` only on
+    `SIMNET_PARAMS`, alongside a full, internally-consistent PoM/OPoI/H-series activation
+    profile built specifically for a from-genesis private Simnet (every field's reasoning is
+    documented inline in the diff, including one corrected discrepancy against the public
+    `TESTNET_PARAMS`'s `pom_v4_activation`/`h10_activation` values — the real miner binary gates
+    those at DAA 500 under `--testnet`, not DAA 1 as `TESTNET_PARAMS` currently says; that
+    pre-existing drift is dormant on the real Testnet only because its tip is already past DAA
+    500, and is not copied into `SIMNET_PARAMS`).
+
+## 4. Environment used for validation
+
+- Hardware: 2x NVIDIA GPU on one rig — CUDA ordinal 0 = RTX 3090 (24 GB), CUDA ordinal 1 = RTX
+  4090 (24 GB). This rig's CUDA driver ordinal does not match the `nvidia-smi` device index by
+  default; validation used `CUDA_DEVICE_ORDER=PCI_BUS_ID` to pin them.
+- Model: Kimi-Linear-48B, Q4_K_M quantization, ~29.7 GB GGUF on disk — too large to fit whole on
+  either single card in this rig.
+- Split: 8 GB target per shard → 4 shards. Real manifest (captured via `--print-shards
+  very-high:8`):
+
+  | Shard | Layers | Chunks | Merkle root |
+  |---|---|---|---|
+  | 0 | [0, 7) | 219,852,216 | `a73a38fe1ef0cddc6e108eca25eb1de1adcdc7a65c01f87058530ac06df669b4` |
+  | 1 | [7, 14) | 238,829,076 | `db22407efc04f5d261498afc7acb397c87e692699484a9bcf2a747636adda9e5` |
+  | 2 | [14, 21) | 243,638,100 | `9c3aed4cc240baea0928f8282ea91ce6b0cd275f8286c45c440017c457f8cb8d` |
+  | 3 | [21, 27) | 225,674,672 | `233fdb1f9b551bb7895a0fca931ce5eddd16d87a12980f7e4361e020cfe29ff2` |
+
+- Network: a private, isolated Simnet instance (no DNS seeders, own genesis) — never the shared
+  public Testnet or Mainnet.
+- Build: Windows, MSVC toolchain via the Visual Studio Developer Shell;
+  `KERYX_LLAMA_SKIP=1` (skips only the llama.cpp CMake library build used for OPoI inference
+  serving — irrelevant to the PoM CUDA kernel path this PoC exercises).
+
+## 5. Results — proven on real hardware
+
+1. **In-process concept proof** (`keryx-miner/examples/shard_walk_poc.rs`): both GPUs
+   independently packed their shard's manifest, installed it (real raw scoped upload), ran a
+   real GPU PoM walk against a synthetic (trivially easy) target, built a real `PomProofV3`
+   witness from the walk, and self-verified it with the same `verify_proof_v3` function a node
+   uses — no live node needed for this step. Both self-verified `true`.
+2. **Live network acceptance** (real gRPC mining loop, against the private Simnet node running
+   the `SIMNET_PARAMS` profile from §3): the node genuinely accepted shard-tier PoM blocks over
+   the real block-submission path, sustained, with zero rejections — 817 blocks on shard 0
+   (GPU0/3090, ~1.05M h/s, `v4 tensor-core` kernel) and 413 blocks on shard 1 (GPU1/4090, ~1.68M
+   h/s), 1,230 combined, 0 rejected.
+3. **Guard regression check** (`keryx-miner/examples/shard_guard_poc.rs`): installs a shard with
+   its correct manifest (succeeds), then reinstalls after dropping one tensor name from the
+   manifest — the cached host index still reflects the correct (larger) chunk count, so the
+   second gather's chunk count diverges and the N-guard correctly refuses to install a miner,
+   confirming a corrupted/wrong manifest cannot silently produce an acceptable proof.
+
+## 6. Explicitly NOT done — open, incomplete by design
+
+This is a concept proof, not a finished feature. In particular:
+
+- **No distributed OPoI inference serving.** A shard device still cannot itself serve real
+  inference over the full model — the OPoI-mandatory-mining gate exemption in §2 only lets a
+  shard-only process skip that requirement for *mining*; it does not make inference work. A
+  real ggml-rpc-style pipeline across shards (already scoped separately as spec §3.3–3.5) is
+  future work, not part of this PoC.
+- **The pre-PoM bootstrap block still needs a whole model.** A fresh chain's very first block
+  (below `pom_activation`) must be mined under the legacy kHeavyHash+OPoI path, which needs one
+  device holding the *entire* model — a pure shard-only rig has no path through that block on
+  its own.
+- **The shard→tier offset (`5 + shard_index`) is a hand-kept convention**, not negotiated by any
+  protocol. The node's `POM_SHARDS_POC` row order must match the miner's shard numbering by
+  agreement, not by any on-chain mechanism. A mismatch here is silently wrong, not rejected —
+  this is a real weakness a production design would need to close.
+- **Not tested beyond this exact configuration**: 2 GPUs, 4 shards, one model
+  (Kimi-Linear-48B), one rig. Behavior with more shards, more devices, a different model, or
+  cross-machine (rather than cross-GPU-on-one-machine) sharding is unexplored.
+- **No reward/economics design.** A shard-only miner's partial possession currently just reuses
+  the ordinary tier-based reward table positionally. Whether that's fair or game-theoretically
+  sound versus a whole-tier miner's possession was not evaluated.
+- **`SIMNET_PARAMS` activation is deliberately Simnet-only.** Extending any of this to a shared
+  network (Testnet or Mainnet) is a separate, much larger decision — governance, rollout timing,
+  and backward compatibility are all out of scope here.
+
+## 7. Where to look / how to reproduce
+
+- `keryx-node`, branch `shard-poc`: commit `76aa3c6f` (shard tier table + gating scaffold, then
+  a placeholder row), commit `ecb0f09e` (real manifest data + the `SIMNET_PARAMS` activation
+  profile from §3).
+- `keryx-miner`, branch `shard-poc`: commits `3cf1bd4` (shard registry + install path), `15649ec`
+  (`--shard`/`--print-shards` CLI), `ba2aa2f` (wiring into tier assignment and the mining loop),
+  `b9c0990` (OPoI-gate exemption for shard devices), `183d3e5` (idle-chain template re-poll
+  fix), `645fd5d` (the two diagnostic examples in §5).
+- To rerun the in-process proof or the guard check: `cargo run --example shard_walk_poc
+  --features cuda` / `cargo run --example shard_guard_poc --features cuda` from the miner repo
+  (both accept `--gguf-path`, `--target-bytes`, and `--mainnet` flags; default to the
+  Kimi-Linear-48B path and testnet-style DAA gates used above).

--- a/SHARD_POSSESSION_POC.md
+++ b/SHARD_POSSESSION_POC.md
@@ -139,8 +139,8 @@ This is a concept proof, not a finished feature. In particular:
 
 ## 7. Where to look / how to reproduce
 
-- `keryx-node`, branch `shard-poc`: commit `76aa3c6f` (shard tier table + gating scaffold, then
-  a placeholder row), commit `ecb0f09e` (real manifest data + the `SIMNET_PARAMS` activation
+- `keryx-node`, branch `shard-poc`: commit `8107a66f` (shard tier table + gating scaffold, then
+  a placeholder row), commit `b7a7c2ed` (real manifest data + the `SIMNET_PARAMS` activation
   profile from §3).
 - `keryx-miner`, branch `shard-poc`: commits `3cf1bd4` (shard registry + install path), `15649ec`
   (`--shard`/`--print-shards` CLI), `ba2aa2f` (wiring into tier assignment and the mining loop),

--- a/SHARD_POSSESSION_POC.pt-BR.md
+++ b/SHARD_POSSESSION_POC.pt-BR.md
@@ -1,0 +1,171 @@
+# PoC de Posse por Fatia (Shard) para o PoM ("network-fatia")
+
+Status: **PROVA DE CONCEITO — incompleta, exploratória.** Não ativada na Mainnet nem na
+Testnet. Só foi exercitada numa Simnet privada e isolada, criada especificamente para este
+trabalho. Nada nesta branch altera o consenso de nenhuma rede compartilhada;
+`shard_poc_activation` é `never()` em todo lugar, exceto no `SIMNET_PARAMS` privado adicionado
+aqui.
+Branch: `shard-poc` tanto em `keryx-miner` quanto em `keryx-node`.
+Repositório companheiro: este documento é duplicado, na íntegra, em `keryx-node` e em
+`keryx-miner` (as duas metades do PoC vivem em repositórios separados e precisam ser lidas
+juntas).
+
+## 1. Motivação
+
+Hoje, os tiers de PoM exigem que uma única GPU segure e percorra (walk) o modelo inteiro. À
+medida que os modelos servidos crescem (ex.: um tier de 48B parâmetros), isso deixa de caber
+numa única GPU de consumidor. Este PoC explora uma alternativa: dividir um modelo em **fatias
+(shards)** de tamanho fixo em bytes, ao longo de faixas de camadas (layers), e deixar que cada
+GPU prove posse apenas da sua própria fatia, em vez do modelo inteiro — assim, um modelo grande
+demais para qualquer placa isolada ainda pode ser minerado, cooperativamente, por várias placas.
+
+Isso é uma questão de prova de posse, não de servir inferência: **não** se tenta tornar um
+dispositivo de fatia capaz de rodar inferência OPoI real sobre o modelo completo (ver §6,
+"O que não foi feito").
+
+## 2. O que mudou — lado do miner (`keryx-miner`, branch `shard-poc`)
+
+- `src/shard.rs`: `ShardManifest { index: u16, layer_lo: u32, layer_hi: u32, tensor_names:
+  Vec<String> }` e `pack_shards(meta, target_bytes) -> Vec<ShardManifest>` — divide os tensores
+  de um GGUF em fatias por faixa de camadas, cada uma próxima do `target_bytes` em disco.
+- `src/pom.rs`: `WeightIndex::build_from_gguf_subset(...)` — constrói um índice de chunks no
+  host (a mesma estrutura estilo Merkle usada num índice de tier inteiro), mas só sobre o
+  subconjunto de tensores de uma fatia.
+- `src/pom_gpu.rs`:
+  - `load_raw_subset(...)` — upload bruto pra GPU restrito ao subconjunto de tensores de uma
+    fatia. Dispositivos de fatia nunca rodam o motor llama e nunca fazem zero-dup contra uma
+    árvore residente do modelo inteiro — é sempre um upload bruto e escopado (raw scoped
+    upload).
+  - Registro por dispositivo de qual fatia ele minera (`set_shard_for_device` /
+    `shard_for_device`) e `ensure_shard_installed_inner`, que contém o **N-guard**: depois de
+    instalar, compara a contagem de chunks obtida pela GPU contra a contagem do índice do host e
+    recusa instalar um miner (`"gather N != shard index N — refusing to mine"`) em qualquer
+    divergência, em vez de produzir silenciosamente uma prova sobre os dados errados. Verificado
+    ao vivo em hardware real — ver §5.
+- `src/models.rs`: `pom_shard_tier_index(model_id, target_bytes, shard_index, daa)` — mapeia uma
+  atribuição de fatia pra um índice de tier de PoM. Neste PoC: `5 + shard_index` pra uma divisão
+  em 4 fatias de 8 GB do tier `very-high` (tiers 5, 6, 7, 8). Esse deslocamento é uma
+  **convenção mantida manualmente**, não negociada por nenhum protocolo — ver §6.
+- `src/cli.rs` / `src/main.rs`: `--shard TIER:TARGET_GIB:IDX[,...]` (minerar uma fatia de
+  tamanho fixo em vez do tier inteiro) e `--print-shards TIER:TARGET_GIB` (calcular e imprimir o
+  manifest de uma fatia, depois sair — usado pra produzir os valores exatos colados na tabela de
+  fatias do node; ver §3).
+- Dois defeitos reais encontrados e corrigidos rodando isso ao vivo (`src/client/grpc.rs`):
+  1. O gate existente "OPoI é obrigatório: recusar minerar sem nenhum modelo carregado" não
+     tinha isenção para dispositivos que só minam fatia, que por design nunca carregam o modelo
+     inteiro. Corrigido com `pom_gpu::any_shard_devices_active()` e uma isenção do gate para
+     processos que só rodam dispositivos de fatia — nenhuma mudança para a mineração normal de
+     tier inteiro.
+  2. Uma chain com produtor único / ociosa (a Simnet deste PoC, com zero peers) nunca voltava a
+     pedir um template de bloco fresco fora de um ciclo de inferência em andamento, então a
+     mineração travava indefinidamente na DAA 0. Corrigido com um re-poll de fallback
+     incondicional de ~500ms.
+- `examples/shard_walk_poc.rs` e `examples/shard_guard_poc.rs` — ver §5.
+
+## 3. O que mudou — lado do node (`keryx-node`, branch `shard-poc`)
+
+- `consensus/core/src/config/params.rs`:
+  - `POM_SHARDS_POC`: uma tabela de tiers de fatia (`crate::pom::PomTier { model_id, root,
+    chunks }` por fatia) — valores reais, medidos, colados literalmente da saída de
+    `keryx-miner --print-shards very-high:8` rodado contra o arquivo de modelo real (ver §4).
+    Protegida atrás de `shard_poc_activation`.
+  - `shard_poc_activation`: um novo gate de ativação de fork. `never()` no `MAINNET_PARAMS` e no
+    `TESTNET_PARAMS` público compartilhado — este PoC nunca encosta em nenhum dos dois. Definido
+    como `new(1)` só no `SIMNET_PARAMS`, junto com um perfil de ativação PoM/OPoI/série-H
+    completo e internamente consistente, construído especificamente para uma Simnet privada
+    partindo do genesis (o raciocínio de cada campo está documentado inline no diff, incluindo
+    uma divergência corrigida contra os valores de `pom_v4_activation`/`h10_activation` do
+    `TESTNET_PARAMS` público — o binário real do miner ativa esses gates na DAA 500 sob
+    `--testnet`, não na DAA 1 como o `TESTNET_PARAMS` diz atualmente; esse desvio pré-existente
+    está dormente na Testnet real só porque seu tip já está bem além da DAA 500, e não foi
+    copiado pro `SIMNET_PARAMS`).
+
+## 4. Ambiente usado na validação
+
+- Hardware: 2 GPUs NVIDIA na mesma máquina — ordinal CUDA 0 = RTX 3090 (24 GB), ordinal CUDA 1 =
+  RTX 4090 (24 GB). Nesta máquina, o ordinal do driver CUDA não bate com o índice do
+  `nvidia-smi` por padrão; a validação usou `CUDA_DEVICE_ORDER=PCI_BUS_ID` pra fixar isso.
+- Modelo: Kimi-Linear-48B, quantização Q4_K_M, ~29,7 GB de GGUF em disco — grande demais pra
+  caber inteiro numa única placa desta máquina.
+- Divisão: alvo de 8 GB por fatia → 4 fatias. Manifest real (capturado via `--print-shards
+  very-high:8`):
+
+  | Fatia | Camadas | Chunks | Raiz Merkle |
+  |---|---|---|---|
+  | 0 | [0, 7) | 219.852.216 | `a73a38fe1ef0cddc6e108eca25eb1de1adcdc7a65c01f87058530ac06df669b4` |
+  | 1 | [7, 14) | 238.829.076 | `db22407efc04f5d261498afc7acb397c87e692699484a9bcf2a747636adda9e5` |
+  | 2 | [14, 21) | 243.638.100 | `9c3aed4cc240baea0928f8282ea91ce6b0cd275f8286c45c440017c457f8cb8d` |
+  | 3 | [21, 27) | 225.674.672 | `233fdb1f9b551bb7895a0fca931ce5eddd16d87a12980f7e4361e020cfe29ff2` |
+
+- Rede: uma instância Simnet privada e isolada (sem DNS seeders, genesis próprio) — nunca a
+  Testnet ou a Mainnet públicas e compartilhadas.
+- Build: Windows, toolchain MSVC via Visual Studio Developer Shell; `KERYX_LLAMA_SKIP=1` (pula
+  só o build da biblioteca CMake do llama.cpp usada pra servir inferência OPoI — irrelevante pro
+  caminho do kernel CUDA de PoM que este PoC exercita).
+
+## 5. Resultados — comprovados em hardware real
+
+1. **Prova de conceito em processo único** (`keryx-miner/examples/shard_walk_poc.rs`): cada GPU,
+   independentemente, empacotou o manifest da sua fatia, instalou (upload bruto e escopado
+   real), rodou um walk de PoM real na GPU contra um alvo sintético (trivialmente fácil),
+   construiu uma testemunha `PomProofV3` real a partir do walk, e se auto-verificou com a mesma
+   função `verify_proof_v3` que um node usa — sem precisar de node ao vivo nesta etapa. As duas
+   se auto-verificaram como `true`.
+2. **Aceitação real na rede** (loop de mineração gRPC real, contra o node Simnet privado rodando
+   o perfil de `SIMNET_PARAMS` do §3): o node genuinamente aceitou blocos de PoM em nível de
+   fatia pelo caminho real de submissão de blocos, de forma sustentada, com zero rejeições — 817
+   blocos na fatia 0 (GPU0/3090, ~1,05M h/s, kernel `v4 tensor-core`) e 413 blocos na fatia 1
+   (GPU1/4090, ~1,68M h/s), 1.230 no total combinado, 0 rejeitados.
+3. **Checagem de regressão do guard** (`keryx-miner/examples/shard_guard_poc.rs`): instala uma
+   fatia com o manifest correto (funciona), depois tenta reinstalar após remover um nome de
+   tensor do manifest — o índice do host, já em cache, continua refletindo a contagem de chunks
+   correta (maior), então a contagem do segundo gather diverge e o N-guard corretamente recusa
+   instalar um miner, confirmando que um manifest corrompido ou errado não consegue produzir
+   silenciosamente uma prova aceitável.
+
+## 6. O que explicitamente NÃO foi feito — em aberto, incompleto por design
+
+Isto é uma prova de conceito, não uma funcionalidade terminada. Em particular:
+
+- **Nenhuma inferência OPoI distribuída.** Um dispositivo de fatia ainda não consegue, por si
+  só, servir inferência real sobre o modelo completo — a isenção do gate de mineração
+  obrigatória por OPoI (§2) só deixa um processo que só roda fatias pular essa exigência pra
+  *minerar*; ela não faz a inferência funcionar. Um pipeline real estilo ggml-rpc entre fatias
+  (já escopado separadamente como spec §3.3–3.5) é trabalho futuro, fora deste PoC.
+- **O bloco de bootstrap pré-PoM ainda precisa do modelo inteiro.** O primeiríssimo bloco de uma
+  chain nova (abaixo de `pom_activation`) precisa ser minerado pelo caminho legado
+  kHeavyHash+OPoI, que exige um dispositivo segurando o modelo *inteiro* — uma máquina que só
+  tenha dispositivos de fatia não tem, sozinha, caminho pra passar desse bloco.
+- **O deslocamento fatia→tier (`5 + shard_index`) é uma convenção mantida manualmente**, não
+  negociada por nenhum protocolo. A ordem das linhas de `POM_SHARDS_POC` no node precisa bater
+  com a numeração de fatias do miner por acordo, não por nenhum mecanismo on-chain. Uma
+  divergência aqui fica silenciosamente errada, não é rejeitada — essa é uma fraqueza real que um
+  design de produção precisaria fechar.
+- **Não testado além desta configuração exata**: 2 GPUs, 4 fatias, um modelo
+  (Kimi-Linear-48B), uma máquina. O comportamento com mais fatias, mais dispositivos, um modelo
+  diferente, ou fatiamento entre máquinas (em vez de entre GPUs na mesma máquina) não foi
+  explorado.
+- **Nenhum design de recompensa/economia.** A posse parcial de um miner que só minera fatia hoje
+  simplesmente reaproveita, posicionalmente, a tabela de recompensa comum baseada em tier. Se
+  isso é justo ou sólido do ponto de vista da teoria dos jogos, comparado à posse de um miner de
+  tier inteiro, não foi avaliado.
+- **A ativação em `SIMNET_PARAMS` é deliberadamente exclusiva da Simnet.** Estender qualquer
+  parte disso pra uma rede compartilhada (Testnet ou Mainnet) é uma decisão separada e bem
+  maior — governança, tempo de lançamento e compatibilidade retroativa estão todos fora do
+  escopo aqui.
+
+## 7. Onde olhar / como reproduzir
+
+- `keryx-node`, branch `shard-poc`: commit `76aa3c6f` (tabela de tiers de fatia + esqueleto do
+  gate, com uma linha placeholder), commit `ecb0f09e` (dados reais do manifest + o perfil de
+  ativação do `SIMNET_PARAMS` do §3).
+- `keryx-miner`, branch `shard-poc`: commits `3cf1bd4` (registro de fatia + caminho de
+  instalação), `15649ec` (CLI `--shard`/`--print-shards`), `ba2aa2f` (integração na atribuição de
+  tiers e no loop de mineração), `b9c0990` (isenção do gate de OPoI pra dispositivos de fatia),
+  `183d3e5` (correção do re-poll de template em chain ociosa), `645fd5d` (os dois exemplos de
+  diagnóstico do §5).
+- Pra rodar de novo a prova em processo único ou a checagem do guard: `cargo run --example
+  shard_walk_poc --features cuda` / `cargo run --example shard_guard_poc --features cuda` a
+  partir do repositório do miner (ambos aceitam as flags `--gguf-path`, `--target-bytes` e
+  `--mainnet`; usam por padrão o caminho do Kimi-Linear-48B e os gates de DAA estilo testnet
+  usados acima).

--- a/SHARD_POSSESSION_POC.pt-BR.md
+++ b/SHARD_POSSESSION_POC.pt-BR.md
@@ -156,8 +156,8 @@ Isto é uma prova de conceito, não uma funcionalidade terminada. Em particular:
 
 ## 7. Onde olhar / como reproduzir
 
-- `keryx-node`, branch `shard-poc`: commit `76aa3c6f` (tabela de tiers de fatia + esqueleto do
-  gate, com uma linha placeholder), commit `ecb0f09e` (dados reais do manifest + o perfil de
+- `keryx-node`, branch `shard-poc`: commit `8107a66f` (tabela de tiers de fatia + esqueleto do
+  gate, com uma linha placeholder), commit `b7a7c2ed` (dados reais do manifest + o perfil de
   ativação do `SIMNET_PARAMS` do §3).
 - `keryx-miner`, branch `shard-poc`: commits `3cf1bd4` (registro de fatia + caminho de
   instalação), `15649ec` (CLI `--shard`/`--print-shards`), `ba2aa2f` (integração na atribuição de

--- a/consensus/core/src/config/params.rs
+++ b/consensus/core/src/config/params.rs
@@ -591,15 +591,46 @@ pub const POM_TIERS_H6: &[crate::pom::PomTier] = &[
 /// verbatim from `keryx-miner --print-shards very-high:8` output — DO NOT hand-derive them.
 /// Gated by `shard_poc_activation`, which is `never()` on every real network (see below) — this
 /// table is dead code until a private testnet flips that gate, so the placeholder row is safe.
+// Pasted verbatim from `keryx-miner --print-shards very-high:8` on the 3090+4090 rig, 2026-09-09
+// (model_id 3dc09358ad75c6ef0c9c86ee4f47c4d6acda961fecbd0e4f9cf55e8f0fdffddb == KIMI_LINEAR_48B_MODEL_ID,
+// target_bytes = 8_000_000_000). Real manifest data, not derived by hand.
 pub const POM_SHARDS_POC: &[crate::pom::PomTier] = &[
-    // TODO(shard-poc): paste real output of `keryx-miner --print-shards very-high:8` here, one
-    // crate::pom::PomTier { model_id: KIMI_LINEAR_48B_MODEL_ID, root: [...], chunks: ... } per
-    // shard line printed. This is the ONLY acceptable source for these values — do not compute
-    // them by hand or guess. Placeholder below is a zeroed root/chunks=0 row: structurally valid
-    // Rust so the gated dead-code path still compiles, but semantically unusable — it MUST be
-    // replaced with real manifest data before `shard_poc_activation` is ever set to anything but
-    // `never()` on a live network.
-    crate::pom::PomTier { model_id: KIMI_LINEAR_48B_MODEL_ID, root: [0u8; 32], chunks: 0 },
+    // shard 0, layers [0,7)
+    crate::pom::PomTier {
+        model_id: KIMI_LINEAR_48B_MODEL_ID,
+        root: [
+            0xa7, 0x3a, 0x38, 0xfe, 0x1e, 0xf0, 0xcd, 0xdc, 0x6e, 0x10, 0x8e, 0xca, 0x25, 0xeb, 0x1d, 0xe1,
+            0xad, 0xcd, 0xc7, 0xa6, 0x5c, 0x01, 0xf8, 0x70, 0x58, 0x53, 0x0a, 0xc0, 0x6d, 0xf6, 0x69, 0xb4,
+        ],
+        chunks: 219_852_216,
+    },
+    // shard 1, layers [7,14)
+    crate::pom::PomTier {
+        model_id: KIMI_LINEAR_48B_MODEL_ID,
+        root: [
+            0xdb, 0x22, 0x40, 0x7e, 0xfc, 0x04, 0xf5, 0xd2, 0x61, 0x49, 0x8a, 0xfc, 0x7a, 0xcb, 0x39, 0x7c,
+            0x87, 0xe6, 0x92, 0x69, 0x94, 0x84, 0xa9, 0xbc, 0xf2, 0xa7, 0x47, 0x63, 0x6a, 0xdd, 0xa9, 0xe5,
+        ],
+        chunks: 238_829_076,
+    },
+    // shard 2, layers [14,21)
+    crate::pom::PomTier {
+        model_id: KIMI_LINEAR_48B_MODEL_ID,
+        root: [
+            0x9c, 0x3a, 0xed, 0x4c, 0xc2, 0x40, 0xba, 0xea, 0x09, 0x28, 0xf8, 0x28, 0x2e, 0xa9, 0x1c, 0xe6,
+            0xb0, 0xcd, 0x27, 0x5f, 0x82, 0x86, 0xc4, 0x5c, 0x44, 0x00, 0x17, 0xc4, 0x57, 0xf8, 0xcb, 0x8d,
+        ],
+        chunks: 243_638_100,
+    },
+    // shard 3, layers [21,27)
+    crate::pom::PomTier {
+        model_id: KIMI_LINEAR_48B_MODEL_ID,
+        root: [
+            0x23, 0x3f, 0xdb, 0x1f, 0x9b, 0x55, 0x1b, 0xb7, 0x89, 0x5a, 0x0f, 0xca, 0x93, 0x1c, 0xe5, 0xed,
+            0xdd, 0x16, 0xd8, 0x7a, 0x12, 0x98, 0x0f, 0x7e, 0x43, 0x61, 0xe0, 0x20, 0xcf, 0xe2, 0x9f, 0xf2,
+        ],
+        chunks: 225_674_672,
+    },
 ];
 
 /// Possession anchors for a block at `daa_score`: the H5 set once `h5_activation` is live (tier-0
@@ -1999,36 +2030,66 @@ pub const SIMNET_PARAMS: Params = Params {
     inference_reward_minimums: INFERENCE_REWARD_MINIMUMS,
     opoi_v2_activation: ForkActivation::always(),
     inference_reward_minimums_v2: INFERENCE_REWARD_MINIMUMS_V2,
-    // PoM possession: dormant until miner emission (§6) + P2P transport land; flip with §7.
-    pom_activation: ForkActivation::never(),
-    very_light_activation: ForkActivation::never(),
-    pom_level_activation: ForkActivation::never(),
-    inference_min_h2_activation: ForkActivation::never(),
+    // Shard-possession PoC (2026-09-09): this is the project owner's private/isolated test
+    // network for the network-fatia PoM PoC (chosen deliberately over the shared public Testnet,
+    // which must stay untouched — see TESTNET_PARAMS.shard_poc_activation's own comment). Simnet
+    // has zero prior chain history, so unlike Testnet's staggered values (which had to stay
+    // compatible with blocks already mined under an older state), every PoM gate here activates
+    // uniformly at the earliest DAA the `pruning.rs` genesis-invariant test allows.
+    //
+    // `pom_activation`/`pom_level_activation`/`pom_v3_activation` MUST NOT be active at the
+    // genesis DAA score (asserted for every network by
+    // `pruning.rs::assert_pruning_depth_consistency`) — `pom_level_activation` also drives the
+    // global header-hashing switch (`init_pom_level_activation`) that appends `pom_final_state`
+    // to the block hash, and `pom_v3_activation` drives `init_service_commit_activation` which
+    // additionally appends `service_state_hash`/`pom_tier`; `SIMNET_GENESIS`'s hash is pinned
+    // under the pre-PoM format, so genesis (daa 0) must stay below all three. Hence `new(1)`.
+    pom_activation: ForkActivation::new(1),
+    very_light_activation: ForkActivation::new(0), // not in the genesis invariant; mirrors miner's h5_activation_daa()-style testnet-mode 0 gates
+    pom_level_activation: ForkActivation::new(1),
+    inference_min_h2_activation: ForkActivation::new(0),
     inference_reward_minimums_v2_h2: INFERENCE_REWARD_MINIMUMS_V2_H2,
-    pow_salt_v2_activation: ForkActivation::never(),
-    pow_salt_v4_activation: ForkActivation::never(),
-    pom_maxlevel_v4_activation: ForkActivation::never(),
-    pom_v4_activation: ForkActivation::never(),
-    h10_activation: ForkActivation::never(),
-    ratio_reward_activation: ForkActivation::never(),
+    // Miner's pow_salt_v2_activation_daa()/pow_salt_v4_activation_daa() both return 0 under
+    // `--testnet` gates (keryx-miner src/pow/heavy_hash.rs) — this miner has no separate simnet
+    // mode, so it runs `--testnet` against this simnet node and MUST see matching salt gates
+    // or every submitted block fails the matrix check.
+    pow_salt_v2_activation: ForkActivation::new(0),
+    pow_salt_v4_activation: ForkActivation::new(0),
+    // Independent of pom_v4_activation (pure pruning-proof level-derivation anchor, no node code
+    // ties the two numerically) — mirrors Testnet's coincidental new(1).
+    pom_maxlevel_v4_activation: ForkActivation::new(1),
+    // NOT new(1): verified directly against keryx-miner/.worktrees/shard-poc/src/pom.rs — under
+    // `--testnet` this binary's pom_v4_activation_daa()/h10_activation_daa() both resolve to 500
+    // (gate(mainnet_daa, 500)), NOT 1. The shared public TESTNET_PARAMS in this same file still
+    // says `new(1)` for both, which is a pre-existing drift from this miner worktree's current
+    // code (dormant on the real testnet only because its tip is already long past DAA 500) — do
+    // not copy that drift here; match what this miner binary will actually gate at.
+    pom_v4_activation: ForkActivation::new(500),
+    h10_activation: ForkActivation::new(500),
+    ratio_reward_activation: ForkActivation::never(), // independent of tier_bps_by_block (gated on pom_activation); no reason to enable for this PoC
     ratio_verification_activation: ForkActivation::new(0), // verify all (no corrupted history)
     difficulty_reset_activation: ForkActivation::never(),
     difficulty_reset_activation_h4: ForkActivation::never(),
     difficulty_reset_activation_h5: ForkActivation::never(),
     difficulty_reset_activation_h5_3: ForkActivation::never(),
     difficulty_reset_activation_h5_4: ForkActivation::never(),
-    difficulty_reset_activation_h6: ForkActivation::never(),
-    difficulty_reset_activation_v4: ForkActivation::never(),
-    h6_reset_bits: None,
+    // MUST be set to the same score as `pom_v3_activation` (this struct field's own doc comment).
+    difficulty_reset_activation_h6: ForkActivation::new(1),
+    difficulty_reset_activation_v4: ForkActivation::new(1),
+    h6_reset_bits: None, // keep genesis.bits (already the easiest target) — no relaunch history to ease off of, unlike Testnet
     difficulty_reset_activation_h9: ForkActivation::never(),
     h9_reset_bits: None,
-    h5_activation: ForkActivation::never(),
-    h5_1_activation: ForkActivation::never(),
-    h5_2_activation: ForkActivation::never(),
-    pom_v3_activation: ForkActivation::never(),
-    shard_poc_activation: ForkActivation::never(),
+    h5_activation: ForkActivation::new(0), // matches miner's h5_activation_daa() testnet-mode gate (0)
+    h5_1_activation: ForkActivation::new(0), // matches miner's h5_1_activation_daa() testnet-mode gate (0)
+    h5_2_activation: ForkActivation::new(0), // matches miner's h5_2_activation_daa() testnet-mode gate (0)
+    pom_v3_activation: ForkActivation::new(1),
+    // The PoC gate itself. Must be <= pom_v3_activation (`pom_tiers()` only takes the shard
+    // branch when both are active) — the miner has no independent shard-mode gate of its own
+    // (`pom_shard_tier_index` only checks `pom_v3_activation_daa()`), so using the same DAA is
+    // the only value that keeps miner and node in lockstep.
+    shard_poc_activation: ForkActivation::new(1),
     service_bond_v2_activation: ForkActivation::never(),
-    reward_routing_activation: ForkActivation::never(),
+    reward_routing_activation: ForkActivation::never(), // H8 request-identity gate, unrelated to PoM/shard possession — left dormant
     service_ledger_activation: ForkActivation::never(),
     production_index_activation: ForkActivation::never(),
     exact_verification_activation: ForkActivation::never(),
@@ -2040,6 +2101,8 @@ pub const SIMNET_PARAMS: Params = Params {
 
     // Coin-age holder-reward (v3): DORMANT until the H4 hard fork is scheduled. The whole
     // machinery (effective_daa UtxoEntry field, bucket indexes, maturation queue) gates here.
+    // Independent of the PoM/shard verifier selection (the v3/v4 PoM verifier branches return
+    // before the coin-age branch), left dormant for this PoC.
     coin_age_activation: ForkActivation::never(),
     coin_age_verification_activation: ForkActivation::never(),
     coin_age_maturity_w: COIN_AGE_MATURITY_W,

--- a/consensus/core/src/config/params.rs
+++ b/consensus/core/src/config/params.rs
@@ -582,6 +582,26 @@ pub const POM_TIERS_H6: &[crate::pom::PomTier] = &[
     POM_TIERS_H4[4], // Kimi-Linear-48B, unchanged
 ];
 
+/// Shard possession anchors for the network-shard PoC (see keryx-miner's
+/// `docs/superpowers/specs/2026-09-09-network-fatia-shard-poc-design.md`). Each row is one
+/// fixed-size, layer-aligned slice of Kimi-Linear-48B at the POC's 8 GiB target
+/// (`models::POC_SHARD_TARGET_BYTES` on the miner side — the two must be kept in lockstep by
+/// hand; there is no dynamic negotiation in this phase). Tier indices are 5, 6, ... immediately
+/// after POM_TIERS_H6's 5 rows (`pom_tiers()` below concatenates them). Roots/chunks are pasted
+/// verbatim from `keryx-miner --print-shards very-high:8` output — DO NOT hand-derive them.
+/// Gated by `shard_poc_activation`, which is `never()` on every real network (see below) — this
+/// table is dead code until a private testnet flips that gate, so the placeholder row is safe.
+pub const POM_SHARDS_POC: &[crate::pom::PomTier] = &[
+    // TODO(shard-poc): paste real output of `keryx-miner --print-shards very-high:8` here, one
+    // crate::pom::PomTier { model_id: KIMI_LINEAR_48B_MODEL_ID, root: [...], chunks: ... } per
+    // shard line printed. This is the ONLY acceptable source for these values — do not compute
+    // them by hand or guess. Placeholder below is a zeroed root/chunks=0 row: structurally valid
+    // Rust so the gated dead-code path still compiles, but semantically unusable — it MUST be
+    // replaced with real manifest data before `shard_poc_activation` is ever set to anything but
+    // `never()` on a live network.
+    crate::pom::PomTier { model_id: KIMI_LINEAR_48B_MODEL_ID, root: [0u8; 32], chunks: 0 },
+];
+
 /// Possession anchors for a block at `daa_score`: the H5 set once `h5_activation` is live (tier-0
 /// model swap), else the H4 candle-free set, else the 5-tier H2 set once `very_light_activation`,
 /// else the legacy 4-tier set. The choice MUST be made per block from that block's own DAA (never
@@ -592,7 +612,11 @@ pub fn pom_tiers(
     h5_active: bool,
     coin_age_active: bool,
     very_light_active: bool,
+    shard_poc_active: bool,
 ) -> &'static [crate::pom::PomTier] {
+    if shard_poc_active && pom_v3_active {
+        return pom_tiers_with_shards();
+    }
     if pom_v3_active {
         POM_TIERS_H6
     } else if h5_active {
@@ -604,6 +628,13 @@ pub fn pom_tiers(
     } else {
         POM_TIERS
     }
+}
+
+/// H6 tiers plus the shard-PoC rows, concatenated once. `shard_poc_active` is `never()`
+/// everywhere except a private testnet, so this path is dead code on every real network.
+fn pom_tiers_with_shards() -> &'static [crate::pom::PomTier] {
+    static COMBINED: std::sync::OnceLock<Vec<crate::pom::PomTier>> = std::sync::OnceLock::new();
+    COMBINED.get_or_init(|| POM_TIERS_H6.iter().copied().chain(POM_SHARDS_POC.iter().copied()).collect())
 }
 
 /// Tier-reward — multiplier in basis points applied to the *immediate miner cut* (the 75 %
@@ -1270,6 +1301,13 @@ pub struct Params {
     /// per nonce than the v2 hash walk).
     pub pom_v3_activation: ForkActivation,
 
+    /// Shard-possession PoC gate (network-shard PoC). At/after this score AND `pom_v3_activation`,
+    /// `pom_tiers()` appends `POM_SHARDS_POC` after the H6 5-tier table, letting a block prove
+    /// possession of a shard instead of a whole model. `never()` on every real network (mainnet,
+    /// testnet, devnet, simnet) — this is dead code everywhere except a private testnet the
+    /// project owner sets up separately to exercise the PoC end to end.
+    pub shard_poc_activation: ForkActivation,
+
     /// Service-bond v2 window retune: halves the cohort-eligibility window (6 000 → 3 000 DAA)
     /// and raises the response-window base (300 → 3 000 DAA). Changes the audit fold, hence the
     /// sealed service state — must be armed above every live tip before the binary ships.
@@ -1548,6 +1586,7 @@ impl Params {
             h5_1_activation: self.h5_1_activation,
             h5_2_activation: self.h5_2_activation,
             pom_v3_activation: self.pom_v3_activation,
+            shard_poc_activation: self.shard_poc_activation,
             service_bond_v2_activation: self.service_bond_v2_activation,
             reward_routing_activation: self.reward_routing_activation,
             service_ledger_activation: self.service_ledger_activation,
@@ -1757,6 +1796,8 @@ pub const MAINNET_PARAMS: Params = Params {
     // H6 matrix walk, armed together with its difficulty-reset companion at the same score.
     // Gate = virtual daa of the relaunch base: active from the first post-relaunch block.
     pom_v3_activation: ForkActivation::new(76_316_623),
+    // Shard-possession PoC: dormant on mainnet. Only ever armed on a private testnet.
+    shard_poc_activation: ForkActivation::never(),
     // H7 service-bond v2. Scheduled for 2026-08-17 20:00 CEST: measured from daa 77_196_191 at
     // 09:01 UTC at the chain's own rate over the preceding hours (~10.12 daa/s).
     service_bond_v2_activation: ForkActivation::new(77_525_000),
@@ -1886,6 +1927,10 @@ pub const TESTNET_PARAMS: Params = Params {
     // itself is committed without body validation, so the mandatory escrow delegation never
     // applies to it. MUST mirror the miner's gate.
     pom_v3_activation: ForkActivation::new(1),
+    // Shard-possession PoC: dormant here too — this is the shared public Testnet network, not
+    // the project owner's private testnet the PoC is meant for. When that private testnet's
+    // params are set up (separately, not in this file), it flips this to `ForkActivation::new(0)`.
+    shard_poc_activation: ForkActivation::never(),
     // H7 service-bond v2 — arm ABOVE the live testnet tip before deploying: the fold is sealed,
     // flipping it below already-folded history splits the testnet.
     service_bond_v2_activation: ForkActivation::new(0),
@@ -1981,6 +2026,7 @@ pub const SIMNET_PARAMS: Params = Params {
     h5_1_activation: ForkActivation::never(),
     h5_2_activation: ForkActivation::never(),
     pom_v3_activation: ForkActivation::never(),
+    shard_poc_activation: ForkActivation::never(),
     service_bond_v2_activation: ForkActivation::never(),
     reward_routing_activation: ForkActivation::never(),
     service_ledger_activation: ForkActivation::never(),
@@ -2068,6 +2114,7 @@ pub const DEVNET_PARAMS: Params = Params {
     h5_1_activation: ForkActivation::never(),
     h5_2_activation: ForkActivation::never(),
     pom_v3_activation: ForkActivation::never(),
+    shard_poc_activation: ForkActivation::never(),
     service_bond_v2_activation: ForkActivation::never(),
     reward_routing_activation: ForkActivation::never(),
     service_ledger_activation: ForkActivation::never(),

--- a/consensus/src/pipeline/body_processor/body_validation_in_isolation.rs
+++ b/consensus/src/pipeline/body_processor/body_validation_in_isolation.rs
@@ -254,6 +254,7 @@ impl BlockBodyProcessor {
             self.h5_activation.is_active(header.daa_score),
             self.coin_age_verification_activation.is_active(header.daa_score),
             self.very_light_activation.is_active(header.daa_score),
+            self.shard_poc_activation.is_active(header.daa_score),
         );
         let tier = tiers.get(proof.tier as usize).ok_or(RuleError::PomUnknownTier(proof.tier))?;
 

--- a/consensus/src/pipeline/body_processor/processor.rs
+++ b/consensus/src/pipeline/body_processor/processor.rs
@@ -92,6 +92,10 @@ pub struct BlockBodyProcessor {
     /// state commitments; the verifier never re-walks). Same seed/target/final_hash inputs as
     /// the v2 path; `header.pom_final_state` carries `pom_v3::fold64(roots[K])`.
     pub(super) pom_v3_activation: ForkActivation,
+    /// Shard-possession PoC gate — when active (with `pom_v3_activation`) at a block's daa_score,
+    /// `pom_tiers()` appends `POM_SHARDS_POC` after the H6 table. `never()` on every real network;
+    /// see `Params::shard_poc_activation`.
+    pub(super) shard_poc_activation: ForkActivation,
     pub(super) pom_v4_activation: ForkActivation,
     pub(super) h10_activation: ForkActivation,
 
@@ -249,6 +253,7 @@ impl BlockBodyProcessor {
             h5_1_activation: params.h5_1_activation,
             h5_2_activation: params.h5_2_activation,
             pom_v3_activation: params.pom_v3_activation,
+            shard_poc_activation: params.shard_poc_activation,
             pom_v4_activation: params.pom_v4_activation,
             h10_activation: params.h10_activation,
 


### PR DESCRIPTION
Proof of concept, not a finished feature. See SHARD_POSSESSION_POC.md (English) and
SHARD_POSSESSION_POC.pt-BR.md (Portuguese) in this branch for the full writeup: motivation,
what changed, the environment/model used for validation, real-hardware results, and an
explicit list of what is intentionally not done yet.

Not activated on Mainnet or the shared Testnet — `shard_poc_activation` stays `never()`
everywhere except the private `SIMNET_PARAMS` this PoC adds. Companion PR in keryx-miner.

Opened as a draft on purpose: this is exploratory research meant to be reviewed and discussed,
not merged as-is.